### PR TITLE
Use kubernetes release-utils versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,53 @@
+# Copyright 2023 Interlynk.io
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-PROJECT_NAME := sbomqs
-BUILD_FILE := ./build/sbomqs
+#inspired by https://github.com/pinterb/go-semver/blob/master/Makefile
 
-.PHONY: all
-all: dep test build 
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+GIT_VERSION ?= $(shell git describe --tags --always --dirty)
+GIT_HASH ?= $(shell git rev-parse HEAD)
+DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+ifdef SOURCE_DATE_EPOCH
+  BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+  BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+GIT_TREESTATE = "clean"
+DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(DIFF), 1)
+    GIT_TREESTATE = "dirty"
+endif
+
+PKG ?= sigs.k8s.io/release-utils/version
+LDFLAGS=-buildid= -X $(PKG).gitVersion=$(GIT_VERSION) \
+        -X $(PKG).gitCommit=$(GIT_HASH) \
+        -X $(PKG).gitTreeState=$(GIT_TREESTATE) \
+        -X $(PKG).buildDate=$(BUILD_DATE)
+
+
+BUILD_DIR = ./build
+
+.PHONY: all 
+all: clean dep test build 
 
 .PHONY: dep
 dep:
@@ -15,9 +59,14 @@ test:
 	go test -cover -race ./...
 
 .PHONY: build
-build:
-	go build -a -installsuffix cgo -o $(BUILD_FILE) main.go 
+build: 
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/sbomqs main.go
 
 .PHONY: clean
 clean:
-	rm -f $(BUILD_FILE)
+	rm -rf $(BUILD_DIR)
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -10,11 +10,21 @@ We support SPDX and CycloneDX sbom standards, in various file formats.
 
 ### Installation 
 Use the steps below to try out the tool. You will need
-golang version 1.19
+golang version 1.19 and above.
+
+##### Using Go install
+Using go install is an easy way to install the binary. Once compiled this will be installed 
+in $(GOBIN) or $(GOPATH)/bin or $(GOROOT)/bin. 
+```
+go install github.com/interlynk-io/sbomqs@latest
+```
+
+##### Using repo
+This approach invovles cloning the repo and building it. 
 
 1. Clone the repo ```git clone git@github.com:interlynk-io/sbomqs.git```
 2. `cd` into `sbomqs` folder 
-3. make
+3. make build
 4. To test if the build was successful run the following command ```./build/sbomqs version```
 
 ### Getting access to SBOMS

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,23 +16,10 @@ package cmd
 
 import (
 	_ "embed"
-	"fmt"
 
-	"github.com/spf13/cobra"
+	version "sigs.k8s.io/release-utils/version"
 )
 
-//go:generate bash version.sh
-//go:embed version.txt
-var version string
-
 func init() {
-	rootCmd.AddCommand(versionCmd)
-}
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number of sbomqs",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("sbomqs version %s", version)
-	},
+	rootCmd.AddCommand(version.Version())
 }

--- a/cmd/version.sh
+++ b/cmd/version.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-git describe --tags --abbrev=0 > version.txt

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,11 @@ require (
 	github.com/spf13/cobra v1.6.1
 	go.uber.org/zap v1.24.0
 	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/release-utils v0.7.3
 )
 
 require (
+	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/spdx/gordf v0.0.0-20201111095634-7098f93598fb // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/CycloneDX/cyclonedx-go v0.7.0 h1:jNxp8hL7UpcvPDFXjY+Y1ibFtsW+e5zyF9Qo
 github.com/CycloneDX/cyclonedx-go v0.7.0/go.mod h1:W5Z9w8pTTL+t+yG3PCiFRGlr8PUlE0pGWzKSJbsyXkg=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -47,5 +49,7 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/release-utils v0.7.3 h1:6pS8x6c5RmdUgR9qcg1LO6hjUzuE4Yo9TGZ3DemrZdM=
+sigs.k8s.io/release-utils v0.7.3/go.mod h1:n0mVez/1PZYZaZUTJmxewxH3RJ/Lf7JUDh7TG1CASOE=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=


### PR DESCRIPTION
The previous way to add version using embed, did not work well with go install. Switched it to use ldflags. Got inspired by go-semver.

```
➜  sbomqs git:(feature/take-2-version) ./build/sbomqs version
  ____    ____     ___    __  __    ___    ____
 / ___|  | __ )   / _ \  |  \/  |  / _ \  / ___|
 \___ \  |  _ \  | | | | | |\/| | | | | | \___ \
  ___) | | |_) | | |_| | | |  | | | |_| |  ___) |
 |____/  |____/   \___/  |_|  |_|  \__\_\ |____/
sbomqs: sbomqs application provides sbom quality scores.

GitVersion:    v0.0.1-12-g2531953-dirty
GitCommit:     2531953bd6e790e6c3474da6eb7f204b8900587c
GitTreeState:  dirty
BuildDate:     '2023-02-01T06:44:12Z'
GoVersion:     go1.19.5
Compiler:      gc
Platform:      linux/amd64

```