### PR TITLE
fix cra compliance report

### DIFF
--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -58,7 +58,7 @@ func setupEngineParams(cmd *cobra.Command, args []string) *engine.Params {
 	engParams.Json, _ = cmd.Flags().GetBool("json")
 
 	// engParams.Ntia, _ = cmd.Flags().GetBool("ntia")
-	engParams.Cra, _ = cmd.Flags().GetBool("cra")
+	engParams.Cra, _ = cmd.Flags().GetBool("bsi")
 	engParams.Oct, _ = cmd.Flags().GetBool("oct")
 
 	engParams.Debug, _ = cmd.Flags().GetBool("debug")


### PR DESCRIPTION
If you try to run `compliance` command  for `cra` type in latest release, 
`$ go run main.go compliance samples/sbomqs-spdx-sbtool.json --bsi`

you will find that it doesn't give any o/p. It's was due to this [PR](https://github.com/interlynk-io/sbomqs/pull/278).  

This PR fixes that.