### PR TITLE
update sbom_with_creator_and_version rule for cdx version >= 1.5

### DIFF
--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -463,6 +463,13 @@ func (c *cdxDoc) parseTool() {
 		t.Version = ct.Version
 		c.tools = append(c.tools, t)
 	}
+
+	for _, ct := range lo.FromPtr(c.doc.Metadata.Tools.Services) {
+		t := Tool{}
+		t.Name = ct.Name
+		t.Version = ct.Version
+		c.tools = append(c.tools, t)
+	}
 }
 
 func (c *cdxDoc) parseAuthors() {


### PR DESCRIPTION
close: https://github.com/interlynk-io/sbomqs/issues/264

update `sbom_with_creator_and_version` rule for cdx  whose spec version >= 1.5.
