### PR TITLE
Supplier count bug

### DIFF
--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -554,7 +554,7 @@ func (c *cdxDoc) assignSupplier(comp *cydx.Component) *Supplier {
 
 	supplier := Supplier{}
 
-	if comp.Supplier.Name == "" {
+	if comp.Supplier.Name != "" {
 		supplier.Name = comp.Supplier.Name
 	}
 


### PR DESCRIPTION
I noticed a bug with the `comp_with_supplier` rule. I scored CycloneDX SBOMs and couldn't get any of them to recognize any suppliers.

Example SBOM:
```
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.4",
  "serialNumber": "urn:uuid:d7700b83-651a-458a-9764-1998b615a8d5",
  "version": 1,
  "metadata": {
    "component": {
      "bom-ref": "foobar",
      "type": "library",
      "name": "some other library here",
      "version": "v0.111.0",
      "supplier": { "name": "foobar supplier" }
    }
  },
  "components": [
    {
      "bom-ref": "zipzap",
      "type": "library",
      "name": "some library here",
      "version": "v0.9.0",
      "scope": "required",
      "supplier": { "name": "zipzap supplier" }
    }
  ]
}
```

When I score this, I get:
```
$ sbomqs score /tmp/sample.cdx.json | grep comp_with_supplier
|                       | comp_with_supplier             | 0.0/10.0  | 0/2 have supplier names        |
```

This PR should fix this.