### PR TITLE
Detect proper supplier name from the component

### DIFF
--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -315,6 +315,7 @@ func (c *cdxDoc) addSupplierName(index int) string {
 
 	if comp.Supplier == nil {
 		c.addToLogs(fmt.Sprintf("cdx doc comp %s at index %d no supplier found", comp.Name, index))
+		return ""
 	}
 
 	name := strings.ToLower(comp.Supplier.Name)

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	cydx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/samber/lo"
@@ -180,9 +181,7 @@ func (c *cdxDoc) parseComps() {
 
 		nc.version = sc.Version
 		nc.name = sc.Name
-		if sc.Supplier != nil {
-			nc.supplerName = sc.Supplier.Name
-		}
+		nc.supplierName = c.addSupplierName(index)
 		nc.purpose = string(sc.Type)
 		nc.isReqFieldsPresent = c.pkgRequiredFields(index)
 		nc.purls = []string{sc.PackageURL}
@@ -310,4 +309,19 @@ func (c *cdxDoc) parseRels() {
 		}
 	}
 
+}
+func (c *cdxDoc) addSupplierName(index int) string {
+	comp := lo.FromPtr(c.doc.Components)[index]
+
+	if comp.Supplier == nil {
+		c.addToLogs(fmt.Sprintf("cdx doc comp %s at index %d no supplier found", comp.Name, index))
+	}
+
+	name := strings.ToLower(comp.Supplier.Name)
+
+	if name == "" {
+		c.addToLogs(fmt.Sprintf("cdx doc comp %s at index %d no supplier found", comp.Name, index))
+		return ""
+	}
+	return name
 }

--- a/pkg/sbom/cdx_test.go
+++ b/pkg/sbom/cdx_test.go
@@ -1,0 +1,112 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"strings"
+	"testing"
+
+	cydx "github.com/CycloneDX/cyclonedx-go"
+)
+
+func cdxBOM() *cydx.BOM {
+	m := cydx.Metadata{
+		Component: &cydx.Component{
+			BOMRef:  "pkg:golang/interlynk-io/sbomqs@v0.0.1",
+			Type:    cydx.ComponentTypeApplication,
+			Name:    "SBOMQS application",
+			Version: "v0.0.1",
+		},
+	}
+
+	comps := []cydx.Component{
+		{
+			BOMRef:     "pkg:golang/github.com/interlynk-io/go-testlib@v0.0.3",
+			Type:       cydx.ComponentTypeLibrary,
+			Author:     "Interlynk.io",
+			Name:       "go-testlib",
+			Version:    "v0.0.3",
+			PackageURL: "pkg:golang/github.com/interlynk-io/go-testlib@v0.0.3",
+		},
+		{
+			BOMRef:     "pkg:golang/github.com/dummy/dummyLib@v3.0.0",
+			Type:       cydx.ComponentTypeLibrary,
+			Author:     "Dummy",
+			Name:       "dummyLib",
+			Version:    "v3.0.0",
+			PackageURL: "pkg:golang/github.com/dummy/dummyLib@v3.0.0",
+			Supplier: &cydx.OrganizationalEntity{
+				Name: "Dummy",
+			},
+		},
+		{
+			BOMRef:     "pkg:golang/github.com/dummy/dummyArrayLib@v2.4.1",
+			Type:       cydx.ComponentTypeLibrary,
+			Author:     "Dummy",
+			Name:       "dummyArrayLib",
+			Version:    "v2.4.1",
+			PackageURL: "pkg:golang/github.com/dummy/dummyArrayLib@v2.4.1",
+			Supplier: &cydx.OrganizationalEntity{
+				Name: "",
+			},
+		},
+	}
+	bom := cydx.NewBOM()
+	bom.Metadata = &m
+	bom.Components = &comps
+
+	return bom
+}
+
+func Test_cdxDoc_addSupplierName(t *testing.T) {
+	type fields struct {
+		doc     *cydx.BOM
+		spec    *spec
+		comps   []Component
+		authors []Author
+		tools   []Tool
+		rels    []Relation
+		logs    []string
+	}
+	type args struct {
+		index int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{"Supplier name is found", fields{doc: cdxBOM()}, args{index: 1}, strings.ToLower("Dummy")},
+		{"Supplier section is not found", fields{doc: cdxBOM()}, args{index: 0}, ""},
+		{"Supplier name is blank", fields{doc: cdxBOM()}, args{index: 2}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cdxDoc{
+				doc:     tt.fields.doc,
+				spec:    tt.fields.spec,
+				comps:   tt.fields.comps,
+				authors: tt.fields.authors,
+				tools:   tt.fields.tools,
+				rels:    tt.fields.rels,
+				logs:    tt.fields.logs,
+			}
+			if got := c.addSupplierName(tt.args.index); got != tt.want {
+				t.Errorf("cdxDoc.addSupplierName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/sbom/component.go
+++ b/pkg/sbom/component.go
@@ -31,9 +31,9 @@ type Component interface {
 }
 
 type component struct {
-	supplerName string
-	name        string
-	version     string
+	supplierName string
+	name         string
+	version      string
 
 	purls []string
 	cpes  []string
@@ -51,7 +51,7 @@ func newComponent() *component {
 }
 
 func (c component) SupplierName() string {
-	return c.supplerName
+	return c.supplierName
 }
 func (c component) Name() string {
 	return c.name

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -135,9 +135,7 @@ func (s *spdxDoc) parseComps() {
 
 		nc.version = sc.PackageVersion
 		nc.name = sc.PackageName
-		if sc.PackageSupplier != nil {
-			nc.supplerName = sc.PackageSupplier.Supplier
-		}
+		nc.supplierName = s.addSupplierName(index)
 		nc.purpose = sc.PrimaryPackagePurpose
 		nc.isReqFieldsPresent = s.pkgRequiredFields(index)
 		nc.purls = s.purls(index)
@@ -415,4 +413,20 @@ func (s *spdxDoc) licenses(index int) []License {
 	}
 
 	return finalLics
+}
+
+func (s *spdxDoc) addSupplierName(index int) string {
+	pkg := s.doc.Packages[index]
+
+	if pkg.PackageSupplier == nil {
+		s.addToLogs(fmt.Sprintf("spdx doc pkg %s at index %d no supplier found", pkg.PackageName, index))
+	}
+
+	name := strings.ToLower(pkg.PackageSupplier.Supplier)
+
+	if name == "" || name == "noassertion" {
+		s.addToLogs(fmt.Sprintf("spdx doc pkg %s at index %d no supplier found", pkg.PackageName, index))
+		return ""
+	}
+	return name
 }

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -420,6 +420,7 @@ func (s *spdxDoc) addSupplierName(index int) string {
 
 	if pkg.PackageSupplier == nil {
 		s.addToLogs(fmt.Sprintf("spdx doc pkg %s at index %d no supplier found", pkg.PackageName, index))
+		return ""
 	}
 
 	name := strings.ToLower(pkg.PackageSupplier.Supplier)

--- a/pkg/sbom/spdx_test.go
+++ b/pkg/sbom/spdx_test.go
@@ -1,0 +1,124 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spdx/tools-golang/spdx/common"
+	spdx_common "github.com/spdx/tools-golang/spdx/common"
+	spdx "github.com/spdx/tools-golang/spdx/v2_3"
+)
+
+func testSpdxDoc() *spdx.Document {
+	return &spdx.Document{
+		SPDXVersion:       "SPDX-2.3",
+		DataLicense:       "CC0-1.0",
+		SPDXIdentifier:    spdx_common.ElementID("DOCUMENT"),
+		DocumentName:      "SPDX-Go-Test-document",
+		DocumentNamespace: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C4401",
+		CreationInfo: &spdx.CreationInfo{
+			LicenseListVersion: "3.9",
+			Creators: []common.Creator{
+				{CreatorType: "Organization", Creator: "Interlynk.io ()"},
+				{CreatorType: "Person", Creator: "Ritesh Noronha ()"},
+			},
+			Created: "2023-02-13T21:52:36+0000",
+		},
+		Packages: []*spdx.Package{
+			{
+				PackageName:             "github.com/CycloneDX/cyclonedx-go",
+				PackageSPDXIdentifier:   spdx_common.ElementID("go-module-github.com-CycloneDX-cyclonedx-go-49d9f8e76205b17e"),
+				PackageVersion:          "v0.0.0-20210810181110-49d9f8e76205",
+				PackageDownloadLocation: "NOASSERTION",
+				PackageSupplier: &spdx_common.Supplier{
+					Supplier: "OWASP",
+				},
+			},
+			{
+				PackageName:             "github.com/inconshreveable/mousetrap",
+				PackageSPDXIdentifier:   spdx_common.ElementID("go-module-github.com-inconshreveable-mousetrap-9434bd3d0b12ac21"),
+				PackageVersion:          "v1.0.1",
+				PackageDownloadLocation: "NOASSERTION",
+			},
+			{
+				PackageName:             "github.com/jessevdk/go-flags",
+				PackageSPDXIdentifier:   spdx_common.ElementID("go-module-github.com-jessevdk-go-flags-3f7f1f7f2f1e2e3e"),
+				PackageVersion:          "v1.4.0",
+				PackageDownloadLocation: "NOASSERTION",
+				PackageSupplier: &spdx_common.Supplier{
+					Supplier: "",
+				},
+			},
+			{
+				PackageName:             "github.com/joho/godotenv",
+				PackageSPDXIdentifier:   spdx_common.ElementID("go-module-github.com-joho-godotenv-1a0d2d5d1b0e5e6e"),
+				PackageVersion:          "v1.3.0",
+				PackageDownloadLocation: "NOASSERTION",
+				PackageSupplier: &spdx_common.Supplier{
+					Supplier: "NOASSERTION",
+				},
+			},
+		},
+	}
+}
+
+func Test_spdxDoc_addSupplierName(t *testing.T) {
+	type fields struct {
+		doc     *spdx.Document
+		format  FileFormat
+		ctx     context.Context
+		spec    *spec
+		comps   []Component
+		authors []Author
+		tools   []Tool
+		rels    []Relation
+		logs    []string
+	}
+	type args struct {
+		index int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{"Supplier name is present", fields{doc: testSpdxDoc()}, args{index: 0}, strings.ToLower("OWASP")},
+		{"Supplier section is missing", fields{doc: testSpdxDoc()}, args{index: 1}, ""},
+		{"Supplier name is empty", fields{doc: testSpdxDoc()}, args{index: 2}, ""},
+		{"Supplier name has noassertion", fields{doc: testSpdxDoc()}, args{index: 3}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &spdxDoc{
+				doc:     tt.fields.doc,
+				format:  tt.fields.format,
+				ctx:     tt.fields.ctx,
+				spec:    tt.fields.spec,
+				comps:   tt.fields.comps,
+				authors: tt.fields.authors,
+				tools:   tt.fields.tools,
+				rels:    tt.fields.rels,
+				logs:    tt.fields.logs,
+			}
+			if got := s.addSupplierName(tt.args.index); got != tt.want {
+				t.Errorf("spdxDoc.addSupplierName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Package Supplier field could have NOASSERTION as a possible value. In our initial implementation we were only checking for blank strings as the supplier being absent, we should also include noassertions. 

Before 
```
➜ sbomqs score --reportFormat detailed --filepath wrk/bom-shelter/in-the-wild/spdx/powershell.spdx --category NTIA-minimum-elements
SBOM Quality Score: 10.0	wrk/bom-shelter/in-the-wild/spdx/powershell.spdx
+-----------------------+--------------------------------+-----------+--------------------------------+
|       CATEGORY        |            FEATURE             |   SCORE   |              DESC              |
+-----------------------+--------------------------------+-----------+--------------------------------+
| NTIA-minimum-elements | Doc has relationships          | 10.0/10.0 | doc has 331 relationships      |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Components have names          | 10.0/10.0 | 331/331 have names             |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Doc has creation timestamp     | 10.0/10.0 | doc has creation timestamp     |
|                       |                                |           | 2021-12-08T21:06:16Z           |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Components have supplier names | 10.0/10.0 | 331/331 have supplier names    |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Components have uniq ids       | 10.0/10.0 | 330/331 have unique ID's       |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Components have versions       | 10.0/10.0 | 331/331 have versions          |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Doc has authors                | 10.0/10.0 | doc has 2 authors              |
+-----------------------+--------------------------------+-----------+--------------------------------+
```

After 
```
➜ ./build/sbomqs score --reportFormat detailed --filepath ../bom-shelter/in-the-wild/spdx/powershell.spdx --category NTIA-minimum-elements
SBOM Quality Score: 8.6	../bom-shelter/in-the-wild/spdx/powershell.spdx
+-----------------------+--------------------------------+-----------+--------------------------------+
|       CATEGORY        |            FEATURE             |   SCORE   |              DESC              |
+-----------------------+--------------------------------+-----------+--------------------------------+
| NTIA-minimum-elements | Components have supplier names | 0.0/10.0  | 1/331 have supplier names      |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Components have versions       | 10.0/10.0 | 331/331 have versions          |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Components have uniq ids       | 10.0/10.0 | 330/331 have unique ID's       |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Doc has creation timestamp     | 10.0/10.0 | doc has creation timestamp     |
|                       |                                |           | 2021-12-08T21:06:16Z           |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Components have names          | 10.0/10.0 | 331/331 have names             |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Doc has relationships          | 10.0/10.0 | doc has 331 relationships      |
+                       +--------------------------------+-----------+--------------------------------+
|                       | Doc has authors                | 10.0/10.0 | doc has 2 authors              |
+-----------------------+--------------------------------+-----------+--------------------------------+
```
