### PR TITLE
49 new rule for checking of vulnerability lookup identifier present

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -28,7 +28,8 @@ Components have licenses | checks if the sbom components have licenses |
 Components have checksums | checks if the sbom components have checksums | 
 Components have valid spdx licenses | checks if the sbom components have licenses which match the spdx license list |
 Components dont have deprecated licenses| checks if the sbom components dont have licenses that are deprecated |
-Components have all uniq lookup ids| checks if the sbom components have both purl and cpe | 
+Components have multiple vulnerability lookup ids| checks if the sbom components have both purl and cpe | 
+Components have any vulnerability lookup ids| checks if the sbom components at least one of purl or cpe | 
 Components have restricted licenses | checks if the sbom components have restricted licenses which match the restricted license list |
 Components have primary purpose defined | checks if the sbom components have a primary purpose defined e.g application/library|
 Doc has Relations | checks if sbom has specified relations between its components | 

--- a/cmd/score.go
+++ b/cmd/score.go
@@ -100,7 +100,7 @@ func processFile(ctx context.Context, filePath string) (sbom.Document, scorer.Sc
 	if err != nil {
 		log.Debugf("failed to create sbom document for  :%s\n", filePath)
 		log.Debugf("%s\n", err)
-		fmt.Printf("failed to parse %s\n", filePath)
+		fmt.Printf("failed to parse %s : %s\n", filePath, err)
 		return nil, nil, err
 	}
 

--- a/pkg/purl/purl.go
+++ b/pkg/purl/purl.go
@@ -20,11 +20,6 @@ import (
 
 type PURL string
 
-type PURLMeta interface {
-	Valid() bool
-	String() string
-}
-
 func NewPURL(prl string) PURL {
 	return PURL(prl)
 }

--- a/pkg/scorer/criteria.go
+++ b/pkg/scorer/criteria.go
@@ -55,7 +55,8 @@ const (
 
 	compWithValidLicenses      criteria = "Components have valid spdx licenses"
 	compWithNoDepLicenses      criteria = "Components have no deprecated licenses"
-	compWithAllId              criteria = "Components have multiple formats of uniq ids"
+	compWithMultipleLookupId   criteria = "Components have multiple vulnerability lookup ids"
+	compWithAnyLookupId        criteria = "Components have any vulnerability lookup id"
 	compWithPrimaryPackages    criteria = "Components have primary purpose defined"
 	compWithRestrictedLicenses criteria = "Components have no restricted licenses"
 
@@ -89,9 +90,10 @@ func init() {
 	//quality
 	_ = registerCriteria(compWithValidLicenses, compWithValidLicensesScore)
 	_ = registerCriteria(compWithNoDepLicenses, compWithNoDepLicensesScore)
-	_ = registerCriteria(compWithAllId, compWithAllIdScore)
 	_ = registerCriteria(compWithPrimaryPackages, compWithPrimaryPackageScore)
 	_ = registerCriteria(compWithRestrictedLicenses, compWithRestrictedLicensesScore)
+	_ = registerCriteria(compWithAnyLookupId, compWithAnyLookupIdScore)
+	_ = registerCriteria(compWithMultipleLookupId, compWithMultipleIdScore)
 
 	//sharing
 	_ = registerCriteria(docShareLicense, sharableLicenseScore)

--- a/pkg/scorer/scorer.go
+++ b/pkg/scorer/scorer.go
@@ -21,7 +21,7 @@ import (
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 )
 
-const EngineVersion = "2"
+const EngineVersion = "3"
 
 type Scorer struct {
 	ctx context.Context


### PR DESCRIPTION
The PR is a follow-up after we figured out that NTIA "other-identifiers" check can be done only by checking bom-ref or spdxid. We added a new quality metric, to check if the SBOM has atleast one id for vulnerability lookup. In addition i modified the multiple vulnerability id check to be simpler. 

