### PR TITLE
Add bash and grep to be compatible with gitlab ci/cd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,7 @@ LABEL org.opencontainers.image.source="https://github.com/interlynk-io/sbomqs"
 LABEL org.opencontainers.image.description="Quality metrics for your sboms"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-# Copy the certs from the builder image
-COPY --from=builder /bin/bash /bin/bash
-COPY --from=builder /bin/grep /bin/grep
-COPY --from=builder /lib /lib
-COPY --from=builder /usr /usr
-
+COPY --from=builder /bin/sh /bin/grep /bin/busybox /bin/touch /bin/chmod /bin/mkdir /bin/date /bin/
 
 # Copy our static executable
 COPY --from=builder /app/build/sbomqs /app/sbomqs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22.2-alpine AS builder
 LABEL org.opencontainers.image.source="https://github.com/interlynk-io/sbomqs"
 
-RUN apk add --no-cache make git
+RUN apk add --no-cache make git bash grep
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
@@ -14,8 +14,17 @@ LABEL org.opencontainers.image.source="https://github.com/interlynk-io/sbomqs"
 LABEL org.opencontainers.image.description="Quality metrics for your sboms"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
+# Copy the certs from the builder image
+COPY --from=builder /bin/bash /bin/bash
+COPY --from=builder /bin/grep /bin/grep
+COPY --from=builder /lib /lib
+COPY --from=builder /usr /usr
 
+
+# Copy our static executable
 COPY --from=builder /app/build/sbomqs /app/sbomqs
+
+# Disable version check
 ENV INTERLYNK_DISABLE_VERSION_CHECK=true
 
 ENTRYPOINT [ "/app/sbomqs" ]


### PR DESCRIPTION
Adds `bash` and `grep` so the sbomqs container can be run in gitlab. 

addresses #238 