### PR TITLE
fix spdxVersion for bsi and oct

### DIFF
--- a/pkg/compliance/bsi.go
+++ b/pkg/compliance/bsi.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	validBsiSpdxVersions = []string{"SPDX-2.3"}
+	validBsiSpdxVersions = []string{"SPDX-2.3", "SPDX-2.2", "SPDX-2.1"}
 	validBsiCdxVersions  = []string{"1.4", "1.5", "1.6"}
 )
 

--- a/pkg/compliance/bsi.go
+++ b/pkg/compliance/bsi.go
@@ -27,7 +27,8 @@ import (
 )
 
 var (
-	validBsiSpdxVersions = []string{"SPDX-2.3", "SPDX-2.2", "SPDX-2.1"}
+	validBsiSpdxVersions = []string{"SPDX-2.3"}
+	validSpdxVersion     = []string{"SPDX-2.1", "SPDX-2.2", "SPDX-2.3"}
 	validBsiCdxVersions  = []string{"1.4", "1.5", "1.6"}
 )
 
@@ -134,9 +135,15 @@ func bsiSpecVersion(doc sbom.Document) *db.Record {
 
 	if spec == "spdx" {
 		count := lo.Count(validBsiSpdxVersions, version)
-		if count > 0 {
-			result = version
-			score = 10.0
+		validate := lo.Contains(validSpdxVersion, version)
+		if validate {
+			if count > 0 {
+				result = version
+				score = 10.0
+			} else {
+				result = version
+				score = 0.0
+			}
 		}
 	} else if spec == "cyclonedx" {
 		count := lo.Count(validBsiCdxVersions, version)

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -45,6 +45,7 @@ var (
 type SpdxDoc struct {
 	doc              *spdx.Document
 	format           FileFormat
+	version          FormatVersion
 	ctx              context.Context
 	SpdxSpec         *Specs
 	Comps            []GetComponent
@@ -58,7 +59,7 @@ type SpdxDoc struct {
 	composition      map[string]string
 }
 
-func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat) (Document, error) {
+func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version FormatVersion) (Document, error) {
 	_ = logger.FromContext(ctx)
 	var err error
 
@@ -87,9 +88,10 @@ func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat) (Docume
 	}
 
 	doc := &SpdxDoc{
-		doc:    d,
-		format: format,
-		ctx:    ctx,
+		doc:     d,
+		format:  format,
+		ctx:     ctx,
+		version: version,
 	}
 
 	doc.parse()
@@ -172,7 +174,7 @@ func (s *SpdxDoc) parseDoc() {
 func (s *SpdxDoc) parseSpec() {
 	sp := NewSpec()
 	sp.Format = string(s.format)
-	sp.Version = s.doc.SPDXVersion
+	sp.Version = string(s.version)
 
 	if s.doc.CreationInfo != nil {
 		for _, c := range s.doc.CreationInfo.Creators {


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomqs/issues/349

This PR fixes parsing of SPDX Version correctly for bsi and oct compliance. Whereas no changes in score.

**For bsi:**
```bash
go run main.go compliance --bsi   samples/photon.spdx.json 
BSI TR-03183-2 v1.1 Compliance Report 
Compliance score by Interlynk Score:2.5 RequiredScore:5.0 OptionalScore:0.0 for samples/photon.spdx.json
* indicates optional fields
+-------------------------------------+---------+--------------------------------+------------------------------------------------------------------+-------+
|              ELEMENTID              | SECTION |           DATAFIELD            |                          ELEMENT RESULT                          | SCORE |
+-------------------------------------+---------+--------------------------------+------------------------------------------------------------------+-------+
| SBOM                                |       4 | specification                  | spdx                                                             |  10.0 |
+                                     +---------+--------------------------------+------------------------------------------------------------------+-------+
|                                     |       4 | specification version          | SPDX-2.2                                                         |  10.0 |
+                                     +---------+--------------------------------+------------------------------------------------------------------+-------+

```

**For oct:**
```bash
go run main.go compliance --oct   samples/photon.spdx.json 
OpenChain Telco Report
Compliance score by Interlynk Score:2.9 RequiredScore:2.9 OptionalScore:0.0 for samples/photon.spdx.json
* indicates optional fields
+-------------------------------------+---------+------------------------------+------------------------------------------------------------------+-------+
|              ELEMENTID              | SECTION |          DATAFIELD           |                          ELEMENT RESULT                          | SCORE |
+-------------------------------------+---------+------------------------------+------------------------------------------------------------------+-------+
| SPDX Elements                       | 3.1.1   | SBOM data format             | spdx                                                             |  10.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+
|                                     | 3.1.10  | SBOM creator tool            | tern                                                             |  10.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+
|                                     | 3.1.11  | SBOM machine readable format | spdx, json                                                       |  10.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+
|                                     | 3.1.12  | SBOM human readable format   | json                                                             |  10.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+
|                                     | 3.1.14  | SBOM delivery time           | unknown                                                          |   0.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+
|                                     | 3.1.15  | SBOM delivery method         | unknown                                                          |   0.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+
|                                     | 3.1.16  | SBOM scope                   | unknown                                                          |   0.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+
|                                     | 3.1.2   | Spec version                 | SPDX-2.2                                                         |  10.0 |
+                                     +---------+------------------------------+------------------------------------------------------------------+-------+

```