### PR TITLE
Add DT scoring support

### DIFF
--- a/cmd/dtrackScore.go
+++ b/cmd/dtrackScore.go
@@ -73,6 +73,8 @@ func extractArgs(cmd *cobra.Command, args []string) (*engine.DtParams, error) {
 	params.Basic = basic
 	params.Detailed = detailed
 
+	params.TagProjectWithScore, _ = cmd.Flags().GetBool("tag-project-with-score")
+
 	for _, arg := range args {
 		argID, err := uuid.Parse(arg)
 		if err != nil {
@@ -87,12 +89,15 @@ func extractArgs(cmd *cobra.Command, args []string) (*engine.DtParams, error) {
 func init() {
 	rootCmd.AddCommand(dtrackScoreCmd)
 	dtrackScoreCmd.Flags().StringP("url", "u", "", "dependency track url https://localhost:8080/")
-	dtrackScoreCmd.Flags().StringP("api-key", "k", "", "dependency track api key")
+	dtrackScoreCmd.Flags().StringP("api-key", "k", "", "dependency track api key, requires VIEW_PORTFOLIO for scoring and PORTFOLIO_MANAGEMENT for tagging")
 	dtrackScoreCmd.MarkFlagRequired("url")
 	dtrackScoreCmd.MarkFlagRequired("api-key")
+
 	dtrackScoreCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
 
 	dtrackScoreCmd.Flags().BoolP("json", "j", false, "results in json")
 	dtrackScoreCmd.Flags().BoolP("detailed", "d", false, "results in table format, default")
 	dtrackScoreCmd.Flags().BoolP("basic", "b", false, "results in single line format")
+
+	dtrackScoreCmd.Flags().BoolP("tag-project-with-score", "t", false, "tag project with sbomqs score")
 }

--- a/cmd/dtrackScore.go
+++ b/cmd/dtrackScore.go
@@ -1,0 +1,87 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"context"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/interlynk-io/sbomqs/pkg/engine"
+	"github.com/interlynk-io/sbomqs/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+// dtrackScoreCmd represents the dtrackScore command
+var dtrackScoreCmd = &cobra.Command{
+	Use:          "dtrackScore <project-id>",
+	Short:        "generate an sbom quality score for a given project id from dependency track",
+	Long:         `dtrackScore allows your to score the sbom quality of a project from dependency track.`,
+	SilenceUsage: true,
+	Args:         cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		debug, _ := cmd.Flags().GetBool("debug")
+		if debug {
+			logger.InitDebugLogger()
+		} else {
+			logger.InitProdLogger()
+		}
+		ctx := logger.WithLogger(context.Background())
+
+		dtParams, err := extractArgs(cmd, args)
+		if err != nil {
+			log.Fatalf("failed to extract args: %v", err)
+		}
+
+		return engine.DtrackScore(ctx, dtParams)
+	},
+}
+
+func extractArgs(cmd *cobra.Command, args []string) (*engine.DtParams, error) {
+	params := &engine.DtParams{}
+
+	url, err := cmd.Flags().GetString("url")
+	if err != nil {
+		return nil, err
+	}
+
+	apiKey, err := cmd.Flags().GetString("api-key")
+	if err != nil {
+		return nil, err
+	}
+
+	json, _ := cmd.Flags().GetBool("json")
+	basic, _ := cmd.Flags().GetBool("basic")
+	detailed, _ := cmd.Flags().GetBool("detailed")
+
+	params.Url = url
+	params.ApiKey = apiKey
+
+	params.Json = json
+	params.Basic = basic
+	params.Detailed = detailed
+
+	for _, arg := range args {
+		argID, err := uuid.Parse(arg)
+		if err != nil {
+			return nil, err
+		}
+		params.ProjectIds = append(params.ProjectIds, argID)
+	}
+
+	return params, nil
+}
+
+func init() {
+	rootCmd.AddCommand(dtrackScoreCmd)
+	dtrackScoreCmd.Flags().StringP("url", "u", "", "dependency track url https://localhost:8080/")
+	dtrackScoreCmd.Flags().StringP("api-key", "k", "", "dependency track api key")
+	dtrackScoreCmd.MarkFlagRequired("url")
+	dtrackScoreCmd.MarkFlagRequired("api-key")
+	dtrackScoreCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
+
+	dtrackScoreCmd.Flags().BoolP("json", "j", false, "results in json")
+	dtrackScoreCmd.Flags().BoolP("detailed", "d", false, "results in table format, default")
+	dtrackScoreCmd.Flags().BoolP("basic", "b", false, "results in single line format")
+}

--- a/cmd/dtrackScore.go
+++ b/cmd/dtrackScore.go
@@ -1,6 +1,17 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-*/
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,6 +1,16 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-*/
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,16 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-*/
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package cmd
 
 import (

--- a/cmd/score.go
+++ b/cmd/score.go
@@ -1,6 +1,16 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-*/
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package cmd
 
 import (

--- a/cmd/score.go
+++ b/cmd/score.go
@@ -73,8 +73,14 @@ var scoreCmd = &cobra.Command{
 }
 
 func processScore(cmd *cobra.Command, args []string) error {
-	ctx := logger.WithLogger(context.Background())
+	debug, _ := cmd.Flags().GetBool("debug")
+	if debug {
+		logger.InitDebugLogger()
+	} else {
+		logger.InitProdLogger()
+	}
 
+	ctx := logger.WithLogger(context.Background())
 	uCmd := toUserCmd(cmd, args)
 
 	if err := validateFlags(uCmd); err != nil {
@@ -207,7 +213,6 @@ func init() {
 
 	//Debug Control
 	scoreCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
-	scoreCmd.Flags().MarkHidden("debug")
 
 	//Deprecated
 	scoreCmd.Flags().StringVar(&inFile, "filepath", "", "sbom file path")

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1
+	github.com/DependencyTrack/client-go v0.9.0
 	github.com/google/uuid v1.3.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.6.1
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/CycloneDX/cyclonedx-go v0.7.1 h1:5w1SxjGm9MTMNTuRbEPyw21ObdbaagTWF/KfF0qHTRE=
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
+github.com/DependencyTrack/client-go v0.9.0 h1:6Ru+9RbmHonWDPUtHZmSS/PU4FO2lLxzam2XbXkTPb4=
+github.com/DependencyTrack/client-go v0.9.0/go.mod h1:XLZnOksOs56Svq+K4xmBkN8U97gpP7r1BkhCc/xA8Iw=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
@@ -14,6 +16,7 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=

--- a/pkg/engine/dtrack.go
+++ b/pkg/engine/dtrack.go
@@ -1,0 +1,105 @@
+// Copyright 2023 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	dtrack "github.com/DependencyTrack/client-go"
+	"github.com/google/uuid"
+	"github.com/interlynk-io/sbomqs/pkg/logger"
+	"github.com/interlynk-io/sbomqs/pkg/reporter"
+	"github.com/interlynk-io/sbomqs/pkg/sbom"
+	"github.com/interlynk-io/sbomqs/pkg/scorer"
+)
+
+type DtParams struct {
+	Url        string
+	ApiKey     string
+	ProjectIds []uuid.UUID
+
+	Json     bool
+	Basic    bool
+	Detailed bool
+}
+
+func DtrackScore(ctx context.Context, dtP *DtParams) error {
+	log := logger.FromContext(ctx)
+	log.Debug("engine.DtrackScore()")
+
+	log.Debugf("Config: %+v", dtP)
+
+	dTrackClient, err := dtrack.NewClient(dtP.Url,
+		dtrack.WithAPIKey(dtP.ApiKey), dtrack.WithDebug(false))
+
+	if err != nil {
+		log.Fatalf("Failed to create Dependency-Track client: %s", err)
+	}
+
+	for _, pid := range dtP.ProjectIds {
+		log.Debugf("Processing project %s", pid)
+
+		prj, err := dTrackClient.Project.Get(ctx, pid)
+		if err != nil {
+			log.Fatalf("Failed to get project: %s", err)
+		}
+
+		bom, err := dTrackClient.BOM.ExportProject(ctx, pid, dtrack.BOMFormatJSON, dtrack.BOMVariantInventory)
+		if err != nil {
+			log.Fatalf("Failed to export project: %s", err)
+		}
+
+		{
+			fname := fmt.Sprintf("tmpfile-%s", pid)
+			f, err := os.CreateTemp("", fname)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			defer f.Close()
+			defer os.Remove(f.Name())
+
+			f.WriteString(bom)
+
+			ep := &Params{
+				Path: f.Name(),
+			}
+			doc, scores, err := processFile(ctx, ep, "")
+			if err != nil {
+				return err
+			}
+
+			path := fmt.Sprintf("ID: %s, Name: %s, Version: %s", prj.UUID, prj.Name, prj.Version)
+
+			reportFormat := "detailed"
+			if dtP.Basic {
+				reportFormat = "basic"
+			} else if dtP.Json {
+				reportFormat = "json"
+			}
+
+			nr := reporter.NewReport(ctx,
+				[]sbom.Document{doc},
+				[]scorer.Scores{scores},
+				[]string{path},
+				reporter.WithFormat(reportFormat))
+			nr.Report()
+		}
+	}
+
+	return nil
+}

--- a/pkg/logger/log.go
+++ b/pkg/logger/log.go
@@ -24,16 +24,31 @@ var logger *zap.SugaredLogger
 
 type logKey struct{}
 
-func init() {
+func InitProdLogger() {
 	l, _ := zap.NewProduction()
 	//l, _ := zap.NewDevelopment()
 	defer l.Sync()
+	if logger != nil {
+		panic("logger already initialized")
+	}
+	logger = l.Sugar()
+}
 
+func InitDebugLogger() {
+	l, _ := zap.NewDevelopment()
+	defer l.Sync()
+	if logger != nil {
+		panic("logger already initialized")
+	}
 	logger = l.Sugar()
 }
 
 func WithLogger(ctx context.Context) context.Context {
 	return context.WithValue(ctx, logKey{}, logger)
+}
+
+func WithLoggerAndCancel(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.WithValue(ctx, logKey{}, logger))
 }
 
 func FromContext(ctx context.Context) *zap.SugaredLogger {


### PR DESCRIPTION
Add support to score DT projects. Currently requires project ids to be entered by UUID. 

```sh
./build/sbomqs dtrackScore  -u "http://localhost:8080/" -k "IIcfPA9qc1F4IkQFa2FqQXPPJoTwcfQI" bbd4434d-8062-4e59-a323-3b416701c948 3449577c-bd7f-468b-8ca9-eb4dd46a66e0 989c8243-c834-4f5e-9657-0e3abc8036ae -b
8.5     ID: bbd4434d-8062-4e59-a323-3b416701c948, Name: DT, Version: 4.7.0
6.3     ID: 3449577c-bd7f-468b-8ca9-eb4dd46a66e0, Name: sbomqs, Version: v0.0.15
6.3     ID: 989c8243-c834-4f5e-9657-0e3abc8036ae, Name: sbomgr, Version: v0.0.4
```