### PR TITLE
Add Goreleaser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ vendor/
 build/
 
 version.txt 
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,45 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,45 +1,43 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
+project_name: sbomqs
+
+env:
+  - GO111MODULE=on
+
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
+    - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+
+gomod:
+  proxy: true 
+
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - id: binaries 
+    binary: sbomqs-{{ .Os }}-{{ .Arch }}
+    no_unique_dist_dir: true 
+    main: .
+    flags:
+      - -trimpath 
+    mod_timestamp: '{{ .CommitTimestamp }}'
     goos:
       - linux
-      - windows
       - darwin
+      - windows 
+    goarch:
+      - amd64
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    env: 
+      - CGO_ENABLED=0
 
 archives:
-  - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of uname.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-    - goos: windows
-      format: zip
-checksum:
-  name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ incpatch .Version }}-next"
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
+- format: binary
+  name_template: "{{ .Binary }}"
+  allow_different_binary_count: true 
 
-# The lines beneath this are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+snapshot: 
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+release:
+  prerelease: allow 
+  draft: true 

--- a/Makefile
+++ b/Makefile
@@ -46,27 +46,27 @@ LDFLAGS=-buildid= -X $(PKG).gitVersion=$(GIT_VERSION) \
 
 BUILD_DIR = ./build
 
-.PHONY: all 
-all: clean dep test build 
-
 .PHONY: dep
 dep:
-	go mod vendor 
-	go mod tidy 
+	go mod vendor
+	go mod tidy
 
-.PHONY: test 
+.PHONY: test
 test:
 	go test -cover -race ./...
 
 .PHONY: build
-build: 
+build:
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/sbomqs main.go
 
 .PHONY: clean
 clean:
-	rm -rf $(BUILD_DIR)
+	\rm -rf $(BUILD_DIR)
 
-
-
-
-
+.PHONY: snapshot
+snapshot:
+	LDFLAGS="$(LDFLAGS)" \goreleaser release --clean --snapshot --skip-sign --skip-publish --timeout 120m
+	
+.PHONY: release
+release:
+	LDFLAGS="$(LDFLAGS)" \goreleaser release release --clean --timeout 120m

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Doc has require fields | check if the sbom has all the required fields as specif
 Doc has sharable license | check if the sbom doc has an unemcumbered license which can aid in sharing | 
 
 
+## Stargazers over time
+
+[![Stargazers over time](https://starchart.cc/interlynk-io/sbomqs.svg)](https://starchart.cc/interlynk-io/sbomqs)
+
+
 
 
 


### PR DESCRIPTION
This PR adds support for [GoReleaser](https://github.com/interlynk-io/sbomqs/issues/11). This PR will allow us the following features 

- Cross-compile your Go project, currently for Mac/Linux/Windows for amd64
- Tag releases to github

A small change to the readme to support stargazers. 