### PR TITLE
Add tabular and basic reports

### DIFF
--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -53,10 +53,9 @@ var complianceCmd = &cobra.Command{
 func setupEngineParams(cmd *cobra.Command, args []string) *engine.Params {
 	engParams := &engine.Params{}
 
-	// engParams.Basic, _ = cmd.Flags().GetBool("basic")
-	// engParams.Detailed, _ = cmd.Flags().GetBool("detailed")
+	engParams.Basic, _ = cmd.Flags().GetBool("basic")
+	engParams.Detailed, _ = cmd.Flags().GetBool("detailed")
 	engParams.Json, _ = cmd.Flags().GetBool("json")
-	//engParams.Pdf, _ = cmd.Flags().GetBool("pdf")
 
 	// engParams.Ntia, _ = cmd.Flags().GetBool("ntia")
 	engParams.Cra, _ = cmd.Flags().GetBool("cra")
@@ -76,10 +75,10 @@ func init() {
 
 	//Output control
 	complianceCmd.Flags().BoolP("json", "j", false, "output in json format")
-	// complianceCmd.Flags().BoolP("basic", "b", false, "output in basic format")
-	// complianceCmd.Flags().BoolP("detailed", "d", false, "output in detailed format")
+	complianceCmd.Flags().BoolP("basic", "b", false, "output in basic format")
+	complianceCmd.Flags().BoolP("detailed", "d", false, "output in detailed format")
 	//complianceCmd.Flags().BoolP("pdf", "p", false, "output in pdf format")
-	// complianceCmd.MarkFlagsMutuallyExclusive("json", "basic", "detailed")
+	complianceCmd.MarkFlagsMutuallyExclusive("json", "basic", "detailed")
 
 	//Standards control
 	// complianceCmd.Flags().BoolP("ntia", "n", false, "check for NTIA minimum elements compliance")

--- a/pkg/compliance/cra.go
+++ b/pkg/compliance/cra.go
@@ -47,7 +47,7 @@ const (
 	COMP_DEPTH
 )
 
-func craResult(ctx context.Context, doc sbom.Document, fileName string, outFormat string) *db {
+func craResult(ctx context.Context, doc sbom.Document, fileName string, outFormat string) {
 	log := logger.FromContext(ctx)
 	log.Debug("compliance.craResult()")
 
@@ -62,8 +62,17 @@ func craResult(ctx context.Context, doc sbom.Document, fileName string, outForma
 	db.addRecord(craSbomURI(doc))
 	db.addRecords(craComponents(doc))
 
-	cra_json_report(db, fileName)
-	return db
+	if outFormat == "json" {
+		craJsonReport(db, fileName)
+	}
+
+	if outFormat == "basic" {
+		craBasicReport(db, fileName)
+	}
+
+	if outFormat == "detailed" {
+		craDetailedReport(db, fileName)
+	}
 }
 
 func craSpec(doc sbom.Document) *record {

--- a/pkg/engine/compliance.go
+++ b/pkg/engine/compliance.go
@@ -48,12 +48,12 @@ func ComplianceRun(ctx context.Context, ep *Params) error {
 		reportType = "CRA"
 	}
 
-	outFormat := "json"
+	outFormat := "detailed"
 
 	if ep.Basic {
 		outFormat = "basic"
-	} else if ep.Pdf {
-		outFormat = "pdf"
+	} else if ep.Json {
+		outFormat = "json"
 	}
 
 	err := compliance.ComplianceResult(ctx, *doc, reportType, ep.Path[0], outFormat)

--- a/pkg/reporter/detailed.go
+++ b/pkg/reporter/detailed.go
@@ -51,7 +51,7 @@ func (r *Reporter) detailedReport() {
 			return outDoc[i][1] < outDoc[j][1]
 		})
 
-		fmt.Printf("SBOM Quality Score:%0.1f\tcomponents:%d\t%s\n", scores.AvgScore(), len(doc.Components()), path)
+		fmt.Printf("SBOM Quality by Interlynk Score:%0.1f\tcomponents:%d\t%s\n", scores.AvgScore(), len(doc.Components()), path)
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader([]string{"Category", "Feature", "Score", "Desc"})
 		table.SetRowLine(true)

--- a/pkg/reporter/json.go
+++ b/pkg/reporter/json.go
@@ -49,6 +49,7 @@ type creation struct {
 	Name          string `json:"name"`
 	Version       string `json:"version"`
 	ScoringEngine string `json:"scoring_engine_version"`
+	Vendor        string `json:"vendor"`
 }
 
 type jsonReport struct {
@@ -66,6 +67,7 @@ func newJsonReport() *jsonReport {
 			Name:          "sbomqs",
 			Version:       version.GetVersionInfo().GitVersion,
 			ScoringEngine: scorer.EngineVersion,
+			Vendor:        "Interlynk (support@interlynk.io)",
 		},
 		Files: []file{},
 	}

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -191,7 +191,11 @@ func (s *spdxDoc) parseComps() {
 		nc.sourceCodeHash = sc.PackageVerificationCode.Value
 
 		//nc.sourceCodeUrl //no conlusive way to get this from SPDX
-		nc.downloadLocation = sc.PackageDownloadLocation
+		if strings.ToLower(sc.PackageDownloadLocation) == "noassertion" || strings.ToLower(sc.PackageDownloadLocation) == "none" {
+			nc.downloadLocation = ""
+		} else {
+			nc.downloadLocation = sc.PackageDownloadLocation
+		}
 
 		nc.isPrimary = s.primaryComponentId == string(sc.PackageSPDXIdentifier)
 

--- a/pkg/scorer/scorer.go
+++ b/pkg/scorer/scorer.go
@@ -21,7 +21,7 @@ import (
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 )
 
-const EngineVersion = "6"
+const EngineVersion = "7"
 
 type FilterType int
 


### PR DESCRIPTION
- Adds tabular view for compliance reports 
- Adds basic view for compliance reports
- Increments the scoring_engine_version, due to the way license lookup has changed. 
- Add support@interlynk.io as vendor, in case anyone has issues. 