### PR TITLE
shorten name and version to avoid table breaking or destructuring

### DIFF
--- a/pkg/compliance/common/common.go
+++ b/pkg/compliance/common/common.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"path"
 	"strings"
 	"time"
 
@@ -347,7 +348,20 @@ func GetID(componentID string) string {
 }
 
 func UniqueElementID(component sbom.GetComponent) string {
-	return component.GetName() + "-" + component.GetVersion()
+	componentName := path.Base(component.GetName())
+
+	if len(componentName) > 20 {
+		// "org.jetbrains.kotlin:kotlin-stdlib-jdk7" would become "org.jetbrain...lib-jdk7"
+		componentName = componentName[:12] + "..." + componentName[len(componentName)-8:]
+	}
+
+	version := component.GetVersion()
+	if len(version) > 12 {
+		// "v0.0.0-20230321023759-10a507213a29" would become "v0.0.0...213a29"
+		version = version[:6] + "..." + version[len(version)-6:]
+	}
+
+	return componentName + "-" + version
 }
 
 func IsComponentPartOfPrimaryDependency(primaryCompDeps []string, comp string) bool {


### PR DESCRIPTION
Sometime when component name or version are big, this leads to break the table structure and that looks really bad. In that user have to zoom out to make table structure, due to which the text size becomes too small. To avoid this, we come up with shortening names or version, which resolves these issues.

![image](https://github.com/user-attachments/assets/4f6163d3-4907-47c5-8080-657a2840d038)


Examples, 
- comp name is `org.jetbrains.kotlin:kotlin-stdlib-jdk7`, then it would become `org.jetbrain...lib-jdk7`
- similarly if comp version is  `v0.0.0-20230321023759-10a507213a29`, then it would become `v0.0.0...213a29`.

And both combined as ElementdID would look like: `org.jetbrain...lib-jdk7-v0.0.0...213a29`

![image](https://github.com/user-attachments/assets/a163969b-313a-44ba-816d-56249213b6a6)

