### PR TITLE
Fixed off by one error 

### DIFF
--- a/pkg/scorer/ntia.go
+++ b/pkg/scorer/ntia.go
@@ -105,13 +105,13 @@ func compWithUniqIDCheck(d sbom.Document, c *check) score {
 		return strings.Join([]string{d.Spec().Namespace(), c.ID()}, ""), true
 	})
 
-	uniqComps := lo.Uniq(compIDs)
+	//uniqComps := lo.Uniq(compIDs)
 
 	if totalComponents > 0 {
 
-		s.setScore((float64(len(uniqComps)) / float64(totalComponents)) * 10.0)
+		s.setScore((float64(len(compIDs)) / float64(totalComponents)) * 10.0)
 	}
-	s.setDesc(fmt.Sprintf("%d/%d have unique ID's", len(uniqComps), totalComponents))
+	s.setDesc(fmt.Sprintf("%d/%d have unique ID's", len(compID), totalComponents))
 	return *s
 }
 


### PR DESCRIPTION
Fixed off by one error where when all ID elements are removed there was a 1/n ratio given by SBOMqs instead of the expected 0/n ratio. Where n is the total number of packages.

In the new code, the scores are still accurate, showing the ID feature's correct ratio. 
When 0 elements are removed SBOMqs returned this ratio:

{
          "category": "NTIA-minimum-elements",
          "feature": "comp_with_uniq_ids",
          "score": 9.375,
          "max_score": 10,
          "description": "15/16 have unique ID's",
          "ignored": false
        },

this ratio was verified by hand to be correct.

When 4 elements are removed,

"category": "NTIA-minimum-elements",
          "feature": "comp_with_uniq_ids",
          "score": 6.875,
          "max_score": 10,
          "description": "11/16 have unique ID's",
          "ignored": false

The ratio is reduced by 4.

When all ID values are removed with the new change :

  {
          "category": "NTIA-minimum-elements",
          "feature": "comp_with_uniq_ids",
          "score": 0,
          "max_score": 10,
          "description": "0/16 have unique ID's",
          "ignored": false
        },

Again this was confirmed by hand.

In prechange code sometimes this ratio would be left as a 1/n. Now the ratio is reflective of the reality of the SBOM. 

This was tested on 1000 SBOMs in CDX and SPDX generated by Trivy and Syft and scores are accurate and change with what is removed accurately in the ID field. 