### PR TITLE
support 1.6 CycloneDX spec version

### DIFF
--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	cdx_spec_versions   = []string{"1.0", "1.1", "1.2", "1.3", "1.4", "1.5"}
+	cdx_spec_versions   = []string{"1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6"}
 	cdx_file_formats    = []string{"json", "xml"}
 	cdx_primary_purpose = []string{"application", "framework", "library", "container", "operating-system", "device", "firmware", "file"}
 )


### PR DESCRIPTION
Closes: #267 

This PR add the supports for new version(i.e. 1.6) of CycloneDX SBOMs, which was [released](https://cyclonedx.org/news/cyclonedx-v1.6-released/) few days. 
