### PR TITLE
Setup permissions and git controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,19 @@ on:
 jobs:
   releaser:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v3 
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags 
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.20'
           check-latest: true
+          cache: true
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
Fixed goreleaser permissions, so it can write to github releases. 