### PR TITLE
Add component count to json

### DIFF
--- a/pkg/reporter/json.go
+++ b/pkg/reporter/json.go
@@ -37,6 +37,7 @@ type file struct {
 	SpecVersion string   `json:"spec_version"`
 	Format      string   `json:"file_format"`
 	AvgScore    float64  `json:"avg_score"`
+	Components  int      `json:"no_components"`
 	Scores      []*score `json:"scores"`
 }
 
@@ -74,6 +75,7 @@ func (r *Reporter) jsonReport() {
 
 		f := file{}
 		f.AvgScore = scores.AvgScore()
+		f.Components = len(doc.Components())
 		f.Format = doc.Spec().FileFormat()
 		f.Name = path
 		f.Spec = doc.Spec().Name()

--- a/pkg/reporter/json.go
+++ b/pkg/reporter/json.go
@@ -37,7 +37,7 @@ type file struct {
 	SpecVersion string   `json:"spec_version"`
 	Format      string   `json:"file_format"`
 	AvgScore    float64  `json:"avg_score"`
-	Components  int      `json:"no_components"`
+	Components  int      `json:"num_components"`
 	Scores      []*score `json:"scores"`
 }
 


### PR DESCRIPTION
Adding component count to json, to keep it consistent with others.


```
{
  "run_id": "73adc38a-7fb7-4cd5-82d1-efceb1eb8c6f",
  "timestamp": "2023-03-01T13:08:10Z",
  "creation_info": {
    "name": "sbomqs",
    "version": "v0.0.7-18-g32115c6-dirty",
    "scoring_engine_version": "3"
  },
  "files": [
    {
      "file_name": "/mnt/c/Users/rites/Downloads/syft-0.73.0_busybox-1-glibc.cdx.json",
      "spec": "cyclonedx",
      "spec_version": "1.4",
      "file_format": "json",
      "avg_score": 5.476190476190476,
      "no_components": 2,
```