### PR TITLE
make bsi consistent throughout codebase in place of cra

### DIFF
--- a/Compliance.md
+++ b/Compliance.md
@@ -8,7 +8,7 @@ The goal of compliance reports is to verify if the sbom file adheres to these st
 We have explained below how sbomqs approaches compliance reports for BSI TR-03183-2 v1.1. We are not going to explain
 this technical guideline here, but rather go into our intepretation of it.
 
-## TR-03183: SBOM Requirements for CRA
+## TR-03183: SBOM Requirements for BSI
 
 The [BSI TR-03183-2 v1.1](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2.pdf) specifies mandatory properties for an SBOM. Below is how we have derived all the values.
 

--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -58,7 +58,7 @@ func setupEngineParams(cmd *cobra.Command, args []string) *engine.Params {
 	engParams.Json, _ = cmd.Flags().GetBool("json")
 
 	// engParams.Ntia, _ = cmd.Flags().GetBool("ntia")
-	engParams.Cra, _ = cmd.Flags().GetBool("bsi")
+	engParams.Bsi, _ = cmd.Flags().GetBool("bsi")
 	engParams.Oct, _ = cmd.Flags().GetBool("oct")
 
 	engParams.Debug, _ = cmd.Flags().GetBool("debug")

--- a/pkg/compliance/bsi.go
+++ b/pkg/compliance/bsi.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	valid_cra_spdx_versions = []string{"SPDX-2.3"}
-	valid_cra_cdx_versions  = []string{"1.4", "1.5", "1.6"}
+	valid_bsi_spdx_versions = []string{"SPDX-2.3"}
+	valid_bsi_cdx_versions  = []string{"1.4", "1.5", "1.6"}
 )
 
 const (
@@ -75,35 +75,35 @@ const (
 	PACK_EXT_REF
 )
 
-func craResult(ctx context.Context, doc sbom.Document, fileName string, outFormat string) {
+func bsiResult(ctx context.Context, doc sbom.Document, fileName string, outFormat string) {
 	log := logger.FromContext(ctx)
-	log.Debug("compliance.craResult()")
+	log.Debug("compliance.bsiResult()")
 
 	db := newDB()
 
-	db.addRecord(craSpec(doc))
-	db.addRecord(craSpecVersion(doc))
-	db.addRecord(craBuildPhase(doc))
-	db.addRecord(craSbomDepth(doc))
-	db.addRecord(craCreator(doc))
-	db.addRecord(craTimestamp(doc))
-	db.addRecord(craSbomURI(doc))
-	db.addRecords(craComponents(doc))
+	db.addRecord(bsiSpec(doc))
+	db.addRecord(bsiSpecVersion(doc))
+	db.addRecord(bsiBuildPhase(doc))
+	db.addRecord(bsiSbomDepth(doc))
+	db.addRecord(bsiCreator(doc))
+	db.addRecord(bsiTimestamp(doc))
+	db.addRecord(bsiSbomURI(doc))
+	db.addRecords(bsiComponents(doc))
 
 	if outFormat == "json" {
-		craJsonReport(db, fileName)
+		bsiJsonReport(db, fileName)
 	}
 
 	if outFormat == "basic" {
-		craBasicReport(db, fileName)
+		bsiBasicReport(db, fileName)
 	}
 
 	if outFormat == "detailed" {
-		craDetailedReport(db, fileName)
+		bsiDetailedReport(db, fileName)
 	}
 }
 
-func craSpec(doc sbom.Document) *record {
+func bsiSpec(doc sbom.Document) *record {
 	v := doc.Spec().GetSpecType()
 	v_to_lower := strings.Trim(strings.ToLower(v), " ")
 	result := ""
@@ -119,7 +119,7 @@ func craSpec(doc sbom.Document) *record {
 	return newRecordStmt(SBOM_SPEC, "doc", result, score)
 }
 
-func craSpecVersion(doc sbom.Document) *record {
+func bsiSpecVersion(doc sbom.Document) *record {
 	spec := doc.Spec().GetSpecType()
 	version := doc.Spec().GetVersion()
 
@@ -127,13 +127,13 @@ func craSpecVersion(doc sbom.Document) *record {
 	score := 0.0
 
 	if spec == "spdx" {
-		count := lo.Count(valid_cra_spdx_versions, version)
+		count := lo.Count(valid_bsi_spdx_versions, version)
 		if count > 0 {
 			result = version
 			score = 10.0
 		}
 	} else if spec == "cyclonedx" {
-		count := lo.Count(valid_cra_cdx_versions, version)
+		count := lo.Count(valid_bsi_cdx_versions, version)
 		if count > 0 {
 			result = version
 			score = 10.0
@@ -143,7 +143,7 @@ func craSpecVersion(doc sbom.Document) *record {
 	return newRecordStmt(SBOM_SPEC_VERSION, "doc", result, score)
 }
 
-func craBuildPhase(doc sbom.Document) *record {
+func bsiBuildPhase(doc sbom.Document) *record {
 	lifecycles := doc.Lifecycles()
 	result := ""
 	score := 0.0
@@ -158,7 +158,7 @@ func craBuildPhase(doc sbom.Document) *record {
 	return newRecordStmt(SBOM_BUILD, "doc", result, score)
 }
 
-func craSbomDepth(doc sbom.Document) *record {
+func bsiSbomDepth(doc sbom.Document) *record {
 	if !doc.PrimaryComponent() {
 		return newRecordStmt(SBOM_DEPTH, "doc", "no-primary", 0.0)
 	}
@@ -186,7 +186,7 @@ func craSbomDepth(doc sbom.Document) *record {
 	return newRecordStmt(SBOM_DEPTH, "doc", "non-compliant", 0.0)
 }
 
-func craCreator(doc sbom.Document) *record {
+func bsiCreator(doc sbom.Document) *record {
 	result := ""
 	score := 0.0
 
@@ -276,7 +276,7 @@ func craCreator(doc sbom.Document) *record {
 	return newRecordStmt(SBOM_CREATOR, "doc", "", 0.0)
 }
 
-func craTimestamp(doc sbom.Document) *record {
+func bsiTimestamp(doc sbom.Document) *record {
 	score := 0.0
 	result := doc.Spec().GetCreationTimestamp()
 
@@ -287,7 +287,7 @@ func craTimestamp(doc sbom.Document) *record {
 	return newRecordStmt(SBOM_TIMESTAMP, "doc", result, score)
 }
 
-func craSbomURI(doc sbom.Document) *record {
+func bsiSbomURI(doc sbom.Document) *record {
 	uri := doc.Spec().URI()
 
 	if uri != "" {
@@ -297,7 +297,7 @@ func craSbomURI(doc sbom.Document) *record {
 	return newRecordStmt(SBOM_URI, "doc", "", 0)
 }
 
-func craComponents(doc sbom.Document) []*record {
+func bsiComponents(doc sbom.Document) []*record {
 	records := []*record{}
 
 	if len(doc.Components()) == 0 {
@@ -306,16 +306,16 @@ func craComponents(doc sbom.Document) []*record {
 	}
 
 	for _, component := range doc.Components() {
-		records = append(records, craComponentCreator(component))
-		records = append(records, craComponentName(component))
-		records = append(records, craComponentVersion(component))
-		records = append(records, craComponentLicense(component))
-		records = append(records, craComponentDepth(component))
-		records = append(records, craComponentHash(component))
-		records = append(records, craComponentSourceCodeUrl(component))
-		records = append(records, craComponentDownloadUrl(component))
-		records = append(records, craComponentSourceHash(component))
-		records = append(records, craComponentOtherUniqIds(component))
+		records = append(records, bsiComponentCreator(component))
+		records = append(records, bsiComponentName(component))
+		records = append(records, bsiComponentVersion(component))
+		records = append(records, bsiComponentLicense(component))
+		records = append(records, bsiComponentDepth(component))
+		records = append(records, bsiComponentHash(component))
+		records = append(records, bsiComponentSourceCodeUrl(component))
+		records = append(records, bsiComponentDownloadUrl(component))
+		records = append(records, bsiComponentSourceHash(component))
+		records = append(records, bsiComponentOtherUniqIds(component))
 	}
 
 	records = append(records, newRecordStmt(SBOM_COMPONENTS, "doc", "present", 10.0))
@@ -323,7 +323,7 @@ func craComponents(doc sbom.Document) []*record {
 	return records
 }
 
-func craComponentDepth(component sbom.GetComponent) *record {
+func bsiComponentDepth(component sbom.GetComponent) *record {
 	if !component.HasRelationShips() {
 		return newRecordStmt(COMP_DEPTH, component.GetID(), "no-relationships", 0.0)
 	}
@@ -339,7 +339,7 @@ func craComponentDepth(component sbom.GetComponent) *record {
 	return newRecordStmt(COMP_DEPTH, component.GetID(), "non-compliant", 0.0)
 }
 
-func craComponentLicense(component sbom.GetComponent) *record {
+func bsiComponentLicense(component sbom.GetComponent) *record {
 	licenses := component.Licenses()
 	score := 0.0
 
@@ -382,7 +382,7 @@ func craComponentLicense(component sbom.GetComponent) *record {
 	return newRecordStmt(COMP_LICENSE, component.GetID(), "compliant", 10.0)
 }
 
-func craComponentSourceHash(component sbom.GetComponent) *record {
+func bsiComponentSourceHash(component sbom.GetComponent) *record {
 	result := ""
 	score := 0.0
 
@@ -394,7 +394,7 @@ func craComponentSourceHash(component sbom.GetComponent) *record {
 	return newRecordStmtOptional(COMP_SOURCE_HASH, component.GetID(), result, score)
 }
 
-func craComponentOtherUniqIds(component sbom.GetComponent) *record {
+func bsiComponentOtherUniqIds(component sbom.GetComponent) *record {
 	result := ""
 	score := 0.0
 
@@ -419,7 +419,7 @@ func craComponentOtherUniqIds(component sbom.GetComponent) *record {
 	return newRecordStmtOptional(COMP_OTHER_UNIQ_IDS, component.GetID(), "", 0.0)
 }
 
-func craComponentDownloadUrl(component sbom.GetComponent) *record {
+func bsiComponentDownloadUrl(component sbom.GetComponent) *record {
 	result := component.GetDownloadLocationUrl()
 
 	if result != "" {
@@ -428,7 +428,7 @@ func craComponentDownloadUrl(component sbom.GetComponent) *record {
 	return newRecordStmtOptional(COMP_DOWNLOAD_URL, component.GetID(), "", 0.0)
 }
 
-func craComponentSourceCodeUrl(component sbom.GetComponent) *record {
+func bsiComponentSourceCodeUrl(component sbom.GetComponent) *record {
 	result := component.SourceCodeUrl()
 
 	if result != "" {
@@ -438,7 +438,7 @@ func craComponentSourceCodeUrl(component sbom.GetComponent) *record {
 	return newRecordStmtOptional(COMP_SOURCE_CODE_URL, component.GetID(), "", 0.0)
 }
 
-func craComponentHash(component sbom.GetComponent) *record {
+func bsiComponentHash(component sbom.GetComponent) *record {
 	result := ""
 	algos := []string{"SHA256", "SHA-256", "sha256", "sha-256"}
 	score := 0.0
@@ -456,7 +456,7 @@ func craComponentHash(component sbom.GetComponent) *record {
 	return newRecordStmt(COMP_HASH, component.GetID(), result, score)
 }
 
-func craComponentVersion(component sbom.GetComponent) *record {
+func bsiComponentVersion(component sbom.GetComponent) *record {
 	result := component.GetVersion()
 
 	if result != "" {
@@ -466,7 +466,7 @@ func craComponentVersion(component sbom.GetComponent) *record {
 	return newRecordStmt(COMP_VERSION, component.GetID(), "", 0.0)
 }
 
-func craComponentName(component sbom.GetComponent) *record {
+func bsiComponentName(component sbom.GetComponent) *record {
 	result := component.GetName()
 
 	if result != "" {
@@ -476,7 +476,7 @@ func craComponentName(component sbom.GetComponent) *record {
 	return newRecordStmt(COMP_NAME, component.GetID(), "", 0.0)
 }
 
-func craComponentCreator(component sbom.GetComponent) *record {
+func bsiComponentCreator(component sbom.GetComponent) *record {
 	result := ""
 	score := 0.0
 

--- a/pkg/compliance/bsi_report.go
+++ b/pkg/compliance/bsi_report.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/release-utils/version"
 )
 
-var craSectionDetails = map[int]craSection{
+var bsiSectionDetails = map[int]bsiSection{
 	SBOM_SPEC:            {Title: "SBOM formats", Id: "4", Required: true, DataField: "specification"},
 	SBOM_SPEC_VERSION:    {Title: "SBOM formats", Id: "4", Required: true, DataField: "specification version"},
 	SBOM_BUILD:           {Title: "Level of Detail", Id: "5.1", Required: true, DataField: "build process"},
@@ -63,7 +63,7 @@ type Summary struct {
 	TotalRequiredScore float64 `json:"required_elements_score"`
 	TotalOptionalScore float64 `json:"optional_elements_score"`
 }
-type craSection struct {
+type bsiSection struct {
 	Title         string  `json:"section_title"`
 	Id            string  `json:"section_id"`
 	DataField     string  `json:"section_data_field"`
@@ -72,19 +72,19 @@ type craSection struct {
 	ElementResult string  `json:"element_result"`
 	Score         float64 `json:"score"`
 }
-type craComplianceReport struct {
+type bsiComplianceReport struct {
 	Name     string       `json:"report_name"`
 	Subtitle string       `json:"subtitle"`
 	Revision string       `json:"revision"`
 	Run      run          `json:"run"`
 	Tool     tool         `json:"tool"`
 	Summary  Summary      `json:"summary"`
-	Sections []craSection `json:"sections"`
+	Sections []bsiSection `json:"sections"`
 }
 
-func newJsonReport() *craComplianceReport {
-	return &craComplianceReport{
-		Name:     "Cyber Resilience Requirements for Manufacturers and Products Report",
+func newJsonReport() *bsiComplianceReport {
+	return &bsiComplianceReport{
+		Name:     "BSI TR-03183-2 v1.1 Compliance Report",
 		Subtitle: "Part 2: Software Bill of Materials (SBOM)",
 		Revision: "TR-03183-2 (1.1)",
 		Run: run{
@@ -101,11 +101,11 @@ func newJsonReport() *craComplianceReport {
 	}
 }
 
-func craJsonReport(db *db, fileName string) {
+func bsiJsonReport(db *db, fileName string) {
 	jr := newJsonReport()
 	jr.Run.FileName = fileName
 
-	score := craAggregateScore(db)
+	score := bsiAggregateScore(db)
 	summary := Summary{}
 	summary.MaxScore = 10.0
 	summary.TotalScore = score.totalScore()
@@ -119,21 +119,21 @@ func craJsonReport(db *db, fileName string) {
 	fmt.Println(string(o))
 }
 
-func constructSections(db *db) []craSection {
-	var sections []craSection
+func constructSections(db *db) []bsiSection {
+	var sections []bsiSection
 	allIds := db.getAllIds()
 	for _, id := range allIds {
 		records := db.getRecordsById(id)
 
 		for _, r := range records {
-			section := craSectionDetails[r.check_key]
-			new_section := craSection{
+			section := bsiSectionDetails[r.check_key]
+			new_section := bsiSection{
 				Title:     section.Title,
 				Id:        section.Id,
 				DataField: section.DataField,
 				Required:  section.Required,
 			}
-			score := craKeyIdScore(db, r.check_key, r.id)
+			score := bsiKeyIdScore(db, r.check_key, r.id)
 			new_section.Score = score.totalScore()
 			if r.id == "doc" {
 				new_section.ElementId = "sbom"
@@ -149,11 +149,11 @@ func constructSections(db *db) []craSection {
 	return sections
 }
 
-func craDetailedReport(db *db, fileName string) {
+func bsiDetailedReport(db *db, fileName string) {
 	table := tablewriter.NewWriter(os.Stdout)
-	score := craAggregateScore(db)
+	score := bsiAggregateScore(db)
 
-	fmt.Printf("Cyber Resilience Requirements for Manufacturers and Products Report TR-03183-2 (1.1)\n")
+	fmt.Printf("BSI TR-03183-2 v1.1 Compliance Report \n")
 	fmt.Printf("Compliance score by Interlynk Score:%0.1f RequiredScore:%0.1f OptionalScore:%0.1f for %s\n", score.totalScore(), score.totalRequiredScore(), score.totalOptionalScore(), fileName)
 	fmt.Printf("* indicates optional fields\n")
 	table.SetHeader([]string{"ElementId", "Section", "Datafield", "Element Result", "Score"})
@@ -171,8 +171,8 @@ func craDetailedReport(db *db, fileName string) {
 	table.Render()
 }
 
-func craBasicReport(db *db, fileName string) {
-	score := craAggregateScore(db)
-	fmt.Printf("Cyber Resilience Requirements for Manufacturers and Products Report TR-03183-2 (1.1)\n")
+func bsiBasicReport(db *db, fileName string) {
+	score := bsiAggregateScore(db)
+	fmt.Printf("BSI TR-03183-2 v1.1 Compliance Report\n")
 	fmt.Printf("Score:%0.1f RequiredScore:%0.1f OptionalScore:%0.1f for %s\n", score.totalScore(), score.totalRequiredScore(), score.totalOptionalScore(), fileName)
 }

--- a/pkg/compliance/bsi_score.go
+++ b/pkg/compliance/bsi_score.go
@@ -14,7 +14,7 @@
 
 package compliance
 
-type craScoreResult struct {
+type bsiScoreResult struct {
 	id              string
 	requiredScore   float64
 	optionalScore   float64
@@ -22,11 +22,11 @@ type craScoreResult struct {
 	optionalRecords int
 }
 
-func newCraScoreResult(id string) *craScoreResult {
-	return &craScoreResult{id: id}
+func newBsiScoreResult(id string) *bsiScoreResult {
+	return &bsiScoreResult{id: id}
 }
 
-func (r *craScoreResult) totalScore() float64 {
+func (r *bsiScoreResult) totalScore() float64 {
 	if r.requiredRecords == 0 && r.optionalRecords == 0 {
 		return 0.0
 	}
@@ -42,7 +42,7 @@ func (r *craScoreResult) totalScore() float64 {
 	return r.totalRequiredScore()
 }
 
-func (r *craScoreResult) totalRequiredScore() float64 {
+func (r *bsiScoreResult) totalRequiredScore() float64 {
 	if r.requiredRecords == 0 {
 		return 0.0
 	}
@@ -50,7 +50,7 @@ func (r *craScoreResult) totalRequiredScore() float64 {
 	return r.requiredScore / float64(r.requiredRecords)
 }
 
-func (r *craScoreResult) totalOptionalScore() float64 {
+func (r *bsiScoreResult) totalOptionalScore() float64 {
 	if r.optionalRecords == 0 {
 		return 0.0
 	}
@@ -58,11 +58,11 @@ func (r *craScoreResult) totalOptionalScore() float64 {
 	return r.optionalScore / float64(r.optionalRecords)
 }
 
-func craKeyIdScore(db *db, key int, id string) *craScoreResult {
+func bsiKeyIdScore(db *db, key int, id string) *bsiScoreResult {
 	records := db.getRecordsByKeyId(key, id)
 
 	if len(records) == 0 {
-		return newCraScoreResult(id)
+		return newBsiScoreResult(id)
 	}
 
 	required_score := 0.0
@@ -81,21 +81,20 @@ func craKeyIdScore(db *db, key int, id string) *craScoreResult {
 		}
 	}
 
-	return &craScoreResult{
+	return &bsiScoreResult{
 		id:              id,
 		requiredScore:   required_score,
 		optionalScore:   optional_score,
 		requiredRecords: required_recs,
 		optionalRecords: optional_recs,
 	}
-
 }
 
-func craIdScore(db *db, id string) *craScoreResult {
+func bsiIdScore(db *db, id string) *bsiScoreResult {
 	records := db.getRecordsById(id)
 
 	if len(records) == 0 {
-		return newCraScoreResult(id)
+		return newBsiScoreResult(id)
 	}
 
 	required_score := 0.0
@@ -114,7 +113,7 @@ func craIdScore(db *db, id string) *craScoreResult {
 		}
 	}
 
-	return &craScoreResult{
+	return &bsiScoreResult{
 		id:              id,
 		requiredScore:   required_score,
 		optionalScore:   optional_score,
@@ -123,13 +122,13 @@ func craIdScore(db *db, id string) *craScoreResult {
 	}
 }
 
-func craAggregateScore(db *db) *craScoreResult {
-	var results []craScoreResult
-	var finalResult craScoreResult
+func bsiAggregateScore(db *db) *bsiScoreResult {
+	var results []bsiScoreResult
+	var finalResult bsiScoreResult
 
 	ids := db.getAllIds()
 	for _, id := range ids {
-		results = append(results, *craIdScore(db, id))
+		results = append(results, *bsiIdScore(db, id))
 	}
 
 	for _, r := range results {

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	CRA_REPORT  = "CRA"
+	BSI_REPORT  = "BSI"
 	NTIA_REPORT = "NTIA"
 	OCT_TELCO   = "OCT"
 )
@@ -33,7 +33,7 @@ func ComplianceResult(ctx context.Context, doc sbom.Document, reportType, fileNa
 	log := logger.FromContext(ctx)
 	log.Debug("compliance.ComplianceResult()")
 
-	if reportType != CRA_REPORT && reportType != NTIA_REPORT && reportType != OCT_TELCO {
+	if reportType != BSI_REPORT && reportType != NTIA_REPORT && reportType != OCT_TELCO {
 		log.Debugf("Invalid report type: %s\n", reportType)
 		return errors.New("invalid report type")
 	}
@@ -53,8 +53,8 @@ func ComplianceResult(ctx context.Context, doc sbom.Document, reportType, fileNa
 		return errors.New("output format is empty")
 	}
 
-	if reportType == CRA_REPORT {
-		craResult(ctx, doc, fileName, outFormat)
+	if reportType == BSI_REPORT {
+		bsiResult(ctx, doc, fileName, outFormat)
 	}
 
 	if reportType == NTIA_REPORT {

--- a/pkg/engine/compliance.go
+++ b/pkg/engine/compliance.go
@@ -44,8 +44,8 @@ func ComplianceRun(ctx context.Context, ep *Params) error {
 
 	reportType := "NTIA"
 
-	if ep.Cra {
-		reportType = "CRA"
+	if ep.Bsi {
+		reportType = "BSI"
 	} else if ep.Oct {
 		reportType = "OCT"
 	}

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -48,7 +48,7 @@ type Params struct {
 	ConfigPath string
 
 	Ntia bool
-	Cra  bool
+	Bsi  bool
 	Oct  bool
 }
 


### PR DESCRIPTION
This PR is additional version of  [PR](https://github.com/interlynk-io/sbomqs/pull/293) to make bsi or BSI consistent over cra or CRA throughout the codebase. 