### PR TITLE
fix primary comp name for spdx

### DIFF
--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -330,6 +330,13 @@ func (s *SpdxDoc) parsePrimaryCompAndRelationships() {
 			primaryComponent = CleanKey(string(bBytes))
 			s.PrimaryComponent.ID = primaryComponent
 			s.PrimaryComponent.Present = true
+			modified := strings.TrimPrefix(primaryComponent, "SPDXRef-")
+
+			for _, pack := range s.doc.Packages {
+				if string(pack.PackageSPDXIdentifier) == modified {
+					s.PrimaryComponent.Name = pack.PackageName
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix primary comp name for SPDX SBOM.

![image](https://github.com/user-attachments/assets/acf7e005-73ee-41c9-9adf-2853f945834d)
