### PR TITLE
support external and internal signature verification for sbom

### DIFF
--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -88,7 +88,11 @@ func setupEngineParams(cmd *cobra.Command, args []string) *engine.Params {
 
 	engParams.Debug, _ = cmd.Flags().GetBool("debug")
 
+	engParams.Signature, _ = cmd.Flags().GetString("sig")
+	engParams.PublicKey, _ = cmd.Flags().GetString("pub")
+
 	engParams.Path = append(engParams.Path, args[0])
+	engParams.Blob = args[0]
 
 	return engParams
 }
@@ -114,4 +118,7 @@ func init() {
 	complianceCmd.Flags().BoolP("bsi-v2", "s", false, "BSI TR-03183-2 (v2.0.0)")
 	complianceCmd.Flags().BoolP("oct", "t", false, "OpenChain Telco SBOM (v1.0)")
 	complianceCmd.Flags().BoolP("fsct", "f", false, "Framing Software Component Transparency (v3)")
+
+	complianceCmd.Flags().StringP("sig", "v", "", "signature of sbom")
+	complianceCmd.Flags().StringP("pub", "p", "", "public key of sbom")
 }

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,9 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/gjson v1.14.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
@@ -44,6 +47,7 @@ require (
 	github.com/spdx/gordf v0.0.0-20221230105357-b735bd5aac89 // indirect
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tidwall/sjson v1.2.5
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,14 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/terminalstatic/go-xsd-validate v0.1.5 h1:RqpJnf6HGE2CB/lZB1A8BYguk8uRtcvYAPLCF15qguo=
 github.com/terminalstatic/go-xsd-validate v0.1.5/go.mod h1:18lsvYFofBflqCrvo1umpABZ99+GneNTw2kEEc8UPJw=
+github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/pkg/compliance/bsi.go
+++ b/pkg/compliance/bsi.go
@@ -81,6 +81,7 @@ const (
 	SBOM_TYPE
 	PACK_EXT_REF
 	SBOM_VULNERABILITES
+	SBOM_SIGNATURE
 )
 
 func bsiResult(ctx context.Context, doc sbom.Document, fileName string, outFormat string) {

--- a/pkg/compliance/bsiV2.go
+++ b/pkg/compliance/bsiV2.go
@@ -16,6 +16,7 @@ package compliance
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/interlynk-io/sbomqs/pkg/compliance/common"
 	db "github.com/interlynk-io/sbomqs/pkg/compliance/db"
@@ -45,7 +46,7 @@ func bsiV2Result(ctx context.Context, doc sbom.Document, fileName string, outFor
 	dtb.AddRecord(bsiSbomURI(doc))
 	dtb.AddRecords(bsiV2Components(doc))
 	// New SBOM fields
-	// dtb.AddRecord(bsiSbomSignature(doc))
+	dtb.AddRecord(bsiV2SbomSignature(doc))
 	// dtb.AddRecord(bsiSbomLinks(doc))
 
 	if outFormat == "json" {
@@ -74,6 +75,34 @@ func bsiV2Vulnerabilities(doc sbom.Document) *db.Record {
 		score = 0.0
 	}
 	return db.NewRecordStmt(SBOM_VULNERABILITES, "doc", result, score, "")
+}
+
+// bsiV2SbomSignature
+func bsiV2SbomSignature(doc sbom.Document) *db.Record {
+	result, score := "", 0.0
+
+	if doc.Signature() != nil {
+		// verify signature
+		// common.VerifySignature()
+		pubKey := doc.Signature().GetPublicKey()
+		blob := doc.Signature().GetBlob()
+		sig := doc.Signature().GetSigValue()
+		valid, err := common.VerifySignature(pubKey, blob, sig)
+		if err != nil {
+			fmt.Printf("Verification failed: %v\n", err)
+			result = "Verification failed"
+			score = 0.0
+		}
+		if valid {
+			score = 10.0
+			result = "Signature verification succeeded!"
+		} else {
+			score = 5.0
+			result = "Signature verification failed!"
+		}
+	}
+
+	return db.NewRecordStmt(SBOM_SIGNATURE, "doc", result, score, "")
 }
 
 func bsiV2SpecVersion(doc sbom.Document) *db.Record {

--- a/pkg/compliance/bsi_report.go
+++ b/pkg/compliance/bsi_report.go
@@ -46,6 +46,7 @@ var bsiSectionDetails = map[int]bsiSection{
 	COMP_SOURCE_HASH:     {Title: "Additional fields components", ID: "5.3.2", Required: false, DataField: "Hash value of the source code of the component"},
 	COMP_OTHER_UNIQ_IDS:  {Title: "Additional fields components", ID: "5.3.2", Required: false, DataField: "Other unique identifiers"},
 	SBOM_VULNERABILITES:  {Title: "Definition of SBOM", ID: "3.1", Required: true, DataField: "vuln"},
+	SBOM_SIGNATURE:       {Title: "Optional sboms fields", ID: "8.1.11", Required: false, DataField: "signature"},
 }
 
 type run struct {

--- a/pkg/engine/compliance.go
+++ b/pkg/engine/compliance.go
@@ -86,6 +86,19 @@ func getSbomDocument(ctx context.Context, ep *Params) (*sbom.Document, error) {
 	log.Debugf("engine.getSbomDocument()")
 
 	path := ep.Path[0]
+
+	blob := ep.Path[0]
+	fmt.Println("Blob: ", blob)
+	signature := ep.Signature
+	fmt.Println("Signature: ", signature)
+	publicKey := ep.PublicKey
+	fmt.Println("PublicKey: ", publicKey)
+
+	sig := sbom.Signature{
+		SigValue:  signature,
+		PublicKey: publicKey,
+		Blob:      blob,
+	}
 	var doc sbom.Document
 
 	if IsURL(path) {
@@ -111,7 +124,7 @@ func getSbomDocument(ctx context.Context, ep *Params) (*sbom.Document, error) {
 			return nil, err
 		}
 
-		doc, err = sbom.NewSBOMDocument(ctx, f)
+		doc, err = sbom.NewSBOMDocument(ctx, f, sig)
 		if err != nil {
 			log.Fatalf("failed to parse SBOM document: %w", err)
 		}
@@ -130,7 +143,7 @@ func getSbomDocument(ctx context.Context, ep *Params) (*sbom.Document, error) {
 		}
 		defer f.Close()
 
-		doc, err = sbom.NewSBOMDocument(ctx, f)
+		doc, err = sbom.NewSBOMDocument(ctx, f, sig)
 		if err != nil {
 			log.Debugf("failed to create sbom document for  :%s\n", path)
 			log.Debugf("%s\n", err)

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -59,7 +59,10 @@ type Params struct {
 	Oct   bool
 	Fsct  bool
 
-	Color bool
+	Color     bool
+	Signature string
+	PublicKey string
+	Blob      string
 }
 
 func Run(ctx context.Context, ep *Params) error {
@@ -172,7 +175,7 @@ func handlePaths(ctx context.Context, ep *Params) error {
 				return err
 			}
 
-			doc, err := sbom.NewSBOMDocument(ctx, f)
+			doc, err := sbom.NewSBOMDocument(ctx, f, sbom.Signature{})
 			if err != nil {
 				log.Fatalf("failed to parse SBOM document: %w", err)
 			}
@@ -258,7 +261,7 @@ func processFile(ctx context.Context, ep *Params, path string, fs billy.Filesyst
 		}
 		defer f.Close()
 
-		doc, err = sbom.NewSBOMDocument(ctx, f)
+		doc, err = sbom.NewSBOMDocument(ctx, f, sbom.Signature{})
 		if err != nil {
 			log.Debugf("failed to create sbom document for  :%s\n", path)
 			log.Debugf("%s\n", err)
@@ -280,7 +283,7 @@ func processFile(ctx context.Context, ep *Params, path string, fs billy.Filesyst
 		}
 		defer f.Close()
 
-		doc, err = sbom.NewSBOMDocument(ctx, f)
+		doc, err = sbom.NewSBOMDocument(ctx, f, sbom.Signature{})
 		if err != nil {
 			log.Debugf("failed to create sbom document for  :%s\n", path)
 			log.Debugf("%s\n", err)

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -56,9 +56,10 @@ type CdxDoc struct {
 	Dependencies     map[string][]string
 	composition      map[string]string
 	vuln             GetVulnerabilities
+	SignatureDetail  GetSignature
 }
 
-func newCDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat) (Document, error) {
+func newCDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, sig Signature) (Document, error) {
 	var err error
 
 	_, err = f.Seek(0, io.SeekStart)
@@ -86,9 +87,10 @@ func newCDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat) (Documen
 	}
 
 	doc := &CdxDoc{
-		doc:    bom,
-		format: format,
-		ctx:    ctx,
+		doc:             bom,
+		format:          format,
+		ctx:             ctx,
+		SignatureDetail: &sig,
 	}
 	doc.parse()
 
@@ -145,6 +147,10 @@ func (c CdxDoc) GetComposition(componentID string) string {
 
 func (s CdxDoc) Vulnerabilities() GetVulnerabilities {
 	return s.vuln
+}
+
+func (c CdxDoc) Signature() GetSignature {
+	return c.SignatureDetail
 }
 
 func (c *CdxDoc) parse() {

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -16,9 +16,15 @@ package sbom
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log"
+	"math/big"
+	"os"
 	"strings"
 
 	cydx "github.com/CycloneDX/cyclonedx-go"
@@ -163,6 +169,9 @@ func (c *CdxDoc) parse() {
 	c.parseCompositions()
 	c.parsePrimaryCompAndRelationships()
 	c.parseVulnerabilities()
+	if c.Signature().GetPublicKey() == "" && c.Signature().GetPublicKey() == "" {
+		c.parseSignature()
+	}
 	c.parseComps()
 }
 
@@ -230,6 +239,109 @@ func (c *CdxDoc) parseVulnerabilities() {
 		}
 	}
 	c.vuln = vuln
+}
+
+func (c *CdxDoc) parseSignature() {
+	c.SignatureDetail = &Signature{}
+	if c.doc.Declarations != nil {
+		if c.doc.Declarations.Signature != nil {
+			sigAlgo := c.doc.Declarations.Signature.Algorithm
+			sigValue := c.doc.Declarations.Signature.Value
+			pubKeyAlgo := c.doc.Declarations.Signature.PublicKey.KTY
+			pubKeyModulus := c.doc.Declarations.Signature.PublicKey.N
+			pubKeyExponent := c.doc.Declarations.Signature.PublicKey.E
+
+			fmt.Println("Extracted Signature Section:")
+			fmt.Printf("Algorithm: %s\n", sigAlgo)
+			fmt.Printf("Value: %s\n", sigValue)
+			fmt.Printf("APublic Key lgorithm: %s\n", pubKeyAlgo)
+			fmt.Printf("Public Key Modulus (N): %s\n", pubKeyModulus)
+			fmt.Printf("Public Key Exponent (E): %s\n", pubKeyExponent)
+
+			// Decode the signature
+			signatureValue, err := base64.StdEncoding.DecodeString(sigValue)
+			if err != nil {
+				fmt.Println("Error decoding signature:", err)
+				return
+			}
+
+			// Write the signature to a file
+			if err := os.WriteFile("extracted_signature.bin", signatureValue, 0o644); err != nil {
+				fmt.Println("Error writing signature to file:", err)
+				return
+			}
+			fmt.Println("Signature written to file: extracted_signature.bin")
+
+			// Extract the public key modulus and exponent
+			modulus, err := base64.StdEncoding.DecodeString(pubKeyModulus)
+			if err != nil {
+				fmt.Println("Error decoding public key modulus:", err)
+				return
+			}
+
+			exponent := decodeBase64URLEncodingToInt(pubKeyExponent)
+			if exponent == 0 {
+				fmt.Println("Invalid public key exponent.")
+				return
+			}
+
+			// Create the RSA public key
+			pubKey := &rsa.PublicKey{
+				N: decodeBigInt(modulus),
+				E: int(exponent),
+			}
+
+			// Write the public key to a PEM file
+			pubKeyPEM := publicKeyToPEM(pubKey)
+			if err := os.WriteFile("extracted_public_key.pem", pubKeyPEM, 0o644); err != nil {
+				fmt.Println("Error writing public key to file:", err)
+				return
+			}
+
+			sig := Signature{}
+			sig.PublicKey = string(pubKeyPEM)
+			sig.SigValue = string(signatureValue)
+
+			c.SignatureDetail = &sig
+
+			fmt.Println("Public key written to file: extracted_public_key.pem")
+
+		}
+	}
+}
+
+func decodeBase64URLEncodingToInt(input string) int {
+	bytes, err := base64.StdEncoding.DecodeString(input)
+	if err != nil {
+		return 0
+	}
+	if len(bytes) == 0 {
+		return 0
+	}
+	result := 0
+	for _, b := range bytes {
+		result = result<<8 + int(b)
+	}
+	return result
+}
+
+func decodeBigInt(input []byte) *big.Int {
+	result := new(big.Int)
+	result.SetBytes(input)
+	return result
+}
+
+func publicKeyToPEM(pub *rsa.PublicKey) []byte {
+	pubASN1, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		fmt.Println("Error marshaling public key:", err)
+		return nil
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubASN1,
+	})
+	return pubPEM
 }
 
 func (c *CdxDoc) requiredFields() bool {

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -33,4 +33,5 @@ type Document interface {
 	GetRelationships(string) []string
 
 	Vulnerabilities() GetVulnerabilities
+	Signature() GetSignature
 }

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -165,7 +165,7 @@ func detectSbomFormat(f io.ReadSeeker) (SpecFormat, FileFormat, FormatVersion, e
 	return SBOMSpecUnknown, FileFormatUnknown, "", nil
 }
 
-func NewSBOMDocument(ctx context.Context, f io.ReadSeeker) (Document, error) {
+func NewSBOMDocument(ctx context.Context, f io.ReadSeeker, sig Signature) (Document, error) {
 	log := logger.FromContext(ctx)
 
 	spec, format, version, err := detectSbomFormat(f)
@@ -179,9 +179,9 @@ func NewSBOMDocument(ctx context.Context, f io.ReadSeeker) (Document, error) {
 
 	switch spec {
 	case SBOMSpecSPDX:
-		doc, err = newSPDXDoc(ctx, f, format, version)
+		doc, err = newSPDXDoc(ctx, f, format, version, sig)
 	case SBOMSpecCDX:
-		doc, err = newCDXDoc(ctx, f, format)
+		doc, err = newCDXDoc(ctx, f, format, sig)
 	default:
 		return nil, errors.New("unsupported sbom format")
 	}

--- a/pkg/sbom/signature.go
+++ b/pkg/sbom/signature.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+type GetSignature interface {
+	GetSigValue() string
+	GetPublicKey() string
+	GetBlob() string
+}
+
+type Signature struct {
+	SigValue  string
+	PublicKey string
+	Blob      string
+}
+
+func (s *Signature) GetSigValue() string {
+	return s.SigValue
+}
+
+func (s *Signature) GetPublicKey() string {
+	return s.PublicKey
+}
+
+func (s *Signature) GetBlob() string {
+	return s.Blob
+}

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -89,11 +89,6 @@ func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version
 		return nil, err
 	}
 
-	// sig := Signature{
-	// 	SigValue:  "kkkkd",
-	// 	PublicKey: "kkkd",
-	// 	Blob:      "dkkddk",
-	// }
 	doc := &SpdxDoc{
 		doc:             d,
 		format:          format,

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -58,9 +58,10 @@ type SpdxDoc struct {
 	Dependencies     map[string][]string
 	composition      map[string]string
 	vuln             GetVulnerabilities
+	SignatureDetail  GetSignature
 }
 
-func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version FormatVersion) (Document, error) {
+func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version FormatVersion, sig Signature) (Document, error) {
 	_ = logger.FromContext(ctx)
 	var err error
 
@@ -88,11 +89,17 @@ func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version
 		return nil, err
 	}
 
+	// sig := Signature{
+	// 	SigValue:  "kkkkd",
+	// 	PublicKey: "kkkd",
+	// 	Blob:      "dkkddk",
+	// }
 	doc := &SpdxDoc{
-		doc:     d,
-		format:  format,
-		ctx:     ctx,
-		version: version,
+		doc:             d,
+		format:          format,
+		ctx:             ctx,
+		version:         version,
+		SignatureDetail: &sig,
 	}
 
 	doc.parse()
@@ -155,6 +162,10 @@ func (s SpdxDoc) GetComposition(componentID string) string {
 
 func (s SpdxDoc) Vulnerabilities() GetVulnerabilities {
 	return s.vuln
+}
+
+func (c SpdxDoc) Signature() GetSignature {
+	return c.SignatureDetail
 }
 
 func (s *SpdxDoc) parse() {

--- a/samples/stree-cdxgen-signed-sbom.cdx.json
+++ b/samples/stree-cdxgen-signed-sbom.cdx.json
@@ -1,0 +1,495 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "serialNumber": "urn:uuid:de517446-d9eb-49d0-95fd-dd93c54a88d1",
+    "version": 1,
+    "metadata": {
+      "timestamp": "2024-11-22T20:22:51Z",
+      "tools": {
+        "components": [
+          {
+            "group": "@cyclonedx",
+            "name": "cdxgen",
+            "version": "10.7.1",
+            "purl": "pkg:npm/%40cyclonedx/cdxgen@10.7.1",
+            "type": "application",
+            "bom-ref": "pkg:npm/@cyclonedx/cdxgen@10.7.1",
+            "author": "OWASP Foundation",
+            "publisher": "OWASP Foundation"
+          }
+        ]
+      },
+      "authors": [
+        {
+          "name": "OWASP Foundation"
+        }
+      ],
+      "lifecycles": [
+        {
+          "phase": "build"
+        }
+      ],
+      "component": {
+        "group": "",
+        "name": "github.com/viveksahu26/stree",
+        "version": "",
+        "purl": "pkg:golang/github.com/viveksahu26/stree",
+        "bom-ref": "pkg:golang/github.com/viveksahu26/stree",
+        "scope": "required",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/src/github.com/viveksahu26/stree/go.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.21.4"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "false"
+          }
+        ],
+        "type": "application"
+      }
+    },
+    "components": [
+      {
+        "group": "",
+        "name": "github.com/spf13/pflag",
+        "version": "v1.0.5",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "31c5df227251af3e026575593812dbd1b4d9a844e488084cf48c34cb7027d818"
+          }
+        ],
+        "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/spf13/pflag/@v/v1.0.5.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.12"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/spf13/cobra",
+        "version": "v1.8.1",
+        "scope": "required",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "c07c4472e75faa62d86bc8937cbf8eb993db059926be588158a21eccdde40fd6"
+          }
+        ],
+        "purl": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/spf13/cobra/@v/v1.8.1.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.15"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "false"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "golang.org/x/text",
+        "version": "v0.14.0",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "d7c64e4082a963c34956a624b0a1ed4dd8b7d47e62b45463079fea293358cd25"
+          }
+        ],
+        "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+        "type": "library",
+        "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/golang.org/x/text/@v/v0.14.0.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.18"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/gdamore/encoding",
+        "version": "v1.0.0",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "6a5474a25df8738f4509204b8e1a2cc7370f1d06dfdadac3928a39765f95ac48"
+          }
+        ],
+        "purl": "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/gdamore/encoding/@v/v1.0.0.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.9"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/gdamore/tcell/v2",
+        "version": "v2.7.1",
+        "scope": "required",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "7525ed5d348ad15b16d5b8b0eb90d92d9d8d2abee3d2a3ffd09ece366b2b6968"
+          }
+        ],
+        "purl": "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/gdamore/tcell/v2/@v/v2.7.1.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.12"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "false"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/lucasb-eyer/go-colorful",
+        "version": "v1.2.0",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "478752a2d391f4a32d6b2622d5eefb633baf78afa2eebbb3c86aadb629242f2d"
+          }
+        ],
+        "purl": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/lucasb-eyer/go-colorful/@v/v1.2.0.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.12"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/rivo/uniseg",
+        "version": "v0.4.7",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "14ddd2beb33e65d8f5ea3c8b7e63a430d6e55cc72873c0df4c7aee08f51cc7cf"
+          }
+        ],
+        "purl": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/rivo/uniseg/@v/v0.4.7.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.18"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/mattn/go-runewidth",
+        "version": "v0.0.15",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "25d7a98f6968ca2851ccca5d4b7e5793fcdd63c200607b21d79dea52819fdb7c"
+          }
+        ],
+        "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/mattn/go-runewidth/@v/v0.0.15.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.9"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "golang.org/x/sys",
+        "version": "v0.17.0",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "fd55217a989a24c414a78fa86bfed9af50f6de66ba5532c862338e4c564f51c0"
+          }
+        ],
+        "purl": "pkg:golang/golang.org/x/sys@v0.17.0",
+        "type": "library",
+        "bom-ref": "pkg:golang/golang.org/x/sys@v0.17.0",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/golang.org/x/sys/@v/v0.17.0.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.18"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "golang.org/x/term",
+        "version": "v0.17.0",
+        "scope": "optional",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "94b4418c856e7a149b66568eb4631b70c9dc4fe6aa2cb2e62abb2336b520bb09"
+          }
+        ],
+        "purl": "pkg:golang/golang.org/x/term@v0.17.0",
+        "type": "library",
+        "bom-ref": "pkg:golang/golang.org/x/term@v0.17.0",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/golang.org/x/term/@v/v0.17.0.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.18"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/rivo/tview",
+        "version": "v0.0.0-20240921122403-a64fc48d7654",
+        "scope": "required",
+        "hashes": [
+          {
+            "alg": "SHA-256",
+            "content": "d36885233ecafc0f63182beb8b32cfbe8aabe1c108c7bab9e111f942e764aecb"
+          }
+        ],
+        "purl": "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+        "properties": [
+          {
+            "name": "SrcGoMod",
+            "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/rivo/tview/@v/v0.0.0-20240921122403-a64fc48d7654.mod"
+          },
+          {
+            "name": "ModuleGoVersion",
+            "value": "1.18"
+          },
+          {
+            "name": "cdx:go:indirect",
+            "value": "false"
+          }
+        ]
+      },
+      {
+        "group": "",
+        "name": "github.com/viveksahu26/stree",
+        "version": "",
+        "purl": "pkg:golang/github.com/viveksahu26/stree",
+        "type": "library",
+        "bom-ref": "pkg:golang/github.com/viveksahu26/stree",
+        "evidence": {
+          "identity": {
+            "field": "purl",
+            "confidence": 1,
+            "methods": [
+              {
+                "technique": "manifest-analysis",
+                "confidence": 1,
+                "value": "/home/linuzz/go/src/github.com/viveksahu26/stree/go.mod"
+              }
+            ]
+          }
+        },
+        "properties": [
+          {
+            "name": "SrcFile",
+            "value": "/home/linuzz/go/src/github.com/viveksahu26/stree/go.mod"
+          }
+        ]
+      }
+    ],
+    "dependencies": [
+      {
+        "ref": "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+        "dependsOn": []
+      },
+      {
+        "ref": "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+        "dependsOn": [
+          "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+          "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+          "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+          "pkg:golang/golang.org/x/sys@v0.17.0",
+          "pkg:golang/golang.org/x/term@v0.17.0",
+          "pkg:golang/golang.org/x/text@v0.14.0"
+        ]
+      },
+      {
+        "ref": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+        "dependsOn": []
+      },
+      {
+        "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+        "dependsOn": []
+      },
+      {
+        "ref": "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+        "dependsOn": [
+          "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+          "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+          "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+          "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+          "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+          "pkg:golang/golang.org/x/sys@v0.17.0",
+          "pkg:golang/golang.org/x/term@v0.17.0",
+          "pkg:golang/golang.org/x/text@v0.14.0"
+        ]
+      },
+      {
+        "ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+        "dependsOn": []
+      },
+      {
+        "ref": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+        "dependsOn": [
+          "pkg:golang/github.com/spf13/pflag@v1.0.5"
+        ]
+      },
+      {
+        "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "dependsOn": []
+      },
+      {
+        "ref": "pkg:golang/github.com/viveksahu26/stree",
+        "dependsOn": [
+          "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+          "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+          "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+          "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+          "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+          "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+          "pkg:golang/github.com/spf13/cobra@v1.8.1",
+          "pkg:golang/github.com/spf13/pflag@v1.0.5",
+          "pkg:golang/golang.org/x/sys@v0.17.0",
+          "pkg:golang/golang.org/x/term@v0.17.0",
+          "pkg:golang/golang.org/x/text@v0.14.0"
+        ]
+      },
+      {
+        "ref": "pkg:golang/golang.org/x/sys@v0.17.0",
+        "dependsOn": []
+      },
+      {
+        "ref": "pkg:golang/golang.org/x/term@v0.17.0",
+        "dependsOn": [
+          "pkg:golang/golang.org/x/sys@v0.17.0"
+        ]
+      },
+      {
+        "ref": "pkg:golang/golang.org/x/text@v0.14.0",
+        "dependsOn": []
+      }
+    ],
+    "signature": {
+        "value": "bSg/KIeBdMDnMskQrMh2kDQXKTkP7/X65CAizpfCzljnQPDPn7TjyCK3r1RDw47RauWSU+jp/ZB6e2HirFtaM6ZbkDtXGD/GcwE+3g6ttKDJP67cdHKPZUhdDnd4Pa0bYurPXiADdrWDjrckTjPlpAPtrCmBgLpCVCC4y3EHsk0ikDsihOWxnq4wW1EQfIdWBeJlURGCPH5neW+qPMAMTks+DxRJVf97Q0dpNNn4J4ESObYrZRdC/0Ov5IfBwU9f3XNy9BZuZM1hbeKZlpFJuQ1ZtNARVFr7Gn29fA0eblOi+IJlHQldaAKsdNLXl7GISA8kKQXg+Btg8Cn0YpAVNQ==",
+        "publicKey": {
+            "kty": "RSA",
+            "n": "qcYF1QXF3oM/oD9Ct3daSAcFrQQThvvlts90vR25g/5F/6UanzW3FAC/Rd/1arAajja8IhlA9JnlGDqHME39U+dMi7jmWFl31sBTR+s8hYK7TmsREg/oXH6tuFJ28sMiBfGge0TvqmoydOmVAj0W8TJPWdJE/gfXbUNHmmpvPyUSRvzpO+2uqEoWv7X5d8NiC5PziZCrrAQaUbvOfGUoabtuuZDYSdyfHs783+seTxsUjf/p14T3vE10de99fT7uwbSRugfvDVqvTqD8pGYi2g/Efem+M+OUfJ3WN6xbTjQvhv878lsAv9wfvcxrcaNiggTiB5FwvreJLwWKkDz4fw==",
+            "e": "AQAB"
+        },
+        "algorithm": "RS256"
+    } 
+  }

--- a/samples/stree-cdxgen.cdx.json
+++ b/samples/stree-cdxgen.cdx.json
@@ -1,0 +1,486 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:de517446-d9eb-49d0-95fd-dd93c54a88d1",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-11-22T20:22:51Z",
+    "tools": {
+      "components": [
+        {
+          "group": "@cyclonedx",
+          "name": "cdxgen",
+          "version": "10.7.1",
+          "purl": "pkg:npm/%40cyclonedx/cdxgen@10.7.1",
+          "type": "application",
+          "bom-ref": "pkg:npm/@cyclonedx/cdxgen@10.7.1",
+          "author": "OWASP Foundation",
+          "publisher": "OWASP Foundation"
+        }
+      ]
+    },
+    "authors": [
+      {
+        "name": "OWASP Foundation"
+      }
+    ],
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
+    "component": {
+      "group": "",
+      "name": "github.com/viveksahu26/stree",
+      "version": "",
+      "purl": "pkg:golang/github.com/viveksahu26/stree",
+      "bom-ref": "pkg:golang/github.com/viveksahu26/stree",
+      "scope": "required",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/src/github.com/viveksahu26/stree/go.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.21.4"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "false"
+        }
+      ],
+      "type": "application"
+    }
+  },
+  "components": [
+    {
+      "group": "",
+      "name": "github.com/spf13/pflag",
+      "version": "v1.0.5",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "31c5df227251af3e026575593812dbd1b4d9a844e488084cf48c34cb7027d818"
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/spf13/pflag/@v/v1.0.5.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.12"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/spf13/cobra",
+      "version": "v1.8.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "c07c4472e75faa62d86bc8937cbf8eb993db059926be588158a21eccdde40fd6"
+        }
+      ],
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/spf13/cobra/@v/v1.8.1.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.15"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "false"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "golang.org/x/text",
+      "version": "v0.14.0",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d7c64e4082a963c34956a624b0a1ed4dd8b7d47e62b45463079fea293358cd25"
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/text@v0.14.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/golang.org/x/text/@v/v0.14.0.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.18"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/gdamore/encoding",
+      "version": "v1.0.0",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "6a5474a25df8738f4509204b8e1a2cc7370f1d06dfdadac3928a39765f95ac48"
+        }
+      ],
+      "purl": "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/gdamore/encoding/@v/v1.0.0.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.9"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/gdamore/tcell/v2",
+      "version": "v2.7.1",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "7525ed5d348ad15b16d5b8b0eb90d92d9d8d2abee3d2a3ffd09ece366b2b6968"
+        }
+      ],
+      "purl": "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/gdamore/tcell/v2/@v/v2.7.1.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.12"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "false"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/lucasb-eyer/go-colorful",
+      "version": "v1.2.0",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "478752a2d391f4a32d6b2622d5eefb633baf78afa2eebbb3c86aadb629242f2d"
+        }
+      ],
+      "purl": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/lucasb-eyer/go-colorful/@v/v1.2.0.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.12"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/rivo/uniseg",
+      "version": "v0.4.7",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "14ddd2beb33e65d8f5ea3c8b7e63a430d6e55cc72873c0df4c7aee08f51cc7cf"
+        }
+      ],
+      "purl": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/rivo/uniseg/@v/v0.4.7.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.18"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/mattn/go-runewidth",
+      "version": "v0.0.15",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "25d7a98f6968ca2851ccca5d4b7e5793fcdd63c200607b21d79dea52819fdb7c"
+        }
+      ],
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/mattn/go-runewidth/@v/v0.0.15.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.9"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "golang.org/x/sys",
+      "version": "v0.17.0",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "fd55217a989a24c414a78fa86bfed9af50f6de66ba5532c862338e4c564f51c0"
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/sys@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.17.0",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/golang.org/x/sys/@v/v0.17.0.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.18"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "golang.org/x/term",
+      "version": "v0.17.0",
+      "scope": "optional",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "94b4418c856e7a149b66568eb4631b70c9dc4fe6aa2cb2e62abb2336b520bb09"
+        }
+      ],
+      "purl": "pkg:golang/golang.org/x/term@v0.17.0",
+      "type": "library",
+      "bom-ref": "pkg:golang/golang.org/x/term@v0.17.0",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/golang.org/x/term/@v/v0.17.0.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.18"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "true"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/rivo/tview",
+      "version": "v0.0.0-20240921122403-a64fc48d7654",
+      "scope": "required",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "d36885233ecafc0f63182beb8b32cfbe8aabe1c108c7bab9e111f942e764aecb"
+        }
+      ],
+      "purl": "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+      "properties": [
+        {
+          "name": "SrcGoMod",
+          "value": "/home/linuzz/go/pkg/mod/cache/download/github.com/rivo/tview/@v/v0.0.0-20240921122403-a64fc48d7654.mod"
+        },
+        {
+          "name": "ModuleGoVersion",
+          "value": "1.18"
+        },
+        {
+          "name": "cdx:go:indirect",
+          "value": "false"
+        }
+      ]
+    },
+    {
+      "group": "",
+      "name": "github.com/viveksahu26/stree",
+      "version": "",
+      "purl": "pkg:golang/github.com/viveksahu26/stree",
+      "type": "library",
+      "bom-ref": "pkg:golang/github.com/viveksahu26/stree",
+      "evidence": {
+        "identity": {
+          "field": "purl",
+          "confidence": 1,
+          "methods": [
+            {
+              "technique": "manifest-analysis",
+              "confidence": 1,
+              "value": "/home/linuzz/go/src/github.com/viveksahu26/stree/go.mod"
+            }
+          ]
+        }
+      },
+      "properties": [
+        {
+          "name": "SrcFile",
+          "value": "/home/linuzz/go/src/github.com/viveksahu26/stree/go.mod"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+      "dependsOn": [
+        "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+        "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+        "pkg:golang/golang.org/x/sys@v0.17.0",
+        "pkg:golang/golang.org/x/term@v0.17.0",
+        "pkg:golang/golang.org/x/text@v0.14.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+      "dependsOn": [
+        "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+        "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+        "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+        "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+        "pkg:golang/golang.org/x/sys@v0.17.0",
+        "pkg:golang/golang.org/x/term@v0.17.0",
+        "pkg:golang/golang.org/x/text@v0.14.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+      "dependsOn": [
+        "pkg:golang/github.com/spf13/pflag@v1.0.5"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/github.com/viveksahu26/stree",
+      "dependsOn": [
+        "pkg:golang/github.com/gdamore/encoding@v1.0.0",
+        "pkg:golang/github.com/gdamore/tcell/v2@v2.7.1",
+        "pkg:golang/github.com/lucasb-eyer/go-colorful@v1.2.0",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.15",
+        "pkg:golang/github.com/rivo/tview@v0.0.0-20240921122403-a64fc48d7654",
+        "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+        "pkg:golang/github.com/spf13/cobra@v1.8.1",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "pkg:golang/golang.org/x/sys@v0.17.0",
+        "pkg:golang/golang.org/x/term@v0.17.0",
+        "pkg:golang/golang.org/x/text@v0.14.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/sys@v0.17.0",
+      "dependsOn": []
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/term@v0.17.0",
+      "dependsOn": [
+        "pkg:golang/golang.org/x/sys@v0.17.0"
+      ]
+    },
+    {
+      "ref": "pkg:golang/golang.org/x/text@v0.14.0",
+      "dependsOn": []
+    }
+  ]
+}


### PR DESCRIPTION

part of https://github.com/interlynk-io/sbomqs/issues/329

This PR add support for supporting BSI:2.0 sbom new fields such as signature. For now, it only supports signature provided externally. For example:

`go run main.go compliance --bsi-v2 SPDXJSONExample-v2.3.spdx.json --sig sbom.sig --pub public_key.pem`

TODO: Still working on signature attached with SBOM itself.