### PR TITLE
working refactor

### DIFF
--- a/cmd/share.go
+++ b/cmd/share.go
@@ -16,13 +16,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	"github.com/interlynk-io/sbomqs/pkg/engine"
 	"github.com/interlynk-io/sbomqs/pkg/logger"
-	"github.com/interlynk-io/sbomqs/pkg/reporter"
-	"github.com/interlynk-io/sbomqs/pkg/sbom"
-	"github.com/interlynk-io/sbomqs/pkg/scorer"
-	"github.com/interlynk-io/sbomqs/pkg/share"
 	"github.com/spf13/cobra"
 )
 
@@ -48,27 +44,14 @@ For more information, please visit https://sbombenchmark.dev
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := logger.WithLogger(context.Background())
-
 		sbomFileName := args[0]
-		doc, scores, err := processFile(ctx, sbomFileName, nil)
 
-		if err != nil {
-			fmt.Printf("Error processing file %s: %s", sbomFileName, err)
-			return err
+		engParams := &engine.Params{
+			Path:  sbomFileName,
+			Basic: true,
+			Debug: false,
 		}
-		url, err := share.Share(ctx, doc, scores, sbomFileName)
-		if err != nil {
-			fmt.Printf("Error sharing file %s: %s", sbomFileName, err)
-			return err
-		}
-		nr := reporter.NewReport(ctx,
-			[]sbom.Document{doc},
-			[]scorer.Scores{scores},
-			[]string{sbomFileName},
-			reporter.WithFormat(strings.ToLower("basic")))
-		nr.Report()
-		fmt.Printf("ShareLink: %s\n", url)
-		return nil
+		return engine.ShareRun(ctx, engParams)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/release-utils v0.7.3
-	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -32,4 +31,5 @@ require (
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,0 +1,256 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/interlynk-io/sbomqs/pkg/logger"
+	"github.com/interlynk-io/sbomqs/pkg/reporter"
+	"github.com/interlynk-io/sbomqs/pkg/sbom"
+	"github.com/interlynk-io/sbomqs/pkg/scorer"
+	"github.com/interlynk-io/sbomqs/pkg/share"
+	"github.com/samber/lo"
+	"gopkg.in/yaml.v2"
+)
+
+type Params struct {
+	Path string
+
+	Category string
+	Features []string
+
+	Json     bool
+	Basic    bool
+	Detailed bool
+
+	Spdx bool
+	Cdx  bool
+
+	Recurse bool
+
+	Debug bool
+
+	ConfigPath string
+}
+
+type Record struct {
+	Name     string     `yaml:"name" json:"name"`
+	Enabled  bool       `yaml:"enabled" json:"enabled"`
+	Criteria []criteria `yaml:"criteria" json:"criteria"`
+}
+
+type criteria struct {
+	Name        string `yaml:"shortName" json:"shortName"`
+	Description string `yaml:"description" json:"description"`
+	Enabled     bool   `yaml:"enabled" json:"enabled"`
+}
+
+type Config struct {
+	Record []Record `yaml:"category" json:"category"`
+}
+
+func ShareRun(ctx context.Context, ep *Params) error {
+	log := logger.FromContext(ctx)
+	log.Debug("engine.ShareRun()")
+
+	if ep.Path == "" {
+		log.Fatal("path is required")
+	}
+
+	doc, scores, err := processFile(ctx, ep, nil)
+	if err != nil {
+		return err
+	}
+
+	url, err := share.Share(ctx, doc, scores, ep.Path)
+
+	if err != nil {
+		fmt.Printf("Error sharing file %s: %s", ep.Path, err)
+		return err
+	}
+	nr := reporter.NewReport(ctx,
+		[]sbom.Document{doc},
+		[]scorer.Scores{scores},
+		[]string{ep.Path},
+		reporter.WithFormat(strings.ToLower("basic")))
+	nr.Report()
+	fmt.Printf("ShareLink: %s\n", url)
+
+	return nil
+}
+
+func Run(ctx context.Context, ep *Params) error {
+	log := logger.FromContext(ctx)
+	log.Debug("engine.Run()")
+
+	if ep.Path == "" {
+		log.Fatal("path is required")
+	}
+
+	var criterias []string
+	if ep.Features != nil {
+		for _, f := range ep.Features {
+			if lo.Contains(scorer.CriteriaArgs, f) {
+				criterias = append(criterias, string(scorer.CriteriaArgMap[scorer.CriteriaArg(f)]))
+			}
+		}
+	}
+
+	if ep.ConfigPath != "" {
+		err := processConfigFile(ctx, ep.ConfigPath, criterias)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return handlePath(ctx, ep, criterias)
+}
+
+func handlePath(ctx context.Context, ep *Params, criterias []string) error {
+	log := logger.FromContext(ctx)
+	log.Debugf("processing path: %s\n", ep.Path)
+	var err error
+
+	pInfo, err := os.Stat(ep.Path)
+	if err != nil {
+		return err
+	}
+
+	var docs []sbom.Document
+	var paths []string
+	var scores []scorer.Scores
+
+	if pInfo.IsDir() {
+		files, err := os.ReadDir(ep.Path)
+		if err != nil {
+			log.Debugf("os.ReadDir failed for path:%s\n", ep.Path)
+			log.Debugf("%s\n", err)
+			return err
+		}
+
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			path := filepath.Join(ep.Path, file.Name())
+			doc, scs, err := processFile(ctx, ep, criterias)
+			if err != nil {
+				continue
+			}
+			docs = append(docs, doc)
+			scores = append(scores, scs)
+			paths = append(paths, path)
+		}
+	} else {
+		doc, scs, err := processFile(ctx, ep, criterias)
+		if err != nil {
+			return err
+		}
+		docs = append(docs, doc)
+		scores = append(scores, scs)
+		paths = append(paths, ep.Path)
+	}
+
+	reportFormat := "detailed"
+	if ep.Basic {
+		reportFormat = "basic"
+	} else if ep.Json {
+		reportFormat = "json"
+	}
+
+	nr := reporter.NewReport(ctx,
+		docs,
+		scores,
+		paths,
+		reporter.WithFormat(strings.ToLower(reportFormat)))
+
+	nr.Report()
+
+	return nil
+}
+
+func processFile(ctx context.Context, ep *Params, criterias []string) (sbom.Document, scorer.Scores, error) {
+	log := logger.FromContext(ctx)
+	log.Debugf("Processing file :%s\n", ep.Path)
+
+	if _, err := os.Stat(ep.Path); err != nil {
+		log.Debugf("os.Stat failed for file :%s\n", ep.Path)
+		fmt.Printf("failed to stat %s\n", ep.Path)
+		return nil, nil, err
+	}
+
+	f, err := os.Open(ep.Path)
+	if err != nil {
+		log.Debugf("os.Open failed for file :%s\n", ep.Path)
+		fmt.Printf("failed to open %s\n", ep.Path)
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	doc, err := sbom.NewSBOMDocument(ctx, f)
+	if err != nil {
+		log.Debugf("failed to create sbom document for  :%s\n", ep.Path)
+		log.Debugf("%s\n", err)
+		fmt.Printf("failed to parse %s : %s\n", ep.Path, err)
+		return nil, nil, err
+	}
+
+	sr := scorer.NewScorer(ctx,
+		doc,
+		scorer.WithCategory(ep.Category),
+		scorer.WithFeature(criterias))
+
+	scores := sr.Score()
+	return doc, scores, nil
+}
+
+func processConfigFile(ctx context.Context, filePath string, criterias []string) error {
+	log := logger.FromContext(ctx)
+	cnf := Config{}
+	log.Debugf("Processing file :%s\n", filePath)
+	if _, err := os.Stat(filePath); err != nil {
+		log.Debugf("os.Stat failed for file :%s\n", filePath)
+		fmt.Printf("failed to stat %s\n", filePath)
+		return err
+	}
+	f, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Debugf("os.Open failed for file :%s\n", filePath)
+		fmt.Printf("failed to open %s\n", filePath)
+		return err
+	}
+	err = yaml.Unmarshal(f, &cnf)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range cnf.Record {
+		if r.Enabled {
+			for _, c := range r.Criteria {
+				if c.Enabled {
+					criterias = append(criterias, c.Description)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/scorer/criteria.go
+++ b/pkg/scorer/criteria.go
@@ -79,7 +79,7 @@ const (
 	compWithRestrictedLicenses criterion = "Components have no restricted licenses"
 	docWithCreator             criterion = "Doc has creator tool and version"
 
-	docShareLicense criterion = "Doc sharable license"
+	docShareLicense criterion = "Doc shareable license"
 )
 
 var criteria = map[criterion]func(d sbom.Document) score{}

--- a/pkg/scorer/scorer.go
+++ b/pkg/scorer/scorer.go
@@ -71,19 +71,19 @@ func (s *Scorer) Score() Scores {
 		score := cr(s.doc)
 		if len(s.feature) > 0 {
 			if lo.Contains(s.feature, string(key)) {
-				scoreFilterWithCategory(score, scores)
+				s.scoreFilterWithCategory(score, scores)
 			}
 		} else {
-			scoreFilterWithCategory(score, scores)
+			s.scoreFilterWithCategory(score, scores)
 		}
 	}
 	return scores
 }
 
-func scoreFilterWithCategory(s score, ss *scores) {
-	if s.category != "" && s.category == s.Category() {
-		ss.addScore(s)
+func (s *Scorer) scoreFilterWithCategory(cs score, ss *scores) {
+	if s.category != "" && cs.category == s.category {
+		ss.addScore(cs)
 	} else if s.category == "" {
-		ss.addScore(s)
+		ss.addScore(cs)
 	}
 }


### PR DESCRIPTION
Refactored the sbomqs inputs

Things to note 
- file and directory are now positional arguments
- reportFormat are now just flags consistent with `sbomgr`
- all the old fields still work, but are marked as deprecated. 

```sh 
➜  sbomqs git:(refactor/input) ./build/sbomqs score  -h
comprehensive quality score for your sbom

Usage:
  sbomqs score [flags]

Flags:
  -b, --basic               results in single line format
  -c, --category string     filter by category
      --configpath string   scoring based on config path
  -d, --detailed            results in table format, default
  -f, --feature string      filter by feature
  -h, --help                help for score
  -j, --json                results in json
```