### PR TITLE
Add primary component detection scorer

### DIFF
--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -32,15 +32,16 @@ var cdx_file_formats = []string{"json", "xml"}
 var cdx_primary_purpose = []string{"application", "framework", "library", "container", "operating-system", "device", "firmware", "file"}
 
 type cdxDoc struct {
-	doc     *cydx.BOM
-	format  FileFormat
-	ctx     context.Context
-	spec    *spec
-	comps   []Component
-	authors []Author
-	tools   []Tool
-	rels    []Relation
-	logs    []string
+	doc              *cydx.BOM
+	format           FileFormat
+	ctx              context.Context
+	spec             *spec
+	comps            []Component
+	authors          []Author
+	tools            []Tool
+	rels             []Relation
+	logs             []string
+	primaryComponent bool
 }
 
 func newCDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat) (Document, error) {
@@ -100,12 +101,17 @@ func (c cdxDoc) Logs() []string {
 	return c.logs
 }
 
+func (c cdxDoc) PrimaryComponent() bool {
+	return c.primaryComponent
+}
+
 func (c *cdxDoc) parse() {
 	c.parseSpec()
 	c.parseComps()
 	c.parseAuthors()
 	c.parseTool()
 	c.parseRels()
+	c.parsePrimaryComponent()
 }
 
 func (c *cdxDoc) addToLogs(log string) {
@@ -392,4 +398,16 @@ func (c *cdxDoc) addSupplierName(comp *cydx.Component) string {
 		return ""
 	}
 	return name
+}
+
+func (c *cdxDoc) parsePrimaryComponent() {
+	if c.doc.Metadata == nil {
+		return
+	}
+
+	if c.doc.Metadata.Component == nil {
+		return
+	}
+
+	c.primaryComponent = true
 }

--- a/pkg/sbom/component.go
+++ b/pkg/sbom/component.go
@@ -15,8 +15,10 @@
 package sbom
 
 //counterfeiter:generate . Component
-import "github.com/interlynk-io/sbomqs/pkg/cpe"
-import "github.com/interlynk-io/sbomqs/pkg/purl"
+import (
+	"github.com/interlynk-io/sbomqs/pkg/cpe"
+	"github.com/interlynk-io/sbomqs/pkg/purl"
+)
 
 type Component interface {
 	ID() string

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -24,4 +24,6 @@ type Document interface {
 	Authors() []Author
 	Tools() []Tool
 	Logs() []string
+
+	PrimaryComponent() bool
 }

--- a/pkg/sbom/sbomfakes/fake_document.go
+++ b/pkg/sbom/sbomfakes/fake_document.go
@@ -38,6 +38,16 @@ type FakeDocument struct {
 	logsReturnsOnCall map[int]struct {
 		result1 []string
 	}
+	PrimaryComponentStub        func() bool
+	primaryComponentMutex       sync.RWMutex
+	primaryComponentArgsForCall []struct {
+	}
+	primaryComponentReturns struct {
+		result1 bool
+	}
+	primaryComponentReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	RelationsStub        func() []sbom.Relation
 	relationsMutex       sync.RWMutex
 	relationsArgsForCall []struct {
@@ -231,6 +241,59 @@ func (fake *FakeDocument) LogsReturnsOnCall(i int, result1 []string) {
 	}{result1}
 }
 
+func (fake *FakeDocument) PrimaryComponent() bool {
+	fake.primaryComponentMutex.Lock()
+	ret, specificReturn := fake.primaryComponentReturnsOnCall[len(fake.primaryComponentArgsForCall)]
+	fake.primaryComponentArgsForCall = append(fake.primaryComponentArgsForCall, struct {
+	}{})
+	stub := fake.PrimaryComponentStub
+	fakeReturns := fake.primaryComponentReturns
+	fake.recordInvocation("PrimaryComponent", []interface{}{})
+	fake.primaryComponentMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeDocument) PrimaryComponentCallCount() int {
+	fake.primaryComponentMutex.RLock()
+	defer fake.primaryComponentMutex.RUnlock()
+	return len(fake.primaryComponentArgsForCall)
+}
+
+func (fake *FakeDocument) PrimaryComponentCalls(stub func() bool) {
+	fake.primaryComponentMutex.Lock()
+	defer fake.primaryComponentMutex.Unlock()
+	fake.PrimaryComponentStub = stub
+}
+
+func (fake *FakeDocument) PrimaryComponentReturns(result1 bool) {
+	fake.primaryComponentMutex.Lock()
+	defer fake.primaryComponentMutex.Unlock()
+	fake.PrimaryComponentStub = nil
+	fake.primaryComponentReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeDocument) PrimaryComponentReturnsOnCall(i int, result1 bool) {
+	fake.primaryComponentMutex.Lock()
+	defer fake.primaryComponentMutex.Unlock()
+	fake.PrimaryComponentStub = nil
+	if fake.primaryComponentReturnsOnCall == nil {
+		fake.primaryComponentReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.primaryComponentReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeDocument) Relations() []sbom.Relation {
 	fake.relationsMutex.Lock()
 	ret, specificReturn := fake.relationsReturnsOnCall[len(fake.relationsArgsForCall)]
@@ -399,6 +462,8 @@ func (fake *FakeDocument) Invocations() map[string][][]interface{} {
 	defer fake.componentsMutex.RUnlock()
 	fake.logsMutex.RLock()
 	defer fake.logsMutex.RUnlock()
+	fake.primaryComponentMutex.RLock()
+	defer fake.primaryComponentMutex.RUnlock()
 	fake.relationsMutex.RLock()
 	defer fake.relationsMutex.RUnlock()
 	fake.specMutex.RLock()

--- a/pkg/scorer/criteria.go
+++ b/pkg/scorer/criteria.go
@@ -65,6 +65,7 @@ var checks = []check{
 	{string(quality), "comp_with_any_vuln_lookup_id", false, "components with any vulnerability lookup id", compWithAnyLookupIdCheck},
 	{string(quality), "comp_with_multi_vuln_lookup_id", false, "components with multiple vulnerability lookup id", compWithMultipleIdCheck},
 	{string(quality), "sbom_with_creator_and_version", false, "sbom has creator and version", docWithCreatorCheck},
+	{string(quality), "sbom_with_primary_component", false, "sbom has primary component", docWithPrimaryComponentCheck},
 
 	//sharing
 	{string(sharing), "sbom_sharable", false, "sbom document has a sharable license", sharableLicenseCheck},

--- a/pkg/scorer/quality.go
+++ b/pkg/scorer/quality.go
@@ -219,3 +219,18 @@ func docWithCreatorCheck(d sbom.Document, c *check) score {
 	s.setDesc(fmt.Sprintf("%d/%d tools have creator and version", withCreatorAndVersion, totalTools))
 	return *s
 }
+
+func docWithPrimaryComponentCheck(d sbom.Document, c *check) score {
+	s := newScoreFromCheck(c)
+
+	if d.PrimaryComponent() {
+		s.setScore(10.0)
+		s.setDesc("primary component found")
+		return *s
+	} else {
+		s.setScore(0.0)
+		s.setDesc("no primary component found")
+		return *s
+	}
+	return *s
+}

--- a/pkg/scorer/scorer.go
+++ b/pkg/scorer/scorer.go
@@ -21,7 +21,7 @@ import (
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 )
 
-const EngineVersion = "5"
+const EngineVersion = "6"
 
 type FilterType int
 


### PR DESCRIPTION
@surendrapathak  Added primary component detection to our scoring framework. I have added it as a quality metric.  For SPDX we are checking if the relationships contains a describes for a package identifier. For Cyclonedx we are checking if the metadata describes a primary component. 

CDX example 
```
SBOM Quality Score:10.0	components:4	/Users/riteshnoronha/wrk/interlynk-io/lynk-api/scripts/samples/misc/ascii-boxes-sbom-cdx.json
+----------+-----------------------------+-----------+-------------------------+
| CATEGORY |           FEATURE           |   SCORE   |          DESC           |
+----------+-----------------------------+-----------+-------------------------+
| Quality  | sbom_with_primary_component | 10.0/10.0 | primary component found |
+----------+-----------------------------+-----------+-------------------------+
SBOM Quality Score:0.0	components:105	/Users/riteshnoronha/wrk/interlynk-io/lynk-api/scripts/samples/misc/ghidra-sbom-cdx.json
+----------+-----------------------------+----------+----------------------------+
| CATEGORY |           FEATURE           |  SCORE   |            DESC            |
+----------+-----------------------------+----------+----------------------------+
| Quality  | sbom_with_primary_component | 0.0/10.0 | no primary component found |
+----------+-----------------------------+----------+----------------------------+
```

SPDX Example 

```
SBOM Quality Score:0.0	components:1303	/Users/riteshnoronha/wrk/interlynk-io/lynk-api/scripts/samples/spdx/constellation-spdx.json
+----------+-----------------------------+----------+----------------------------+
| CATEGORY |           FEATURE           |  SCORE   |            DESC            |
+----------+-----------------------------+----------+----------------------------+
| Quality  | sbom_with_primary_component | 0.0/10.0 | no primary component found |
+----------+-----------------------------+----------+----------------------------+
SBOM Quality Score:10.0	components:34	/Users/riteshnoronha/wrk/interlynk-io/lynk-api/scripts/samples/spdx/julia.spdx.json
+----------+-----------------------------+-----------+-------------------------+
| CATEGORY |           FEATURE           |   SCORE   |          DESC           |
+----------+-----------------------------+-----------+-------------------------+
| Quality  | sbom_with_primary_component | 10.0/10.0 | primary component found |
+----------+-----------------------------+-----------+-------------------------+
```