### PR TITLE
add bsi-v2 command

### DIFF
--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -29,13 +29,16 @@ var complianceCmd = &cobra.Command{
 Check if our SBOM meets compliance requirements for various standards, such as NTIA minimum elements, 
 BSI TR-03183-2, Framing Software Component Transparency (v3) and OpenChain Telco.
 	`,
-	Example: ` sbomqs compliance <--ntia | --bsi | --fsct | --oct > [--basic | --json] <SBOM file>
+	Example: ` sbomqs compliance  < --ntia | --bsi | --bsi-v2 | --fsct | --oct >  [--basic | --json]   <SBOM file>
 
   # Check a NTIA minimum elements compliance against a SBOM in a table output
   sbomqs compliance --ntia samples/sbomqs-spdx-syft.json
 
   # Check a BSI TR-03183-2 v1.1 compliance against a SBOM in a table output
   sbomqs compliance --bsi samples/sbomqs-spdx-syft.json
+
+  # Check a BSI TR-03183-2 v2.0.0 compliance against a SBOM in a table output
+  sbomqs compliance --bsi-v2 samples/sbomqs-spdx-syft.json
 
    # Check a Framing Software Component Transparency (v3) compliance against a SBOM in a table output
   sbomqs compliance --fsct samples/sbomqs-spdx-syft.json
@@ -78,8 +81,8 @@ func setupEngineParams(cmd *cobra.Command, args []string) *engine.Params {
 	engParams.Color, _ = cmd.Flags().GetBool("color")
 
 	engParams.Ntia, _ = cmd.Flags().GetBool("ntia")
-	// engParams.Ntia, _ = cmd.Flags().GetBool("ntia")
 	engParams.Bsi, _ = cmd.Flags().GetBool("bsi")
+	engParams.BsiV2, _ = cmd.Flags().GetBool("bsi-v2")
 	engParams.Oct, _ = cmd.Flags().GetBool("oct")
 	engParams.Fsct, _ = cmd.Flags().GetBool("fsct")
 
@@ -108,6 +111,7 @@ func init() {
 	// Standards control
 	complianceCmd.Flags().BoolP("ntia", "n", false, "NTIA minimum elements (July 12, 2021)")
 	complianceCmd.Flags().BoolP("bsi", "c", false, "BSI TR-03183-2 (v1.1)")
+	complianceCmd.Flags().BoolP("bsi-v2", "s", false, "BSI TR-03183-2 (v2.0.0)")
 	complianceCmd.Flags().BoolP("oct", "t", false, "OpenChain Telco SBOM (v1.0)")
 	complianceCmd.Flags().BoolP("fsct", "f", false, "Framing Software Component Transparency (v3)")
 }

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -26,18 +26,20 @@ import (
 
 //nolint:revive,stylecheck
 const (
-	BSI_REPORT  = "BSI"
-	NTIA_REPORT = "NTIA"
-	OCT_TELCO   = "OCT"
-	FSCT_V3     = "FSCT"
+	BSI_REPORT    = "BSI"
+	BSI_V2_REPORT = "BSI-V2"
+	NTIA_REPORT   = "NTIA"
+	OCT_TELCO     = "OCT"
+	FSCT_V3       = "FSCT"
 )
 
 func validReportTypes() map[string]bool {
 	return map[string]bool{
-		BSI_REPORT:  true,
-		NTIA_REPORT: true,
-		OCT_TELCO:   true,
-		FSCT_V3:     true,
+		BSI_REPORT:    true,
+		BSI_V2_REPORT: true,
+		NTIA_REPORT:   true,
+		OCT_TELCO:     true,
+		FSCT_V3:       true,
 	}
 }
 
@@ -69,6 +71,10 @@ func ComplianceResult(ctx context.Context, doc sbom.Document, reportType, fileNa
 	switch {
 	case reportType == BSI_REPORT:
 		bsiResult(ctx, doc, fileName, outFormat)
+
+	case reportType == BSI_V2_REPORT:
+		fmt.Println("Future work: bsiV2Result() will execute")
+		// bsiV2Result(ctx, doc, fileName, outFormat)
 
 	case reportType == NTIA_REPORT:
 		ntiaResult(ctx, doc, fileName, outFormat)

--- a/pkg/engine/compliance.go
+++ b/pkg/engine/compliance.go
@@ -47,6 +47,8 @@ func ComplianceRun(ctx context.Context, ep *Params) error {
 	switch {
 	case ep.Bsi:
 		reportType = "BSI"
+	case ep.BsiV2:
+		reportType = "BSI-V2"
 	case ep.Oct:
 		reportType = "OCT"
 	case ep.Fsct:

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -53,10 +53,11 @@ type Params struct {
 
 	ConfigPath string
 
-	Ntia bool
-	Bsi  bool
-	Oct  bool
-	Fsct bool
+	Ntia  bool
+	Bsi   bool
+	BsiV2 bool
+	Oct   bool
+	Fsct  bool
 
 	Color bool
 }


### PR DESCRIPTION

closes #329 

This PR is a part of new big feature to support `bsi-v2` compliance. 

- [ :heavy_check_mark: ] Add the command `bsi-v2`. 

`$ go run main.go compliance --bsi-v2  samples/photon.spdx.json`
`$ go run main.go compliance -s  samples/photon.spdx.json`

```bash
go run main.go compliance -h                                

Check if our SBOM meets compliance requirements for various standards, such as NTIA minimum elements, 
BSI TR-03183-2, Framing Software Component Transparency (v3) and OpenChain Telco.

Usage:
  sbomqs compliance [flags]

Examples:
 sbomqs compliance  < --ntia | --bsi | --bsi-v2 | --fsct | --oct >  [--basic | --json]   <SBOM file>

  # Check a NTIA minimum elements compliance against a SBOM in a table output
  sbomqs compliance --ntia samples/sbomqs-spdx-syft.json

  # Check a BSI TR-03183-2 v1.1 compliance against a SBOM in a table output
  sbomqs compliance --bsi samples/sbomqs-spdx-syft.json

  # Check a BSI TR-03183-2 v2.0.0 compliance against a SBOM in a table output
  sbomqs compliance --bsi-v2 samples/sbomqs-spdx-syft.json

   # Check a Framing Software Component Transparency (v3) compliance against a SBOM in a table output
  sbomqs compliance --fsct samples/sbomqs-spdx-syft.json

  # Check a OpenChain Telco compliance against a SBOM in a JSON output
  sbomqs compliance --oct --json samples/sbomqs-spdx-syft.json

   # Check a Framing Software Component Transparency (v3) compliance against a SBOM in a table colorful output
  sbomqs compliance --fsct --color samples/sbomqs-spdx-syft.json



Flags:
  -b, --basic      output in basic format
  -c, --bsi        BSI TR-03183-2 (v1.1)
  -s, --bsi-v2     BSI TR-03183-2 (v2.0.0)
  -l, --color      output in colorful
  -D, --debug      debug logging
  -d, --detailed   output in detailed format(default)
  -f, --fsct       Framing Software Component Transparency (v3)
  -h, --help       help for compliance
  -j, --json       output in json format
  -n, --ntia       NTIA minimum elements (July 12, 2021)
  -t, --oct        OpenChain Telco SBOM (v1.0)
```