### PR TITLE
[BUG][FIXED] <h>Bug when tried to build project</h> `pkg/sbom/cdx.go:…

### DIFF
--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -305,9 +305,10 @@ func (c *cdxDoc) licenses(comp *cydx.Component) []License {
 		}
 	}
 
-	if comp.Evidence != nil {
+	// Remove the empty if statement
+	// if comp.Evidence != nil {
 
-	}
+	// }
 
 	removeDups := func(lics []License) []License {
 		uniqs := []License{}
@@ -336,7 +337,7 @@ func (c *cdxDoc) parseTool() {
 		return
 	}
 
-	for _, tt := range lo.FromPtr(c.doc.Metadata.Tools) {
+	for _, tt := range lo.FromPtr(c.doc.Metadata.Tools.Tools) {
 		t := tool{}
 		t.name = tt.Name
 		t.version = tt.Version


### PR DESCRIPTION
…339:21: cannot range over lo.FromPtr(c.doc.Metadata.Tools) (value of type cyclonedx.ToolsChoice)`
![image](https://github.com/interlynk-io/sbomqs/assets/66005831/09a4b2ba-d15a-4a88-bdaf-b96b5833bf61)
