### PR TITLE
Add support to ignore scores when not applicable

### DIFF
--- a/pkg/reporter/basic.go
+++ b/pkg/reporter/basic.go
@@ -18,9 +18,7 @@ import "fmt"
 
 func (r *Reporter) simpleReport() {
 	for index, path := range r.Paths {
-		//doc := r.Docs[index]
 		scores := r.Scores[index]
-
 		fmt.Printf("%0.1f\t%s\n", scores.AvgScore(), path)
 	}
 }

--- a/pkg/reporter/detailed.go
+++ b/pkg/reporter/detailed.go
@@ -32,7 +32,12 @@ func (r *Reporter) detailedReport() {
 		outDoc := [][]string{}
 
 		for _, score := range scores.ScoreList() {
-			l := []string{score.Category(), score.Feature(), fmt.Sprintf("%0.1f/10.0", score.Score()), score.Descr()}
+			var l []string
+			if score.Ignore() {
+				l = []string{score.Category(), score.Feature(), " - ", score.Descr()}
+			} else {
+				l = []string{score.Category(), score.Feature(), fmt.Sprintf("%0.1f/10.0", score.Score()), score.Descr()}
+			}
 			outDoc = append(outDoc, l)
 		}
 
@@ -53,6 +58,5 @@ func (r *Reporter) detailedReport() {
 		table.SetAutoMergeCellsByColumnIndex([]int{0})
 		table.AppendBulk(outDoc)
 		table.Render()
-
 	}
 }

--- a/pkg/reporter/json.go
+++ b/pkg/reporter/json.go
@@ -30,6 +30,7 @@ type score struct {
 	Score    float64 `json:"score"`
 	MaxScore float64 `json:"max_score"`
 	Desc     string  `json:"description"`
+	Ignored  bool    `json:"ignored"`
 }
 type file struct {
 	Name        string   `json:"file_name"`
@@ -88,6 +89,7 @@ func (r *Reporter) jsonReport() {
 			ns.Score = ss.Score()
 			ns.MaxScore = ss.MaxScore()
 			ns.Desc = ss.Descr()
+			ns.Ignored = ss.Ignore()
 
 			f.Scores = append(f.Scores, ns)
 		}

--- a/pkg/sbom/cdx_test.go
+++ b/pkg/sbom/cdx_test.go
@@ -15,7 +15,6 @@
 package sbom
 
 import (
-	"strings"
 	"testing"
 
 	cydx "github.com/CycloneDX/cyclonedx-go"
@@ -93,47 +92,6 @@ func cdxBOM() *cydx.BOM {
 	bom.Components = &comps
 
 	return bom
-}
-
-func Test_cdxDoc_addSupplierName(t *testing.T) {
-	type fields struct {
-		doc     *cydx.BOM
-		spec    *spec
-		comps   []Component
-		authors []Author
-		tools   []Tool
-		rels    []Relation
-		logs    []string
-	}
-	type args struct {
-		index int
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		{"Supplier name is found", fields{doc: cdxBOM()}, args{index: 1}, strings.ToLower("Dummy")},
-		{"Supplier section is not found", fields{doc: cdxBOM()}, args{index: 0}, ""},
-		{"Supplier name is blank", fields{doc: cdxBOM()}, args{index: 2}, ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &cdxDoc{
-				doc:     tt.fields.doc,
-				spec:    tt.fields.spec,
-				comps:   tt.fields.comps,
-				authors: tt.fields.authors,
-				tools:   tt.fields.tools,
-				rels:    tt.fields.rels,
-				logs:    tt.fields.logs,
-			}
-			if got := c.addSupplierName(tt.args.index); got != tt.want {
-				t.Errorf("cdxDoc.addSupplierName() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }
 
 func Test_cdxDoc_parseComps_Cpes(t *testing.T) {

--- a/pkg/scorer/ntia.go
+++ b/pkg/scorer/ntia.go
@@ -26,6 +26,13 @@ func compSupplierScore(d sbom.Document) score {
 	s := newScore(CategoryNTIAMiniumElements, string(compSupplierName))
 
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
+
 	withNames := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		return c.SupplierName() != ""
 	})
@@ -42,6 +49,12 @@ func compSupplierScore(d sbom.Document) score {
 func compWithNameScore(d sbom.Document) score {
 	s := newScore(CategoryNTIAMiniumElements, string(compWithNames))
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 	withNames := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		return c.Name() != ""
 	})
@@ -56,7 +69,12 @@ func compWithNameScore(d sbom.Document) score {
 func compWithVersionScore(d sbom.Document) score {
 	s := newScore(CategoryNTIAMiniumElements, string(compWithVersion))
 	totalComponents := len(d.Components())
-
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 	withVersions := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		return c.Version() != ""
 	})
@@ -71,6 +89,12 @@ func compWithVersionScore(d sbom.Document) score {
 func compWithUniqIDScore(d sbom.Document) score {
 	s := newScore(CategoryNTIAMiniumElements, string(compWithUniqID))
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 
 	compIDs := lo.Map(d.Components(), func(c sbom.Component, i int) string {
 		return strings.Join([]string{d.Spec().Namespace(), c.ID()}, "")

--- a/pkg/scorer/quality.go
+++ b/pkg/scorer/quality.go
@@ -28,6 +28,12 @@ func compWithValidLicensesScore(d sbom.Document) score {
 	s := newScore(CategoryQuality, string(compWithValidLicenses))
 
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 
 	compScores := lo.Map(d.Components(), func(c sbom.Component, _ int) float64 {
 		tl := len(c.Licenses())
@@ -63,7 +69,12 @@ func compWithPrimaryPackageScore(d sbom.Document) score {
 	s := newScore(CategoryQuality, string(compWithPrimaryPackages))
 
 	totalComponents := len(d.Components())
-
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 	withPurpose := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		return c.PrimaryPurpose() != "" && lo.Contains(sbom.SupportedPrimaryPurpose(d.Spec().Name()), strings.ToLower(c.PrimaryPurpose()))
 	})
@@ -78,6 +89,12 @@ func compWithPrimaryPackageScore(d sbom.Document) score {
 func compWithNoDepLicensesScore(d sbom.Document) score {
 	s := newScore(CategoryQuality, string(compWithNoDepLicenses))
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 
 	totalLicenses := lo.Reduce(d.Components(), func(agg int, c sbom.Component, _ int) int {
 		return agg + len(c.Licenses())
@@ -104,6 +121,12 @@ func compWithNoDepLicensesScore(d sbom.Document) score {
 func compWithRestrictedLicensesScore(d sbom.Document) score {
 	s := newScore(CategoryQuality, string(compWithRestrictedLicenses))
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 
 	totalLicenses := lo.Reduce(d.Components(), func(agg int, c sbom.Component, _ int) int {
 		return agg + len(c.Licenses())
@@ -131,6 +154,12 @@ func compWithAnyLookupIdScore(d sbom.Document) score {
 	s := newScore(CategoryQuality, string(compWithAnyLookupId))
 
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 
 	withAnyLookupId := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		if len(c.Cpes()) > 0 || len(c.Purls()) > 0 {
@@ -152,6 +181,12 @@ func compWithMultipleIdScore(d sbom.Document) score {
 	s := newScore(CategoryQuality, string(compWithMultipleLookupId))
 
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 
 	withMultipleId := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		if len(c.Cpes()) > 0 && len(c.Purls()) > 0 {

--- a/pkg/scorer/score.go
+++ b/pkg/scorer/score.go
@@ -55,6 +55,10 @@ func (s *score) setDesc(d string) {
 	s.descr = d
 }
 
+func (s *score) setIgnore(i bool) {
+	s.ignore = i
+}
+
 func (s score) Category() string {
 	return s.category
 }

--- a/pkg/scorer/scorer.go
+++ b/pkg/scorer/scorer.go
@@ -22,7 +22,7 @@ import (
 	"github.com/samber/lo"
 )
 
-const EngineVersion = "3"
+const EngineVersion = "4"
 
 type Scorer struct {
 	ctx context.Context
@@ -86,4 +86,4 @@ func scoreFilterWithCategory(s score, ss *scores) {
 	} else if s.category == "" {
 		ss.addScore(s)
 	}
-}			
+}

--- a/pkg/scorer/scores.go
+++ b/pkg/scorer/scores.go
@@ -42,7 +42,9 @@ func (s scores) Count() int {
 func (s scores) AvgScore() float64 {
 	score := 0.0
 	for _, s := range s.scs {
-		score += s.Score()
+		if !s.Ignore() {
+			score += s.Score()
+		}
 	}
 	return score / float64(s.Count())
 }

--- a/pkg/scorer/semantic.go
+++ b/pkg/scorer/semantic.go
@@ -66,7 +66,12 @@ func compWithLicenseScore(d sbom.Document) score {
 	s := newScore(CategorySemantic, string(compWithLicenses))
 
 	totalComponents := len(d.Components())
-
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 	withLicenses := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		return len(c.Licenses()) > 0
 	})
@@ -84,6 +89,12 @@ func compWithChecksumsScore(d sbom.Document) score {
 	s := newScore(CategorySemantic, string(compWithChecksums))
 
 	totalComponents := len(d.Components())
+	if totalComponents == 0 {
+		s.setScore(0.0)
+		s.setDesc("N/A (no components)")
+		s.setIgnore(true)
+		return *s
+	}
 
 	withChecksums := lo.CountBy(d.Components(), func(c sbom.Component) bool {
 		return len(c.Checksums()) > 0


### PR DESCRIPTION
1. For CDX we were not included the main component, as part of all components. We have added it in this release.
2. Added support to ignore scores, which may not be applicable, this will help now skewing the overall score.
3. Added new field in json called ignored, this informs the consumer if they should use this feature score for average computations. 

```json
        {
          "category": "Semantic",
          "feature": "Components have checksums",
          "score": 0,
          "max_score": 10,
          "description": "N/A (no components)",
          "ignored": true
        }
``` 