### PR TITLE
sbomqs score directly from git URLs

### DIFF
--- a/cmd/score.go
+++ b/cmd/score.go
@@ -37,25 +37,25 @@ var (
 )
 
 type userCmd struct {
-	//input control
+	// input control
 	path []string
 
-	//filter control
+	// filter control
 	category string
 	features []string
 
-	//output control
+	// output control
 	json     bool
 	basic    bool
 	detailed bool
 
-	//directory control
+	// directory control
 	recurse bool
 
-	//debug control
+	// debug control
 	debug bool
 
-	//config control
+	// config control
 	configPath string
 }
 
@@ -69,7 +69,6 @@ var scoreCmd = &cobra.Command{
 			if len(inFile) <= 0 && len(inDirPath) <= 0 {
 				return fmt.Errorf("provide a path to an sbom file or directory of sbom files")
 			}
-
 		}
 		return nil
 	},
@@ -94,10 +93,11 @@ func processScore(cmd *cobra.Command, args []string) error {
 	engParams := toEngineParams(uCmd)
 	return engine.Run(ctx, engParams)
 }
+
 func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 	uCmd := &userCmd{}
 
-	//input control
+	// input control
 	if len(args) <= 0 {
 		if len(inFile) > 0 {
 			uCmd.path = append(uCmd.path, inFile)
@@ -110,13 +110,13 @@ func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 		uCmd.path = append(uCmd.path, args[0:]...)
 	}
 
-	//config control
+	// config control
 	if configPath == "" {
 		uCmd.configPath, _ = cmd.Flags().GetString("configpath")
 	} else {
 		uCmd.configPath = configPath
 	}
-	//filter control
+	// filter control
 	if category == "" {
 		uCmd.category, _ = cmd.Flags().GetString("category")
 	} else {
@@ -128,7 +128,7 @@ func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 		uCmd.features = strings.Split(f, ",")
 	}
 
-	//output control
+	// output control
 	uCmd.json, _ = cmd.Flags().GetBool("json")
 	uCmd.basic, _ = cmd.Flags().GetBool("basic")
 	uCmd.detailed, _ = cmd.Flags().GetBool("detailed")
@@ -139,7 +139,7 @@ func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 		uCmd.detailed = strings.ToLower(reportFormat) == "detailed"
 	}
 
-	//debug control
+	// debug control
 	uCmd.debug, _ = cmd.Flags().GetBool("debug")
 
 	return uCmd
@@ -165,14 +165,8 @@ func validatePath(path string) error {
 	}
 	return nil
 }
+
 func validateFlags(cmd *userCmd) error {
-
-	for _, path := range cmd.path {
-		if err := validatePath(path); err != nil {
-			return fmt.Errorf("invalid path: %w", err)
-		}
-	}
-
 	if cmd.configPath != "" {
 		if err := validatePath(cmd.configPath); err != nil {
 			return fmt.Errorf("invalid config path: %w", err)
@@ -185,36 +179,37 @@ func validateFlags(cmd *userCmd) error {
 
 	return nil
 }
+
 func init() {
 	rootCmd.AddCommand(scoreCmd)
 
-	//Config Control
+	// Config Control
 	scoreCmd.Flags().StringP("configpath", "", "", "scoring based on config path")
 
-	//Filter Control
+	// Filter Control
 	scoreCmd.Flags().StringP("category", "c", "", "filter by category")
 	scoreCmd.Flags().StringP("feature", "f", "", "filter by feature")
 
-	//Spec Control
+	// Spec Control
 	scoreCmd.Flags().BoolP("spdx", "", false, "limit scoring to spdx sboms")
 	scoreCmd.Flags().BoolP("cdx", "", false, "limit scoring to cdx sboms")
 	scoreCmd.MarkFlagsMutuallyExclusive("spdx", "cdx")
 	scoreCmd.Flags().MarkHidden("spdx")
 	scoreCmd.Flags().MarkHidden("cdx")
 
-	//Directory Control
+	// Directory Control
 	scoreCmd.Flags().BoolP("recurse", "r", false, "recurse into subdirectories")
 	scoreCmd.Flags().MarkHidden("recurse")
 
-	//Output Control
+	// Output Control
 	scoreCmd.Flags().BoolP("json", "j", false, "results in json")
 	scoreCmd.Flags().BoolP("detailed", "d", false, "results in table format, default")
 	scoreCmd.Flags().BoolP("basic", "b", false, "results in single line format")
 
-	//Debug Control
+	// Debug Control
 	scoreCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
 
-	//Deprecated
+	// Deprecated
 	scoreCmd.Flags().StringVar(&inFile, "filepath", "", "sbom file path")
 	scoreCmd.Flags().StringVar(&inDirPath, "dirpath", "", "sbom dir path")
 	scoreCmd.MarkFlagsMutuallyExclusive("filepath", "dirpath")

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,12 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -32,12 +32,13 @@ require (
 	github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 // indirect
 	github.com/cloudflare/circl v1.3.9 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
+	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/spdx/gordf v0.0.0-20221230105357-b735bd5aac89 // indirect
+	github.com/spf13/afero v1.11.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/github/go-spdx/v2 v2.3.1 h1:ffGuHTbHuHzWPt53n8f9o8clGutuLPObo3zB4JAjxU8=
 github.com/github/go-spdx/v2 v2.3.1/go.mod h1:2ZxKsOhvBp+OYBDlsGnUMcchLeo2mrpEBn2L1C+U3IQ=
+github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
+github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -59,8 +61,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.46.0 h1:w8G+oaCPgz1PoCJztqymCFaKwXt+5cCXn51uPxExFfQ=
 github.com/samber/lo v1.46.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
@@ -71,6 +73,8 @@ github.com/spdx/gordf v0.0.0-20221230105357-b735bd5aac89 h1:dArkMwZ7Mf2JiU8Ofdmq
 github.com/spdx/gordf v0.0.0-20221230105357-b735bd5aac89/go.mod h1:uKWaldnbMnjsSAXRurWqqrdyZen1R7kxl8TkmWk2OyM=
 github.com/spdx/tools-golang v0.5.5 h1:61c0KLfAcNqAjlg6UNMdkwpMernhw3zVRwDZ2x9XOmk=
 github.com/spdx/tools-golang v0.5.5/go.mod h1:MVIsXx8ZZzaRWNQpUDhC4Dud34edUYJYecciXgrw5vE=
+github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
+github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/engine/dtrack.go
+++ b/pkg/engine/dtrack.go
@@ -49,7 +49,6 @@ func DtrackScore(ctx context.Context, dtP *DtParams) error {
 
 	dTrackClient, err := dtrack.NewClient(dtP.Url,
 		dtrack.WithAPIKey(dtP.ApiKey), dtrack.WithDebug(false))
-
 	if err != nil {
 		log.Fatalf("Failed to create Dependency-Track client: %s", err)
 	}
@@ -81,7 +80,7 @@ func DtrackScore(ctx context.Context, dtP *DtParams) error {
 
 			ep := &Params{}
 			ep.Path = append(ep.Path, f.Name())
-			doc, scores, err := processFile(ctx, ep, ep.Path[0])
+			doc, scores, err := processFile(ctx, ep, ep.Path[0], nil)
 			if err != nil {
 				return err
 			}
@@ -89,7 +88,7 @@ func DtrackScore(ctx context.Context, dtP *DtParams) error {
 			if dtP.TagProjectWithScore {
 
 				log.Debugf("Project: %+v", prj.Tags)
-				//remove old score
+				// remove old score
 				prj.Tags = lo.Filter(prj.Tags, func(t dtrack.Tag, _ int) bool {
 					return !strings.HasPrefix(t.Name, "sbomqs=")
 				})

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -108,17 +108,27 @@ func IsGit(in string) bool {
 func ProcessURL(url string, file afero.File) (afero.File, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Fatalf("failed to get data: %v", err)
+		fmt.Println("FAiled to get http URL")
+		return nil, fmt.Errorf("failed to get data: %v", err)
 	}
 	defer resp.Body.Close()
 
 	// Ensure the response is OK
 	if resp.StatusCode != http.StatusOK {
-		log.Fatalf("failed to download file: %s", resp.Status)
+		return nil, fmt.Errorf("failed to download file: %s", resp.Status)
 	}
 	_, err = io.Copy(file, resp.Body)
 	if err != nil {
-		log.Fatalf("failed to copy in file: %w", err)
+		return nil, fmt.Errorf("failed to copy in file: %w", err)
+	}
+
+	// Check if the file is empty
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+	if info.Size() == 0 {
+		return nil, fmt.Errorf("downloaded file is empty")
 	}
 
 	return file, err

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -115,7 +115,7 @@ func handlePaths(ctx context.Context, ep *Params) error {
 
 	for _, path := range ep.Path {
 		if IsURL(path) {
-			if IsGit(path) {
+			if !IsGit(path) {
 				return fmt.Errorf("path is not a git URL: %s", path)
 			}
 			fmt.Println("It's a GitHub URL: ", path)

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -85,14 +85,11 @@ func handleURL(path string) (string, string, error) {
 	if len(parts) < 5 {
 		log.Fatalf("invalid GitHub URL: %v", path)
 	}
-	fmt.Println("Parts: ", parts)
 
 	sbomFilePath := strings.Join(parts[5:], "/")
-	fmt.Println("sbomFilePath: ", sbomFilePath)
 
 	rawURL := strings.Replace(path, "github.com", "raw.githubusercontent.com", 1)
 	rawURL = strings.Replace(rawURL, "/blob/", "/", 1)
-	fmt.Println("rawURL: ", rawURL)
 
 	return sbomFilePath, rawURL, err
 }
@@ -108,7 +105,6 @@ func IsGit(in string) bool {
 func ProcessURL(url string, file afero.File) (afero.File, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		fmt.Println("FAiled to get http URL")
 		return nil, fmt.Errorf("failed to get data: %v", err)
 	}
 	defer resp.Body.Close()

--- a/pkg/engine/score_test.go
+++ b/pkg/engine/score_test.go
@@ -1,0 +1,108 @@
+package engine
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleURL(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          string
+		expectedPath   string
+		expectedRawURL string
+		expectedError  bool
+	}{
+		{
+			name:           "Valid URL",
+			input:          "https://github.com/interlynk-io/sbomqs/blob/main/samples/sbomqs-spdx-syft.json",
+			expectedPath:   "samples/sbomqs-spdx-syft.json",
+			expectedRawURL: "https://raw.githubusercontent.com/interlynk-io/sbomqs/main/samples/sbomqs-spdx-syft.json",
+			expectedError:  false,
+		},
+		{
+			name:           "Valid URL with direct file",
+			input:          "https://github.com/viveksahu26/go-url/blob/main/spdx.json",
+			expectedError:  false,
+			expectedPath:   "spdx.json",
+			expectedRawURL: "https://raw.githubusercontent.com/viveksahu26/go-url/main/spdx.json",
+		},
+		{
+			name:           "Invalid URL with not enough parts",
+			input:          "https://github.com/interlynk-io/sbomqs/blob/main/",
+			expectedPath:   "",
+			expectedRawURL: "",
+			expectedError:  true,
+		},
+		{
+			name:           "Malformed URL",
+			input:          "invalid-url",
+			expectedPath:   "",
+			expectedRawURL: "",
+			expectedError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sbomFilePath, rawURL, err := handleURL(tc.input)
+			if tc.expectedError {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedPath, sbomFilePath)
+				assert.Equal(t, tc.expectedRawURL, rawURL)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedPath, sbomFilePath)
+				assert.Equal(t, tc.expectedRawURL, rawURL)
+			}
+		})
+	}
+}
+
+// TestProcessURL function
+func TestProcessURL(t *testing.T) {
+	tests := []struct {
+		name                 string
+		url                  string
+		statusCode           int
+		expectedError        bool
+		expectedErrorMessage error
+	}{
+		{
+			name:                 "Successful download",
+			url:                  "https://github.com/interlynk-io/sbomqs/blob/main/samples/sbomqs-spdx-syft.json",
+			statusCode:           http.StatusOK,
+			expectedError:        false,
+			expectedErrorMessage: nil,
+		},
+		{
+			name:                 "Failed to get data",
+			url:                  "http://example.com/file.txt",
+			statusCode:           http.StatusNotFound,
+			expectedError:        true,
+			expectedErrorMessage: fmt.Errorf("failed to download file: %s %s", "404", http.StatusText(http.StatusNotFound)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			file, err := fs.Create("testfile.txt")
+			if err != nil {
+				log.Fatalf("error: %v", err)
+			}
+
+			_, err = ProcessURL(tt.url, file)
+			if tt.expectedError {
+				assert.EqualError(t, err, tt.expectedErrorMessage.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/engine/share.go
+++ b/pkg/engine/share.go
@@ -34,13 +34,12 @@ func ShareRun(ctx context.Context, ep *Params) error {
 		log.Fatal("path is required")
 	}
 
-	doc, scores, err := processFile(ctx, ep, ep.Path[0])
+	doc, scores, err := processFile(ctx, ep, ep.Path[0], nil)
 	if err != nil {
 		return err
 	}
 
 	url, err := share.Share(ctx, doc, scores, ep.Path[0])
-
 	if err != nil {
 		fmt.Printf("Error sharing file %s: %s", ep.Path, err)
 		return err


### PR DESCRIPTION
closes: #266 
This PR add support for `sbomqs score` command to score directly from git URLs. Till now it funtionality limited to local files. For example:
`$ sbomqs score -b <sbom.spdx.json file>`

New feature supports:
```bash
$ sbomqs score -b  https://github.com/interlynk-io/sbomqs/blob/main/samples/
or 
$ sbomqs score -b https://github.com/interlynk-io/sbomqs/blob/main/samples/sbomqs-spdx-syft.json
or 
$ sbomqs score -b  https://github.com/spdx/ntia-conformance-checker/blob/main/tests/data/ -b 
or 
$ sbomqs score -b  https://github.com/spdx/ntia-conformance-checker/blob/main/tests/data/SPDXSBOMExampleTests/ -b
```

Example:
```bash
$ go run main.go score https://github.com/interlynk-io/sbomqs/blob/main/samples/ -b
Enumerating objects: 561, done.
Counting objects: 100% (561/561), done.
Compressing objects: 100% (354/354), done.
Total 561 (delta 363), reused 330 (delta 190), pack-reused 0
7.7     spdx    2.3     json    samples/photon.spdx.json
6.5     cdx     1.4     json    samples/sbomqs-cdx-cgomod.json
6.5     spdx    2.3     json    samples/sbomqs-spdx-sbtool.json
6.4     spdx    2.3     json    samples/sbomqs-spdx-syft.json
```