### PR TITLE
add color flag

### DIFF
--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -76,6 +76,7 @@ func setupEngineParams(cmd *cobra.Command, args []string) *engine.Params {
 	engParams.Basic, _ = cmd.Flags().GetBool("basic")
 	engParams.Detailed, _ = cmd.Flags().GetBool("detailed")
 	engParams.JSON, _ = cmd.Flags().GetBool("json")
+	engParams.Color, _ = cmd.Flags().GetBool("color")
 
 	engParams.Ntia, _ = cmd.Flags().GetBool("ntia")
 	// engParams.Ntia, _ = cmd.Flags().GetBool("ntia")
@@ -100,6 +101,12 @@ func init() {
 	complianceCmd.Flags().BoolP("json", "j", false, "json format")
 	complianceCmd.Flags().BoolP("basic", "b", false, "basic format")
 	complianceCmd.Flags().BoolP("detailed", "d", false, "detailed format")
+	complianceCmd.Flags().BoolP("json", "j", false, "output in json format")
+	complianceCmd.Flags().BoolP("basic", "b", false, "output in basic format")
+	complianceCmd.Flags().BoolP("detailed", "d", false, "output in detailed format")
+	complianceCmd.Flags().BoolP("color", "l", false, "output in colorful")
+
+	// complianceCmd.Flags().BoolP("pdf", "p", false, "output in pdf format")
 	complianceCmd.MarkFlagsMutuallyExclusive("json", "basic", "detailed")
 
 	// Standards control

--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -98,9 +98,6 @@ func init() {
 	complianceCmd.Flags().BoolP("debug", "D", false, "debug logging")
 
 	// Output control
-	complianceCmd.Flags().BoolP("json", "j", false, "json format")
-	complianceCmd.Flags().BoolP("basic", "b", false, "basic format")
-	complianceCmd.Flags().BoolP("detailed", "d", false, "detailed format")
 	complianceCmd.Flags().BoolP("json", "j", false, "output in json format")
 	complianceCmd.Flags().BoolP("basic", "b", false, "output in basic format")
 	complianceCmd.Flags().BoolP("detailed", "d", false, "output in detailed format")

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -42,7 +42,7 @@ func validReportTypes() map[string]bool {
 }
 
 //nolint:revive,stylecheck
-func ComplianceResult(ctx context.Context, doc sbom.Document, reportType, fileName, outFormat string) error {
+func ComplianceResult(ctx context.Context, doc sbom.Document, reportType, fileName, outFormat string, coloredOutput bool) error {
 	log := logger.FromContext(ctx)
 	log.Debug("compliance.ComplianceResult()")
 
@@ -81,7 +81,7 @@ func ComplianceResult(ctx context.Context, doc sbom.Document, reportType, fileNa
 		octResult(ctx, doc, fileName, outFormat)
 
 	case reportType == FSCT_V3:
-		fsct.Result(ctx, doc, fileName, outFormat)
+		fsct.Result(ctx, doc, fileName, outFormat, coloredOutput)
 
 	default:
 		fmt.Println("No compliance type is provided")

--- a/pkg/compliance/fsct/fsct.go
+++ b/pkg/compliance/fsct/fsct.go
@@ -25,7 +25,7 @@ import (
 	"github.com/samber/lo"
 )
 
-func Result(ctx context.Context, doc sbom.Document, fileName string, outFormat string) {
+func Result(ctx context.Context, doc sbom.Document, fileName string, outFormat string, coloredOutput bool) {
 	log := logger.FromContext(ctx)
 	log.Debug("fsct compliance")
 
@@ -49,7 +49,7 @@ func Result(ctx context.Context, doc sbom.Document, fileName string, outFormat s
 	}
 
 	if outFormat == "detailed" {
-		fsctDetailedReport(dtb, fileName)
+		fsctDetailedReport(dtb, fileName, coloredOutput)
 	}
 }
 

--- a/pkg/engine/compliance.go
+++ b/pkg/engine/compliance.go
@@ -66,7 +66,9 @@ func ComplianceRun(ctx context.Context, ep *Params) error {
 		outFormat = "detailed"
 	}
 
-	err = compliance.ComplianceResult(ctx, *doc, reportType, ep.Path[0], outFormat)
+	coloredOutput := ep.Color
+
+	err = compliance.ComplianceResult(ctx, *doc, reportType, ep.Path[0], outFormat, coloredOutput)
 	if err != nil {
 		log.Debugf("compliance.ComplianceResult failed for file :%s\n", ep.Path[0])
 		fmt.Printf("failed to get compliance result for %s\n", ep.Path[0])

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -57,6 +57,8 @@ type Params struct {
 	Bsi  bool
 	Oct  bool
 	Fsct bool
+
+	Color bool
 }
 
 func Run(ctx context.Context, ep *Params) error {


### PR DESCRIPTION
Add flag for color output.
`go run main.go compliance -f --color=false ../lynk-api/scripts/samples/misc/ascii-boxes-sbom-cdx.json`

Command help:
```bash
$ go run main.go compliance -h
Check if your SBOM complies with various SBOM standards like NTIA minimum elements, BSI TR-03183-2, OpenChain Telco.
	Generate a compliance report for an SBOM file.

Usage:
  sbomqs compliance <sbom file> [flags]

Examples:
 sbomqs compliance --bsi|--oct  [--basic|--json] <SBOM file>

  # Check a BSI TR-03183-2 v1.1 compliance against a SBOM in a table output
  sbomqs compliance --bsi samples/sbomqs-spdx-syft.json

  # Check a BSI TR-03183-2 v1.1 compliance against a SBOM in a JSON output
  sbomqs compliance --bsi --json samples/sbomqs-spdx-syft.json

  # Check a OpenChain Telco compliance against a SBOM in a table output
  sbomqs compliance --oct samples/sbomqs-spdx-syft.json

  # Check a OpenChain Telco compliance against a SBOM in a JSON output
  sbomqs compliance --oct --json samples/sbomqs-spdx-syft.json

  # Check a V3 Framing document compliance  against a SBOM in a table output
  sbomqs compliance --fsct <sbom>

  # Check a V3 Framing document compliance  against a SBOM in a JSON output
  sbomqs compliance --fsct -j <sbom>


Flags:
  -b, --basic      output in basic format
  -c, --bsi        BSI TR-03183-2 v1.1 compliance
  -l, --color      output in colorful
  -D, --debug      enable debug logging
  -d, --detailed   output in detailed format
  -f, --fsct       V3 Framing document compliance
  -h, --help       help for compliance
  -j, --json       output in json format
  -n, --ntia       check for NTIA minimum elements compliance
  -t, --oct        OpenChainTelco compliance

```