### PR TITLE
refractor toUserCmd function

### DIFF
--- a/cmd/options/score.go
+++ b/cmd/options/score.go
@@ -1,0 +1,37 @@
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type ScoreOptions struct {
+	// filter control
+	Category string
+	Features []string
+
+	// output control
+	Json     bool
+	Basic    bool
+	Detailed bool
+
+	// directory control
+	Recurse bool
+
+	// debug control
+	Debug bool
+
+	// config control
+	ConfigPath string
+}
+
+// AddFlags implements Interface
+func (o *ScoreOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringArrayVarP(&o.Features, "features", "f", nil, "filter by category")
+	cmd.Flags().StringVarP(&o.Category, "category", "c", "", "filter by category")
+	cmd.Flags().StringVar(&o.ConfigPath, "configPath", "", "scoring based on config path")
+	cmd.Flags().BoolVarP(&o.Json, "json", "j", false, "results in json")
+	cmd.Flags().BoolVarP(&o.Basic, "basic", "b", false, "results in single line format")
+	cmd.Flags().BoolVarP(&o.Detailed, "detailed", "d", true, "results in table format, default")
+	cmd.Flags().BoolVarP(&o.Debug, "debug", "D", false, "enable debug logging")
+	cmd.Flags().BoolVarP(&o.Recurse, "recurse", "r", false, "recurse into subdirectories")
+}

--- a/cmd/score.go
+++ b/cmd/score.go
@@ -16,210 +16,65 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
+	"github.com/interlynk-io/sbomqs/cmd/options"
 	"github.com/interlynk-io/sbomqs/pkg/engine"
 	"github.com/interlynk-io/sbomqs/pkg/logger"
-	"github.com/interlynk-io/sbomqs/pkg/reporter"
-	"github.com/samber/lo"
 
 	"github.com/spf13/cobra"
 )
 
-var (
-	inFile       string
-	inDirPath    string
-	category     string
-	feature      string
-	reportFormat string
-	configPath   string
-)
+func Score() *cobra.Command {
+	o := &options.ScoreOptions{}
 
-type userCmd struct {
-	//input control
-	path []string
+	cmd := &cobra.Command{
+		Use:          "score",
+		Short:        "comprehensive quality score for your sbom",
+		SilenceUsage: true,
+		Args:         cobra.MinimumNArgs(1),
 
-	//filter control
-	category string
-	features []string
-
-	//output control
-	json     bool
-	basic    bool
-	detailed bool
-
-	//directory control
-	recurse bool
-
-	//debug control
-	debug bool
-
-	//config control
-	configPath string
-}
-
-// scoreCmd represents the score command
-var scoreCmd = &cobra.Command{
-	Use:          "score",
-	Short:        "comprehensive quality score for your sbom",
-	SilenceUsage: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) <= 0 {
-			if len(inFile) <= 0 && len(inDirPath) <= 0 {
-				return fmt.Errorf("provide a path to an sbom file or directory of sbom files")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := processScore(*o, args)
+			if err != nil {
+				fmt.Println("err:", err)
 			}
 
-		}
-		return nil
-	},
-	RunE: processScore,
+			return nil
+		},
+	}
+	o.AddFlags(cmd)
+	return cmd
 }
 
-func processScore(cmd *cobra.Command, args []string) error {
-	debug, _ := cmd.Flags().GetBool("debug")
-	if debug {
+func processScore(scoreOption options.ScoreOptions, args []string) error {
+	debug := &scoreOption.Debug
+	if *debug {
 		logger.InitDebugLogger()
 	} else {
 		logger.InitProdLogger()
 	}
 
 	ctx := logger.WithLogger(context.Background())
-	uCmd := toUserCmd(cmd, args)
 
-	if err := validateFlags(uCmd); err != nil {
-		return err
-	}
+	engParams := toEngineParams(scoreOption, args)
 
-	engParams := toEngineParams(uCmd)
 	return engine.Run(ctx, engParams)
 }
-func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
-	uCmd := &userCmd{}
 
-	//input control
-	if len(args) <= 0 {
-		if len(inFile) > 0 {
-			uCmd.path = append(uCmd.path, inFile)
-		}
-
-		if len(inDirPath) > 0 {
-			uCmd.path = append(uCmd.path, inDirPath)
-		}
-	} else {
-		uCmd.path = append(uCmd.path, args[0:]...)
-	}
-
-	//config control
-	if configPath == "" {
-		uCmd.configPath, _ = cmd.Flags().GetString("configpath")
-	} else {
-		uCmd.configPath = configPath
-	}
-	//filter control
-	if category == "" {
-		uCmd.category, _ = cmd.Flags().GetString("category")
-	} else {
-		uCmd.category = category
-	}
-
-	if feature == "" {
-		f, _ := cmd.Flags().GetString("feature")
-		uCmd.features = strings.Split(f, ",")
-	}
-
-	//output control
-	uCmd.json, _ = cmd.Flags().GetBool("json")
-	uCmd.basic, _ = cmd.Flags().GetBool("basic")
-	uCmd.detailed, _ = cmd.Flags().GetBool("detailed")
-
-	if reportFormat != "" {
-		uCmd.json = strings.ToLower(reportFormat) == "json"
-		uCmd.basic = strings.ToLower(reportFormat) == "basic"
-		uCmd.detailed = strings.ToLower(reportFormat) == "detailed"
-	}
-
-	//debug control
-	uCmd.debug, _ = cmd.Flags().GetBool("debug")
-
-	return uCmd
-}
-
-func toEngineParams(uCmd *userCmd) *engine.Params {
+func toEngineParams(scoreOption options.ScoreOptions, args []string) *engine.Params {
 	return &engine.Params{
-		Path:       uCmd.path,
-		Category:   uCmd.category,
-		Features:   uCmd.features,
-		Json:       uCmd.json,
-		Basic:      uCmd.basic,
-		Detailed:   uCmd.detailed,
-		Recurse:    uCmd.recurse,
-		Debug:      uCmd.debug,
-		ConfigPath: uCmd.configPath,
+		Path:       args[0:],
+		Category:   scoreOption.Category,
+		Features:   scoreOption.Features,
+		Json:       scoreOption.Json,
+		Basic:      scoreOption.Basic,
+		Detailed:   scoreOption.Detailed,
+		Recurse:    scoreOption.Recurse,
+		Debug:      scoreOption.Debug,
+		ConfigPath: scoreOption.ConfigPath,
 	}
 }
 
-func validatePath(path string) error {
-	if _, err := os.Stat(path); err != nil {
-		return err
-	}
-	return nil
-}
-func validateFlags(cmd *userCmd) error {
-
-	for _, path := range cmd.path {
-		if err := validatePath(path); err != nil {
-			return fmt.Errorf("invalid path: %w", err)
-		}
-	}
-
-	if cmd.configPath != "" {
-		if err := validatePath(cmd.configPath); err != nil {
-			return fmt.Errorf("invalid config path: %w", err)
-		}
-	}
-
-	if len(reportFormat) > 0 && !lo.Contains(reporter.ReportFormats, reportFormat) {
-		return fmt.Errorf("invalid report format: %s", reportFormat)
-	}
-
-	return nil
-}
 func init() {
-	rootCmd.AddCommand(scoreCmd)
-
-	//Config Control
-	scoreCmd.Flags().StringP("configpath", "", "", "scoring based on config path")
-
-	//Filter Control
-	scoreCmd.Flags().StringP("category", "c", "", "filter by category")
-	scoreCmd.Flags().StringP("feature", "f", "", "filter by feature")
-
-	//Spec Control
-	scoreCmd.Flags().BoolP("spdx", "", false, "limit scoring to spdx sboms")
-	scoreCmd.Flags().BoolP("cdx", "", false, "limit scoring to cdx sboms")
-	scoreCmd.MarkFlagsMutuallyExclusive("spdx", "cdx")
-	scoreCmd.Flags().MarkHidden("spdx")
-	scoreCmd.Flags().MarkHidden("cdx")
-
-	//Directory Control
-	scoreCmd.Flags().BoolP("recurse", "r", false, "recurse into subdirectories")
-	scoreCmd.Flags().MarkHidden("recurse")
-
-	//Output Control
-	scoreCmd.Flags().BoolP("json", "j", false, "results in json")
-	scoreCmd.Flags().BoolP("detailed", "d", false, "results in table format, default")
-	scoreCmd.Flags().BoolP("basic", "b", false, "results in single line format")
-
-	//Debug Control
-	scoreCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
-
-	//Deprecated
-	scoreCmd.Flags().StringVar(&inFile, "filepath", "", "sbom file path")
-	scoreCmd.Flags().StringVar(&inDirPath, "dirpath", "", "sbom dir path")
-	scoreCmd.MarkFlagsMutuallyExclusive("filepath", "dirpath")
-	scoreCmd.Flags().StringVar(&reportFormat, "reportFormat", "", "reporting format basic/detailed/json")
-	scoreCmd.Flags().MarkDeprecated("reportFormat", "use --json, --detailed, or --basic instead")
-	scoreCmd.Flags().MarkDeprecated("filepath", "use positional argument instead")
-	scoreCmd.Flags().MarkDeprecated("dirpath", "use positional argument instead")
+	rootCmd.AddCommand(Score())
 }

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -73,7 +73,12 @@ func handlePaths(ctx context.Context, ep *Params) error {
 
 	for _, path := range ep.Path {
 		log.Debugf("Processing path :%s\n", path)
-		pathInfo, _ := os.Stat(path)
+
+		pathInfo, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("invalid path: %w", err)
+		}
+
 		if pathInfo.IsDir() {
 			files, err := os.ReadDir(path)
 			if err != nil {


### PR DESCRIPTION
While [toUserCmd](https://github.com/interlynk-io/sbomqs/blob/ece283e4b4a572f42b3921da29df41aac578e70d/cmd/score.go#L97) serves a single purpose – feeding data to [engParams](https://github.com/interlynk-io/sbomqs/blob/ece283e4b4a572f42b3921da29df41aac578e70d/cmd/score.go#L94) –  it handles various user-provided arguments and options. This complexity made writing comprehensive test cases challenging.

Therefore, I opted to refactor the code with structs and interfaces. This new approach not only promotes better organization but also allows the code to handle errors more effectively if they arise.