### PR TITLE
77 add consistent creationinformation as a SBOM quality check

### DIFF
--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -210,14 +210,30 @@ func (s *spdxDoc) parseTool() {
 		return
 	}
 
+	//https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#68-creator-field
+	//spdx2.3 spec says If the SPDX document was created using a software tool,
+	//indicate the name and version for that tool
+	extractVersion := func(name string) (string, string) {
+		//check if the version is a single word, i.e no spaces
+		if strings.Contains(name, " ") {
+			return name, ""
+		}
+		//check if name has - in it
+		tool, ver, ok := strings.Cut(name, "-")
+
+		if !ok {
+			return name, ""
+		}
+		return tool, ver
+	}
+
 	for _, c := range s.doc.CreationInfo.Creators {
 		ctType := strings.ToLower(c.CreatorType)
 		if ctType != "tool" {
 			continue
 		}
 		t := tool{}
-		t.name = c.Creator
-		t.version = ""
+		t.name, t.version = extractVersion(c.Creator)
 		s.tools = append(s.tools, t)
 	}
 }

--- a/pkg/scorer/criteria.go
+++ b/pkg/scorer/criteria.go
@@ -77,6 +77,7 @@ const (
 	compWithAnyLookupId        criterion = "Components have any vulnerability lookup id"
 	compWithPrimaryPackages    criterion = "Components have primary purpose defined"
 	compWithRestrictedLicenses criterion = "Components have no restricted licenses"
+	docWithCreator             criterion = "Doc has creator tool and version"
 
 	docShareLicense criterion = "Doc sharable license"
 )
@@ -112,6 +113,7 @@ func init() {
 	_ = registerCriteria(compWithRestrictedLicenses, compWithRestrictedLicensesScore)
 	_ = registerCriteria(compWithAnyLookupId, compWithAnyLookupIdScore)
 	_ = registerCriteria(compWithMultipleLookupId, compWithMultipleIdScore)
+	_ = registerCriteria(docWithCreator, docWithCreatorScore)
 
 	//sharing
 	_ = registerCriteria(docShareLicense, sharableLicenseScore)
@@ -150,6 +152,7 @@ const (
 	SBOMSPEC                 CriteriaArg = "sbom-spec"
 	COMPANYVULNERABILITYID   CriteriaArg = "comp-any-vulnerability-id"
 	COMPMULTIVULNERABILITYID CriteriaArg = "comp-multi-vulnerability-id"
+	DOCCREATORTOOL           CriteriaArg = "doc-creator-tool"
 )
 
 var CriteriaArgs = []string{
@@ -174,6 +177,7 @@ var CriteriaArgs = []string{
 	string(SBOMSPEC),
 	string(COMPANYVULNERABILITYID),
 	string(COMPMULTIVULNERABILITYID),
+	string(DOCCREATORTOOL),
 }
 
 var CriteriaArgMap = map[CriteriaArg]string{
@@ -198,4 +202,5 @@ var CriteriaArgMap = map[CriteriaArg]string{
 	SBOMSPEC:                 string(spec),
 	COMPANYVULNERABILITYID:   string(compWithAnyLookupId),
 	COMPMULTIVULNERABILITYID: string(compWithMultipleLookupId),
+	DOCCREATORTOOL:           string(docWithCreator),
 }

--- a/pkg/scorer/quality.go
+++ b/pkg/scorer/quality.go
@@ -168,3 +168,19 @@ func compWithMultipleIdScore(d sbom.Document) score {
 
 	return *s
 }
+
+func docWithCreatorScore(d sbom.Document) score {
+	s := newScore(CategoryQuality, string(docWithCreator))
+
+	totalTools := len(d.Tools())
+
+	withCreatorAndVersion := lo.CountBy(d.Tools(), func(t sbom.Tool) bool {
+		return t.Name() != "" && t.Version() != ""
+	})
+
+	finalScore := (float64(withCreatorAndVersion) / float64(totalTools)) * 10.0
+
+	s.setScore(finalScore)
+	s.setDesc(fmt.Sprintf("%d/%d tools have creator and version", withCreatorAndVersion, totalTools))
+	return *s
+}


### PR DESCRIPTION
SBOM generators should consistently report their name and version in the SBOM. We have noticed this is not always the case. For consumption, its essential to understand which tool was used to generate this sbom, to understand its quality. 

We have added a quality score to help highlight this issue with sbom generators. 

A couple of examples from the spdx ecosystem
- Microsoft.SBOMTool-0.2.7
- reuse-0.14.0
- sigs.k8s.io/bom/pkg/spdx
- apko (v0.7.1-4-ge6dcd4b)
- trivy 