### PR TITLE
Check if version has a digit

### DIFF
--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/interlynk-io/sbomqs/pkg/cpe"
 	"github.com/interlynk-io/sbomqs/pkg/logger"
@@ -224,7 +225,16 @@ func (s *spdxDoc) parseTool() {
 		if !ok {
 			return name, ""
 		}
-		return tool, ver
+
+		//check if version has atleast one-digit
+		//if not, then it is not a version
+		for _, r := range ver {
+			if unicode.IsDigit(r) {
+				return tool, ver
+			}
+		}
+
+		return name, ""
 	}
 
 	for _, c := range s.doc.CreationInfo.Creators {


### PR DESCRIPTION
The spdx spec states the tool name and version is separated by hypen. 

https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#68-creator-field

However github's sbom is generating a tool-name as such 
` "Tool: GitHub.com-Dependency-Graph"`
According to our current logic, this is evaluate as true, as there is a hypen. 

As we can clearly see there is not version number. So i have added an additional check to see if the version string has a numeric in it. This is an assumption that all versions should atleast have one numeric. 