### PR TITLE
Better commandline handling

### DIFF
--- a/cmd/score.go
+++ b/cmd/score.go
@@ -38,7 +38,7 @@ var (
 
 type userCmd struct {
 	//input control
-	path string
+	path []string
 
 	//filter control
 	category string
@@ -74,8 +74,6 @@ var scoreCmd = &cobra.Command{
 				return fmt.Errorf("provide a path to an sbom file or directory of sbom files")
 			}
 
-		} else if len(args) > 1 {
-			return fmt.Errorf("too many arguments")
 		}
 		return nil
 	},
@@ -106,14 +104,14 @@ func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 	//input control
 	if len(args) <= 0 {
 		if len(inFile) > 0 {
-			uCmd.path = inFile
+			uCmd.path = append(uCmd.path, inFile)
 		}
 
 		if len(inDirPath) > 0 {
-			uCmd.path = inDirPath
+			uCmd.path = append(uCmd.path, inDirPath)
 		}
 	} else {
-		uCmd.path = args[0]
+		uCmd.path = append(uCmd.path, args[0:]...)
 	}
 
 	//config control
@@ -179,8 +177,11 @@ func validatePath(path string) error {
 	return nil
 }
 func validateFlags(cmd *userCmd) error {
-	if err := validatePath(cmd.path); err != nil {
-		return fmt.Errorf("invalid path: %w", err)
+
+	for _, path := range cmd.path {
+		if err := validatePath(path); err != nil {
+			return fmt.Errorf("invalid path: %w", err)
+		}
 	}
 
 	if cmd.configPath != "" {

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -43,18 +43,26 @@ For more information, please visit https://sbombenchmark.dev
 	},
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		debug, _ := cmd.Flags().GetBool("debug")
+		if debug {
+			logger.InitDebugLogger()
+		} else {
+			logger.InitProdLogger()
+		}
+
 		ctx := logger.WithLogger(context.Background())
 		sbomFileName := args[0]
 
-		engParams := &engine.Params{
-			Path:  sbomFileName,
-			Basic: true,
-			Debug: false,
-		}
+		engParams := &engine.Params{Basic: true}
+		engParams.Path = append(engParams.Path, sbomFileName)
 		return engine.ShareRun(ctx, engParams)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(shareCmd)
+
+	//Debug Control
+	shareCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
+
 }

--- a/pkg/engine/dtrack.go
+++ b/pkg/engine/dtrack.go
@@ -79,9 +79,8 @@ func DtrackScore(ctx context.Context, dtP *DtParams) error {
 
 			f.WriteString(bom)
 
-			ep := &Params{
-				Path: f.Name(),
-			}
+			ep := &Params{}
+			ep.Path = append(ep.Path, f.Name())
 			doc, scores, err := processFile(ctx, ep, "")
 			if err != nil {
 				return err

--- a/pkg/engine/share.go
+++ b/pkg/engine/share.go
@@ -30,16 +30,16 @@ func ShareRun(ctx context.Context, ep *Params) error {
 	log := logger.FromContext(ctx)
 	log.Debug("engine.ShareRun()")
 
-	if ep.Path == "" {
+	if len(ep.Path) <= 0 {
 		log.Fatal("path is required")
 	}
 
-	doc, scores, err := processFile(ctx, ep, "")
+	doc, scores, err := processFile(ctx, ep, ep.Path[0])
 	if err != nil {
 		return err
 	}
 
-	url, err := share.Share(ctx, doc, scores, ep.Path)
+	url, err := share.Share(ctx, doc, scores, ep.Path[0])
 
 	if err != nil {
 		fmt.Printf("Error sharing file %s: %s", ep.Path, err)
@@ -48,7 +48,7 @@ func ShareRun(ctx context.Context, ep *Params) error {
 	nr := reporter.NewReport(ctx,
 		[]sbom.Document{doc},
 		[]scorer.Scores{scores},
-		[]string{ep.Path},
+		[]string{ep.Path[0]},
 		reporter.WithFormat(strings.ToLower("basic")))
 	nr.Report()
 	fmt.Printf("ShareLink: %s\n", url)

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -305,6 +305,10 @@ func (c *cdxDoc) licenses(comp *cydx.Component) []License {
 		}
 	}
 
+	if comp.Evidence != nil {
+
+	}
+
 	removeDups := func(lics []License) []License {
 		uniqs := []License{}
 		dedup := map[string]bool{}


### PR DESCRIPTION
Add better support to handling command line arguments. 

The following wildcards are now supported. 
```
sbomqs score ~/wrk/sbom*/samples/*.json  -b
```

also 
```
sbomqs score ~/wrk/sboms/sbom*.json -b 
```
