### PR TITLE
Add token settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
         run: make release 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,6 +49,7 @@ brews:
     description: "Quality score for your SBOM" 
     license: "Apache 2.0"
     folder: Formula
+    token: "{{ .Env.TAP_GITHUB_TOKEN }}" 
     tap:
       owner: interlynk-io
       name: homebrew-interlynk


### PR DESCRIPTION
Since the GH is pushing outside this repo, it needs special permissions. 


https://goreleaser.com/errors/resource-not-accessible-by-integration/