### PR TITLE
Json output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,35 @@ You can evaluate your SBOM's based on specific categories, as described [here](#
 8.5	../sbom-samples/repos/trivy-trivy-ci-test.cdx.json
 ```
 
+#### Using json output format
+We can output the quality score results as json
+```console
+➜  sbomqs ./build/sbomqs score --filepath samples/sbomqs.syft-spdx.json --reportFormat json
+{
+  "run_id": "b6c9b850-8f66-4b70-8d62-d8f29087e68a",
+  "timestamp": "2023-02-18T07:41:58Z",
+  "creation_info": {
+    "name": "sbomqs",
+    "version": "v0.0.6-2-g20e141c",
+    "scoring_engine_version": "1"
+  },
+  "files": [
+    {
+      "file_name": "samples/sbomqs.syft-spdx.json",
+      "spec": "spdx",
+      "spec_version": "SPDX-2.3",
+      "file_format": "json",
+      "avg_score": 6.15,
+      "scores": [
+        {
+          "category": "Quality",
+          "feature": "Components have no deprecated licenses",
+          "score": 0,
+          "max_score": 10,
+          "description": "no licenses found"
+        },
+```
+
 #### Categories 
 We have catergorizes scoring into 5 categories
 

--- a/cmd/score.go
+++ b/cmd/score.go
@@ -34,12 +34,36 @@ var scoreCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := logger.WithLogger(context.Background())
 		var err error
+		if len(category) > 0 && !lo.Contains(scorer.Categories, category) {
+			return fmt.Errorf(fmt.Sprintf("Category not found %s in %s", category, strings.Join(scorer.Categories, ",")))
+		}
+
+		if len(reportFormat) > 0 && !lo.Contains(reporter.ReportFormats, strings.ToLower(reportFormat)) {
+			return fmt.Errorf("report format options are basic or detailed")
+		}
+
+		var docs []sbom.Document
+		var scores []scorer.Scores
+		var paths []string
 
 		if len(inFile) > 0 {
-			err = processFile(ctx, inFile, false)
+			d, s, e := processFile(ctx, inFile)
+			if e != nil {
+				return fmt.Errorf("error processing file")
+			}
+			docs = append(docs, d)
+			scores = append(scores, s)
+			paths = append(paths, inFile)
 		} else if len(inDirPath) > 0 {
-			err = processDir(ctx, inDirPath)
+			docs, scores, paths, err = processDir(ctx, inDirPath)
 		}
+
+		nr := reporter.NewReport(ctx,
+			docs,
+			scores,
+			paths,
+			reporter.WithFormat(strings.ToLower(reportFormat)))
+		nr.Report()
 
 		return err
 	},
@@ -51,24 +75,24 @@ func init() {
 	scoreCmd.Flags().StringVar(&inDirPath, "dirpath", "", "sbom dir path")
 	scoreCmd.MarkFlagsMutuallyExclusive("filepath", "dirpath")
 	scoreCmd.Flags().StringVar(&category, "category", "", "scoring category")
-	scoreCmd.Flags().StringVar(&reportFormat, "reportFormat", "", "reporting format basic or detailed")
+	scoreCmd.Flags().StringVar(&reportFormat, "reportFormat", "", "reporting format basic/detailed/json")
 }
 
-func processFile(ctx context.Context, filePath string, basic bool) error {
+func processFile(ctx context.Context, filePath string) (sbom.Document, scorer.Scores, error) {
 	log := logger.FromContext(ctx)
 	log.Debugf("Processing file :%s\n", filePath)
 
 	if _, err := os.Stat(filePath); err != nil {
 		log.Debugf("os.Stat failed for file :%s\n", filePath)
 		fmt.Printf("failed to stat %s\n", filePath)
-		return err
+		return nil, nil, err
 	}
 
 	f, err := os.Open(filePath)
 	if err != nil {
 		log.Debugf("os.Open failed for file :%s\n", filePath)
 		fmt.Printf("failed to open %s\n", filePath)
-		return err
+		return nil, nil, err
 	}
 	defer f.Close()
 
@@ -77,15 +101,7 @@ func processFile(ctx context.Context, filePath string, basic bool) error {
 		log.Debugf("failed to create sbom document for  :%s\n", filePath)
 		log.Debugf("%s\n", err)
 		fmt.Printf("failed to parse %s\n", filePath)
-		return err
-	}
-
-	if len(category) > 0 && !lo.Contains(scorer.Categories, category) {
-		return fmt.Errorf(fmt.Sprintf("Category not found %s in %s", category, strings.Join(scorer.Categories, ",")))
-	}
-
-	if len(reportFormat) > 0 && !lo.Contains(reporter.ReportFormats, reportFormat) {
-		return fmt.Errorf("report format options are basic or detailed")
+		return nil, nil, err
 	}
 
 	sr := scorer.NewScorer(ctx,
@@ -95,31 +111,35 @@ func processFile(ctx context.Context, filePath string, basic bool) error {
 
 	scores := sr.Score()
 
-	nr := reporter.NewReport(ctx,
-		doc,
-		scores,
-		reporter.WithFormat(strings.ToLower(reportFormat)),
-		reporter.WithFilePath(filePath))
-	nr.Report()
-
-	return nil
+	return doc, scores, nil
 }
 
-func processDir(ctx context.Context, dirPath string) error {
+func processDir(ctx context.Context, dirPath string) ([]sbom.Document, []scorer.Scores, []string, error) {
 	log := logger.FromContext(ctx)
 	log.Debugf("processing dirpath: %s\n", dirPath)
 	files, err := os.ReadDir(dirPath)
 	if err != nil {
 		log.Debugf("os.ReadDir failed for path:%s\n", dirPath)
 		log.Debugf("%s\n", err)
-		return err
+		return nil, nil, nil, err
 	}
+
+	var docs []sbom.Document
+	var paths []string
+	var scores []scorer.Scores
 
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
-		processFile(ctx, filepath.Join(dirPath, file.Name()), true)
+		path := filepath.Join(dirPath, file.Name())
+		doc, scs, err := processFile(ctx, path)
+		if err != nil {
+			continue
+		}
+		docs = append(docs, doc)
+		scores = append(scores, scs)
+		paths = append(paths, path)
 	}
-	return nil
+	return docs, scores, paths, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.0
+	github.com/google/uuid v1.3.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.6.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/package-url/packageurl-go v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/pkg/reporter/basic.go
+++ b/pkg/reporter/basic.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import "fmt"
+
+func (r *Reporter) simpleReport() {
+	for index, path := range r.Paths {
+		//doc := r.Docs[index]
+		scores := r.Scores[index]
+
+		fmt.Printf("%0.1f\t%s\n", scores.AvgScore(), path)
+	}
+}

--- a/pkg/reporter/detailed.go
+++ b/pkg/reporter/detailed.go
@@ -1,0 +1,51 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+func (r *Reporter) detailedReport() {
+
+	for index, path := range r.Paths {
+		doc := r.Docs[index]
+		scores := r.Scores[index]
+
+		outDoc := [][]string{}
+
+		for _, score := range scores.ScoreList() {
+			l := []string{score.Category(), score.Feature(), fmt.Sprintf("%0.1f/10.0", score.Score()), score.Descr()}
+			outDoc = append(outDoc, l)
+		}
+
+		sort.Slice(outDoc, func(i, j int) bool {
+			return outDoc[i][0] < outDoc[j][0]
+		})
+
+		fmt.Printf("SBOM Quality Score:%0.1f\tcomponents:%d\t%s\n", scores.AvgScore(), len(doc.Components()), path)
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"Category", "Feature", "Score", "Desc"})
+		table.SetRowLine(true)
+		table.SetAutoMergeCellsByColumnIndex([]int{0})
+		table.AppendBulk(outDoc)
+		table.Render()
+
+	}
+}

--- a/pkg/reporter/json.go
+++ b/pkg/reporter/json.go
@@ -1,0 +1,97 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/interlynk-io/sbomqs/pkg/scorer"
+	"sigs.k8s.io/release-utils/version"
+)
+
+type score struct {
+	Category string  `json:"category"`
+	Feature  string  `json:"feature"`
+	Score    float64 `json:"score"`
+	MaxScore float64 `json:"max_score"`
+	Desc     string  `json:"description"`
+}
+type file struct {
+	Name        string   `json:"file_name"`
+	Spec        string   `json:"spec"`
+	SpecVersion string   `json:"spec_version"`
+	Format      string   `json:"file_format"`
+	AvgScore    float64  `json:"avg_score"`
+	Scores      []*score `json:"scores"`
+}
+
+type creation struct {
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	ScoringEngine string `json:"scoring_engine_version"`
+}
+
+type jsonReport struct {
+	RunID        string   `json:"run_id"`
+	TimeStamp    string   `json:"timestamp"`
+	CreationInfo creation `json:"creation_info"`
+	Files        []file   `json:"files"`
+}
+
+func newJsonReport() *jsonReport {
+	return &jsonReport{
+		RunID:     uuid.New().String(),
+		TimeStamp: time.Now().UTC().Format(time.RFC3339),
+		CreationInfo: creation{
+			Name:          "sbomqs",
+			Version:       version.GetVersionInfo().GitVersion,
+			ScoringEngine: scorer.EngineVersion,
+		},
+		Files: []file{},
+	}
+}
+
+func (r *Reporter) jsonReport() {
+	jr := newJsonReport()
+	for index, path := range r.Paths {
+		doc := r.Docs[index]
+		scores := r.Scores[index]
+
+		f := file{}
+		f.AvgScore = scores.AvgScore()
+		f.Format = doc.Spec().FileFormat()
+		f.Name = path
+		f.Spec = doc.Spec().Name()
+		f.SpecVersion = doc.Spec().Version()
+
+		for _, ss := range scores.ScoreList() {
+			ns := new(score)
+			ns.Category = ss.Category()
+			ns.Feature = ss.Feature()
+			ns.Score = ss.Score()
+			ns.MaxScore = ss.MaxScore()
+			ns.Desc = ss.Descr()
+
+			f.Scores = append(f.Scores, ns)
+		}
+
+		jr.Files = append(jr.Files, f)
+	}
+	o, _ := json.MarshalIndent(jr, "", "  ")
+	fmt.Println(string(o))
+}

--- a/pkg/scorer/score.go
+++ b/pkg/scorer/score.go
@@ -22,7 +22,10 @@ type Score interface {
 	Ignore() bool
 	Score() float64
 	Descr() string
+	MaxScore() float64
 }
+
+const MAX_SCORE float64 = 10.0
 
 type score struct {
 	category string
@@ -70,4 +73,8 @@ func (s score) Ignore() bool {
 
 func (s score) Descr() string {
 	return s.descr
+}
+
+func (s score) MaxScore() float64 {
+	return MAX_SCORE
 }

--- a/pkg/scorer/scorer.go
+++ b/pkg/scorer/scorer.go
@@ -21,6 +21,8 @@ import (
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 )
 
+const EngineVersion = "1"
+
 type Scorer struct {
 	ctx context.Context
 	doc sbom.Document


### PR DESCRIPTION
I have added support for JSON output. This should help with post analysis of the results produced.  The current implementation batches all the scores in memory, before writing it out. This works well with directorys with upto maybe 1000 files, once it exceeds those, this approach is not idle. We will need to think through  a streaming option for directories with large number of file.s 

```console
➜  sbomqs git:(38-feature-request-output-json) ./build/sbomqs score --category NTIA-minimum-elements --filepath samples/julia.spdx.json --reportFormat JSON
{
  "run_id": "65346347-119f-4de3-9762-5af8f717c5e0",
  "timestamp": "2023-02-17T09:47:07Z",
  "creation_info": {
    "name": "sbomqs",
    "version": "v0.0.6-1-geb3d2e6-dirty",
    "scoring_engine_version": "1"
  },
  "files": [
    {
      "file_name": "samples/julia.spdx.json",
      "spec": "spdx",
      "spec_version": "SPDX-2.2",
      "file_format": "json",
      "avg_score": 5.840336134453781,
      "scores": [
        {
          "category": "NTIA-minimum-elements",
          "feature": "Components have names",
          "score": 10,
          "max_score": 10,
          "description": "34/34 have names"
        },
        {
          "category": "NTIA-minimum-elements",
          "feature": "Doc has relationships",
          "score": 10,
          "max_score": 10,
          "description": "doc has 1 relationships "
        },
        {
          "category": "NTIA-minimum-elements",
          "feature": "Components have versions",
          "score": 0.29411764705882354,
          "max_score": 10,
          "description": "1/34 have versions"
        },
        {
          "category": "NTIA-minimum-elements",
          "feature": "Components have uniq ids",
          "score": 0,
          "max_score": 10,
          "description": "0/34 have unique ID's"
        },
        {
          "category": "NTIA-minimum-elements",
          "feature": "Doc has creation timestamp",
          "score": 10,
          "max_score": 10,
          "description": "doc has creation timestamp 2021-12-21T07:13:19Z"
        },
        {
          "category": "NTIA-minimum-elements",
          "feature": "Components have supplier names",
          "score": 0.5882352941176471,
          "max_score": 10,
          "description": "2/34 have supplier names"
        },
        {
          "category": "NTIA-minimum-elements",
          "feature": "Doc has authors",
          "score": 10,
          "max_score": 10,
          "description": "doc has 2 authors"
        }
      ]
    }
  ]
}
```