### PR TITLE
add support for multiple categories

### DIFF
--- a/cmd/score.go
+++ b/cmd/score.go
@@ -42,8 +42,8 @@ type userCmd struct {
 	path []string
 
 	// filter control
-	category string
-	features []string
+	categories []string
+	features   []string
 
 	// output control
 	json     bool
@@ -81,6 +81,12 @@ var scoreCmd = &cobra.Command{
 
   # Get a score for a 'NTIA-minimum-elements' category and 'sbom_authors' feature against a SBOM in a table output
   sbomqs score --category NTIA-minimum-elements --feature sbom_authors samples/sbomqs-spdx-syft.json
+
+  # Get  a score for multiple features
+  sbomqs score --feature comp_with_name,comp_with_uniq_ids,sbom_authors,sbom_creation_timestamp  samples/sbomqs-spdx-syft.json 
+
+  # Get a score for multiple categories
+  sbomqs score --category NTIA-minimum-elements,Structural,Semantic,Sharing   samples/sbomqs-spdx-syft.json
 `,
 
 	Args: func(_ *cobra.Command, args []string) error {
@@ -137,9 +143,8 @@ func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 	}
 	// filter control
 	if category == "" {
-		uCmd.category, _ = cmd.Flags().GetString("category")
-	} else {
-		uCmd.category = category
+		c, _ := cmd.Flags().GetString("category")
+		uCmd.categories = strings.Split(c, ",")
 	}
 
 	if feature == "" {
@@ -167,7 +172,7 @@ func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 func toEngineParams(uCmd *userCmd) *engine.Params {
 	return &engine.Params{
 		Path:       uCmd.path,
-		Category:   uCmd.category,
+		Categories: uCmd.categories,
 		Features:   uCmd.features,
 		JSON:       uCmd.json,
 		Basic:      uCmd.basic,

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -36,8 +36,8 @@ import (
 type Params struct {
 	Path []string
 
-	Category string
-	Features []string
+	Categories []string
+	Features   []string
 
 	JSON     bool
 	Basic    bool
@@ -281,8 +281,13 @@ func processFile(ctx context.Context, ep *Params, path string, fs billy.Filesyst
 
 	sr := scorer.NewScorer(ctx, doc)
 
-	if ep.Category != "" {
-		sr.AddFilter(ep.Category, scorer.Category)
+	if len(ep.Categories) > 0 {
+		for _, category := range ep.Categories {
+			if len(category) <= 0 {
+				continue
+			}
+			sr.AddFilter(category, scorer.Category)
+		}
 	}
 
 	if len(ep.Features) > 0 {


### PR DESCRIPTION
fixes #301 

The PR adds  support for multiple categories. For example, user want to see score for 3 categories `NTIA-minimum-elements`,`Semantic`,`Sharing`. See below the command and o/p:
```bash
go run main.go score --category NTIA-minimum-elements,Semantic,Sharing   samples/sbomqs-spdx-syft.json  
catScores()
SBOM Quality by Interlynk Score:6.4     components:27   samples/sbomqs-spdx-syft.json
+-----------------------+-------------------------+-----------+--------------------------------+
|       CATEGORY        |         FEATURE         |   SCORE   |              DESC              |
+-----------------------+-------------------------+-----------+--------------------------------+
| NTIA-minimum-elements | comp_with_name          | 10.0/10.0 | 27/27 have names               |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_supplier      | 0.0/10.0  | 0/27 have supplier names       |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_uniq_ids      | 10.0/10.0 | 27/27 have unique ID's         |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_version       | 10.0/10.0 | 27/27 have versions            |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_authors            | 10.0/10.0 | doc has 2 authors              |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_creation_timestamp | 10.0/10.0 | doc has creation timestamp     |
|                       |                         |           | 2023-05-04T09:33:40Z           |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_dependencies       | 10.0/10.0 | doc has 1 relationships        |
+-----------------------+-------------------------+-----------+--------------------------------+
| Semantic              | comp_with_checksums     | 0.0/10.0  | 0/27 have checksums            |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_licenses      | 0.0/10.0  | 0/27 have licenses             |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_required_fields    | 10.0/10.0 | Doc Fields:true Pkg            |
|                       |                         |           | Fields:true                    |
+-----------------------+-------------------------+-----------+--------------------------------+
| Sharing               | sbom_sharable           | 0.0/10.0  | doc has a sharable license     |
|                       |                         |           | free 0 :: of 1                 |
+-----------------------+-------------------------+-----------+--------------------------------+
```