### PR TITLE
introduce cpe as a type, added validation for cpe check

### DIFF
--- a/pkg/cpe/cpe.go
+++ b/pkg/cpe/cpe.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cpe
+
+import (
+	"regexp"
+)
+
+type CPE string
+
+const cpeRegex = (`^([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})`) +
+	(`|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){4})$`)
+
+func (cpe CPE) Valid() bool {
+	return regexp.MustCompile(cpeRegex).MatchString(cpe.String())
+}
+
+func NewCPE(cpe string) CPE {
+	return CPE(cpe)
+}
+
+func (meta CPE) String() string {
+	return string(meta)
+}

--- a/pkg/cpe/cpe_test.go
+++ b/pkg/cpe/cpe_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cpe
+
+import (
+	"testing"
+)
+
+func TestValidCPE(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"Is empty value is valid CPE2.3", "", false},
+		{"Is XYZ is valid CPE2.3", "xyz", false},
+		{"Is cpe:-2.3:a:CycloneDX:cyclonedx-go:v0.7.0:*:*:*:*:*:*:* is valid CPE2.3", "cpe:-2.3:a:CycloneDX:cyclonedx-go:v0.7.0:*:*:*:*:*:*:*", false},
+		{"Is cpe:2.3:a:interlynk:sbomqs:\\(devel\\):*:*:*:*:*:*:* is valid CPE2.3", "cpe:2.3:a:interlynk:sbomqs:\\(devel\\):*:*:*:*:*:*:*", true},
+		{"Is cpe:/a:%40thi.ng%2fegf_project:%40thi.ng%2fegf:0.2.0::~~~node.js~~ is valid CPE2.2", "cpe:/a:%40thi.ng%2fegf_project:%40thi.ng%2fegf:0.2.0::~~~node.js~~", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cpeinput := NewCPE(tt.input)
+			if cpeinput.Valid() != tt.want {
+				t.Errorf("got %t, want %t", cpeinput.Valid(), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	cydx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/interlynk-io/sbomqs/pkg/cpe"
 	"github.com/samber/lo"
 )
 
@@ -185,7 +186,12 @@ func (c *cdxDoc) parseComps() {
 		nc.purpose = string(sc.Type)
 		nc.isReqFieldsPresent = c.pkgRequiredFields(index)
 		nc.purls = []string{sc.PackageURL}
-		nc.cpes = []string{sc.CPE}
+		ncpe := cpe.NewCPE(sc.CPE)
+		if ncpe.Valid() {
+			nc.cpes = []cpe.CPE{ncpe}
+		} else {
+			c.addToLogs(fmt.Sprintf("cdx doc component %s at index %d invalid cpes found", sc.Name, index))
+		}
 		nc.checksums = c.checksums(index)
 		nc.licenses = c.licenses(index)
 		nc.id = sc.BOMRef

--- a/pkg/sbom/cdx_test.go
+++ b/pkg/sbom/cdx_test.go
@@ -39,6 +39,7 @@ func cdxBOM() *cydx.BOM {
 			Name:       "go-testlib",
 			Version:    "v0.0.3",
 			PackageURL: "pkg:golang/github.com/interlynk-io/go-testlib@v0.0.3",
+			CPE: "cpe:2:a:golang:go-testlib:v0.0.3:*:*:*:*:*:*:*",
 		},
 		{
 			BOMRef:     "pkg:golang/github.com/dummy/dummyLib@v3.0.0",
@@ -47,6 +48,7 @@ func cdxBOM() *cydx.BOM {
 			Name:       "dummyLib",
 			Version:    "v3.0.0",
 			PackageURL: "pkg:golang/github.com/dummy/dummyLib@v3.0.0",
+			CPE:        "cpe:2.3:a:golang:dummyLib:v3.0.0:*:*:*:*:*:*:*",
 			Supplier: &cydx.OrganizationalEntity{
 				Name: "Dummy",
 			},
@@ -58,6 +60,7 @@ func cdxBOM() *cydx.BOM {
 			Name:       "dummyArrayLib",
 			Version:    "v2.4.1",
 			PackageURL: "pkg:golang/github.com/dummy/dummyArrayLib@v2.4.1",
+			CPE: "cpe:/o:dummy:dummyArrayLib:2.4.1:update4",
 			Supplier: &cydx.OrganizationalEntity{
 				Name: "",
 			},
@@ -109,4 +112,36 @@ func Test_cdxDoc_addSupplierName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_cdxDoc_parseComps_Cpes(t *testing.T) {
+	type fields struct {
+		doc     *cydx.BOM
+		comps   []Component
+	}
+	type args struct {
+		index int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{"CPE is present but invalid", fields{doc: cdxBOM()}, args{index: 0}, 0},
+		{"CPE is present with valid", fields{doc: cdxBOM()}, args{index: 1}, 1},
+		{"CPE 2.2 is present with valid", fields{doc: cdxBOM()}, args{index: 2}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cdxDoc{
+				doc:     tt.fields.doc,
+			}
+			c.parseComps()
+			if got := c.comps[tt.args.index].Cpes(); len(got) != tt.want {
+				t.Errorf("cdxDoc.parseComps() = %d, want %d", len(got), tt.want)
+			}
+		})
+	}
+
 }

--- a/pkg/sbom/component.go
+++ b/pkg/sbom/component.go
@@ -14,6 +14,8 @@
 
 package sbom
 
+import "github.com/interlynk-io/sbomqs/pkg/cpe"
+
 //counterfeiter:generate . Component
 type Component interface {
 	ID() string
@@ -22,7 +24,7 @@ type Component interface {
 	Version() string
 
 	Purls() []string
-	Cpes() []string
+	Cpes() []cpe.CPE
 
 	Licenses() []License
 	Checksums() []Checksum
@@ -37,7 +39,7 @@ type component struct {
 	version      string
 
 	purls []string
-	cpes  []string
+	cpes  []cpe.CPE
 
 	licenses  []License
 	checksums []Checksum
@@ -63,7 +65,7 @@ func (c component) Version() string {
 func (c component) Purls() []string {
 	return c.purls
 }
-func (c component) Cpes() []string {
+func (c component) Cpes() []cpe.CPE {
 	return c.cpes
 }
 func (c component) Licenses() []License {

--- a/pkg/sbom/component_test.go
+++ b/pkg/sbom/component_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import (
+	"testing"
+
+	"github.com/interlynk-io/sbomqs/pkg/cpe"
+)
+
+func TestGetCpeFromCompo(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input []cpe.CPE
+		want  int
+	}{
+		{"get cpe from component", []cpe.CPE{"cpe:-2.3:a:CycloneDX:cyclonedx-go:v0.7.0:*:*:*:*:*:*:*"}, 1},
+		{"Is XYZ is valid CPE2.3", []cpe.CPE{""}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := component{
+				cpes: tt.input,
+			}
+			if len(tt.input) != len(cp.cpes) {
+				t.Errorf("got %d, want %d", len(cp.cpes), len(tt.input))
+			}
+		})
+	}
+}

--- a/pkg/sbom/sbomfakes/fake_component.go
+++ b/pkg/sbom/sbomfakes/fake_component.go
@@ -4,6 +4,7 @@ package sbomfakes
 import (
 	"sync"
 
+	"github.com/interlynk-io/sbomqs/pkg/cpe"
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 )
 
@@ -18,15 +19,15 @@ type FakeComponent struct {
 	checksumsReturnsOnCall map[int]struct {
 		result1 []sbom.Checksum
 	}
-	CpesStub        func() []string
+	CpesStub        func() []cpe.CPE
 	cpesMutex       sync.RWMutex
 	cpesArgsForCall []struct {
 	}
 	cpesReturns struct {
-		result1 []string
+		result1 []cpe.CPE
 	}
 	cpesReturnsOnCall map[int]struct {
-		result1 []string
+		result1 []cpe.CPE
 	}
 	IDStub        func() string
 	iDMutex       sync.RWMutex
@@ -165,7 +166,7 @@ func (fake *FakeComponent) ChecksumsReturnsOnCall(i int, result1 []sbom.Checksum
 	}{result1}
 }
 
-func (fake *FakeComponent) Cpes() []string {
+func (fake *FakeComponent) Cpes() []cpe.CPE {
 	fake.cpesMutex.Lock()
 	ret, specificReturn := fake.cpesReturnsOnCall[len(fake.cpesArgsForCall)]
 	fake.cpesArgsForCall = append(fake.cpesArgsForCall, struct {
@@ -189,32 +190,32 @@ func (fake *FakeComponent) CpesCallCount() int {
 	return len(fake.cpesArgsForCall)
 }
 
-func (fake *FakeComponent) CpesCalls(stub func() []string) {
+func (fake *FakeComponent) CpesCalls(stub func() []cpe.CPE) {
 	fake.cpesMutex.Lock()
 	defer fake.cpesMutex.Unlock()
 	fake.CpesStub = stub
 }
 
-func (fake *FakeComponent) CpesReturns(result1 []string) {
+func (fake *FakeComponent) CpesReturns(result1 []cpe.CPE) {
 	fake.cpesMutex.Lock()
 	defer fake.cpesMutex.Unlock()
 	fake.CpesStub = nil
 	fake.cpesReturns = struct {
-		result1 []string
+		result1 []cpe.CPE
 	}{result1}
 }
 
-func (fake *FakeComponent) CpesReturnsOnCall(i int, result1 []string) {
+func (fake *FakeComponent) CpesReturnsOnCall(i int, result1 []cpe.CPE) {
 	fake.cpesMutex.Lock()
 	defer fake.cpesMutex.Unlock()
 	fake.CpesStub = nil
 	if fake.cpesReturnsOnCall == nil {
 		fake.cpesReturnsOnCall = make(map[int]struct {
-			result1 []string
+			result1 []cpe.CPE
 		})
 	}
 	fake.cpesReturnsOnCall[i] = struct {
-		result1 []string
+		result1 []cpe.CPE
 	}{result1}
 }
 

--- a/pkg/sbom/spdx_test.go
+++ b/pkg/sbom/spdx_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/sbomqs.syft-cyclone.json
+++ b/samples/sbomqs.syft-cyclone.json
@@ -24,7 +24,7 @@
       "type": "library",
       "name": "github.com/CycloneDX/cyclonedx-go",
       "version": "v0.7.0",
-      "cpe": "cpe:2.3:a:CycloneDX:cyclonedx-go:v0.7.0:*:*:*:*:*:*:*",
+      "cpe": "cpe-:2.3:a:CycloneDX:cyclonedx-go:v0.7.0:*:*:*:*:*:*:*",
       "purl": "pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.7.0",
       "properties": [
         {


### PR DESCRIPTION
Define CPE as a type for SBOM, while reading CPE from CDX and SPDX we are validating if CPE format is valid or not.