### PR TITLE
add vuln field and test example

### DIFF
--- a/pkg/compliance/bsi.go
+++ b/pkg/compliance/bsi.go
@@ -80,6 +80,7 @@ const (
 	PACK_INFO
 	SBOM_TYPE
 	PACK_EXT_REF
+	SBOM_VULNERABILITES
 )
 
 func bsiResult(ctx context.Context, doc sbom.Document, fileName string, outFormat string) {

--- a/pkg/compliance/bsiV2.go
+++ b/pkg/compliance/bsiV2.go
@@ -35,6 +35,7 @@ func bsiV2Result(ctx context.Context, doc sbom.Document, fileName string, outFor
 
 	dtb := db.NewDB()
 
+	dtb.AddRecord(bsiV2Vulnerabilities(doc))
 	dtb.AddRecord(bsiSpec(doc))
 	dtb.AddRecord(bsiV2SpecVersion(doc))
 	dtb.AddRecord(bsiBuildPhase(doc))
@@ -58,6 +59,21 @@ func bsiV2Result(ctx context.Context, doc sbom.Document, fileName string, outFor
 	if outFormat == "detailed" {
 		bsiV2DetailedReport(dtb, fileName)
 	}
+}
+
+func bsiV2Vulnerabilities(doc sbom.Document) *db.Record {
+	result, score := "no-vulnerability", 10.0
+
+	vuln := doc.Vulnerabilities()
+
+	if vuln != nil {
+		vulnId := vuln.GetID()
+		if vulnId != "" {
+			result = vulnId
+		}
+		score = 0.0
+	}
+	return db.NewRecordStmt(SBOM_VULNERABILITES, "doc", result, score, "")
 }
 
 func bsiV2SpecVersion(doc sbom.Document) *db.Record {

--- a/pkg/compliance/bsi_report.go
+++ b/pkg/compliance/bsi_report.go
@@ -45,6 +45,7 @@ var bsiSectionDetails = map[int]bsiSection{
 	COMP_DOWNLOAD_URL:    {Title: "Additional fields components", ID: "5.3.2", Required: false, DataField: "URI of the executable form of the component"},
 	COMP_SOURCE_HASH:     {Title: "Additional fields components", ID: "5.3.2", Required: false, DataField: "Hash value of the source code of the component"},
 	COMP_OTHER_UNIQ_IDS:  {Title: "Additional fields components", ID: "5.3.2", Required: false, DataField: "Other unique identifiers"},
+	SBOM_VULNERABILITES:  {Title: "Definition of SBOM", ID: "3.1", Required: true, DataField: "vuln"},
 }
 
 type run struct {

--- a/pkg/compliance/bsi_v2_report.go
+++ b/pkg/compliance/bsi_v2_report.go
@@ -23,17 +23,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-var bsiV2SectionDetails = map[int]bsiSection{
-	SBOM_VULNERABILITES: {Title: "Definition of SBOM", ID: "3.1", Required: true, DataField: "vuln"},
-	SBOM_SPEC:           {Title: "SBOM formats", ID: "4", Required: true, DataField: "specification"},
-	SBOM_SPEC_VERSION:   {Title: "SBOM formats", ID: "4", Required: true, DataField: "specification version"},
-	SBOM_BUILD:          {Title: "Level of Detail", ID: "5.1", Required: true, DataField: "build process"},
-	SBOM_DEPTH:          {Title: "Level of Detail", ID: "5.1", Required: true, DataField: "depth"},
-	SBOM_CREATOR:        {Title: "Required fields sboms ", ID: "5.2.1", Required: true, DataField: "creator of sbom"},
-	SBOM_TIMESTAMP:      {Title: "Required fields sboms", ID: "5.2.1", Required: true, DataField: "timestamp"},
-	SBOM_URI:            {Title: "Additional fields sboms", ID: "5.3.1", Required: false, DataField: "SBOM-URI"},
-}
-
 func bsiV2JSONReport(dtb *db.DB, fileName string) {
 	name := "BSI TR-03183-2 v2.0.0 Compliance Report"
 	revision := "TR-03183-2 (2.0.0)"

--- a/pkg/compliance/bsi_v2_report.go
+++ b/pkg/compliance/bsi_v2_report.go
@@ -24,13 +24,14 @@ import (
 )
 
 var bsiV2SectionDetails = map[int]bsiSection{
-	SBOM_SPEC:         {Title: "SBOM formats", ID: "4", Required: true, DataField: "specification"},
-	SBOM_SPEC_VERSION: {Title: "SBOM formats", ID: "4", Required: true, DataField: "specification version"},
-	SBOM_BUILD:        {Title: "Level of Detail", ID: "5.1", Required: true, DataField: "build process"},
-	SBOM_DEPTH:        {Title: "Level of Detail", ID: "5.1", Required: true, DataField: "depth"},
-	SBOM_CREATOR:      {Title: "Required fields sboms ", ID: "5.2.1", Required: true, DataField: "creator of sbom"},
-	SBOM_TIMESTAMP:    {Title: "Required fields sboms", ID: "5.2.1", Required: true, DataField: "timestamp"},
-	SBOM_URI:          {Title: "Additional fields sboms", ID: "5.3.1", Required: false, DataField: "SBOM-URI"},
+	SBOM_VULNERABILITES: {Title: "Definition of SBOM", ID: "3.1", Required: true, DataField: "vuln"},
+	SBOM_SPEC:           {Title: "SBOM formats", ID: "4", Required: true, DataField: "specification"},
+	SBOM_SPEC_VERSION:   {Title: "SBOM formats", ID: "4", Required: true, DataField: "specification version"},
+	SBOM_BUILD:          {Title: "Level of Detail", ID: "5.1", Required: true, DataField: "build process"},
+	SBOM_DEPTH:          {Title: "Level of Detail", ID: "5.1", Required: true, DataField: "depth"},
+	SBOM_CREATOR:        {Title: "Required fields sboms ", ID: "5.2.1", Required: true, DataField: "creator of sbom"},
+	SBOM_TIMESTAMP:      {Title: "Required fields sboms", ID: "5.2.1", Required: true, DataField: "timestamp"},
+	SBOM_URI:            {Title: "Additional fields sboms", ID: "5.3.1", Required: false, DataField: "SBOM-URI"},
 }
 
 func bsiV2JSONReport(dtb *db.DB, fileName string) {

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -55,6 +55,7 @@ type CdxDoc struct {
 	PrimaryComponent PrimaryComp
 	Dependencies     map[string][]string
 	composition      map[string]string
+	vuln             GetVulnerabilities
 }
 
 func newCDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat) (Document, error) {
@@ -142,6 +143,10 @@ func (c CdxDoc) GetComposition(componentID string) string {
 	return c.composition[componentID]
 }
 
+func (s CdxDoc) Vulnerabilities() GetVulnerabilities {
+	return s.vuln
+}
+
 func (c *CdxDoc) parse() {
 	c.parseDoc()
 	c.parseSpec()
@@ -151,6 +156,7 @@ func (c *CdxDoc) parse() {
 	c.parseTool()
 	c.parseCompositions()
 	c.parsePrimaryCompAndRelationships()
+	c.parseVulnerabilities()
 	c.parseComps()
 }
 
@@ -208,6 +214,16 @@ func (c *CdxDoc) parseSpec() {
 	}
 
 	c.CdxSpec = sp
+}
+
+func (c *CdxDoc) parseVulnerabilities() {
+	vuln := Vulnerability{}
+	for _, v := range *c.doc.Vulnerabilities {
+		if v.ID != "" {
+			vuln.Id = v.ID
+		}
+	}
+	c.vuln = vuln
 }
 
 func (c *CdxDoc) requiredFields() bool {

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -154,7 +154,7 @@ func (s SpdxDoc) GetComposition(componentID string) string {
 }
 
 func (s SpdxDoc) Vulnerabilities() GetVulnerabilities {
-	return nil
+	return s.vuln
 }
 
 func (s *SpdxDoc) parse() {
@@ -214,6 +214,7 @@ func (s *SpdxDoc) parseSpec() {
 	if s.doc.DocumentNamespace != "" {
 		sp.uri = s.doc.DocumentNamespace
 	}
+	s.vuln = nil
 
 	s.SpdxSpec = sp
 }

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -57,6 +57,7 @@ type SpdxDoc struct {
 	Lifecycle        string
 	Dependencies     map[string][]string
 	composition      map[string]string
+	vuln             GetVulnerabilities
 }
 
 func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version FormatVersion) (Document, error) {
@@ -150,6 +151,10 @@ func CleanKey(key string) string {
 
 func (s SpdxDoc) GetComposition(componentID string) string {
 	return s.composition[componentID]
+}
+
+func (s SpdxDoc) Vulnerabilities() GetVulnerabilities {
+	return nil
 }
 
 func (s *SpdxDoc) parse() {

--- a/pkg/sbom/vulnerabilities.go
+++ b/pkg/sbom/vulnerabilities.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Interlynk.io
+// Copyright 2024 Interlynk.io
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
 
 package sbom
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+type GetVulnerabilities interface {
+	GetID() string
+}
 
-//counterfeiter:generate . Document
-type Document interface {
-	Spec() Spec
-	Components() []GetComponent
-	Relations() []GetRelation
-	Authors() []GetAuthor
-	Tools() []GetTool
-	Logs() []string
+type Vulnerability struct {
+	Id string
+}
 
-	Lifecycles() []string
-	Manufacturer() Manufacturer
-	Supplier() GetSupplier
-
-	PrimaryComp() GetPrimaryComp
-	GetRelationships(string) []string
-
-	Vulnerabilities() GetVulnerabilities
+func (v Vulnerability) GetID() string {
+	return v.Id
 }

--- a/samples/sbomqs-sbomsh-with-vuln.cdx.json
+++ b/samples/sbomqs-sbomsh-with-vuln.cdx.json
@@ -1,0 +1,868 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:bc16861a-b088-4ebc-a064-0413af2512d8",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-11-25T07:03:07Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "author": "anchore",
+          "name": "grype",
+          "version": "0.85.0"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.9.1?package-id=95415202b9cc044d",
+      "type": "library",
+      "name": "github.com/CycloneDX/cyclonedx-go",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/dependencytrack/client-go@v0.13.0?package-id=8fc694278d7f1d70",
+      "type": "library",
+      "name": "github.com/DependencyTrack/client-go",
+      "version": "v0.13.0",
+      "purl": "pkg:golang/github.com/dependencytrack/client-go@v0.13.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/masterminds/semver/v3@v3.3.0?package-id=ac3afaf9b18898cc",
+      "type": "library",
+      "name": "github.com/Masterminds/semver/v3",
+      "version": "v3.3.0",
+      "purl": "pkg:golang/github.com/masterminds/semver/v3@v3.3.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/protonmail/go-crypto@v1.0.0?package-id=cd70701391522794",
+      "type": "library",
+      "name": "github.com/ProtonMail/go-crypto",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/protonmail/go-crypto@v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20240925125616-a0883641c664?package-id=40254925dd04380c",
+      "type": "library",
+      "name": "github.com/anchore/go-struct-converter",
+      "version": "v0.0.0-20240925125616-a0883641c664",
+      "purl": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20240925125616-a0883641c664",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/cloudflare/circl@v1.5.0?package-id=869b5b22bc3adc41",
+      "type": "library",
+      "name": "github.com/cloudflare/circl",
+      "version": "v1.5.0",
+      "purl": "pkg:golang/github.com/cloudflare/circl@v1.5.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be?package-id=947709cfb5967325",
+      "type": "library",
+      "name": "github.com/common-nighthawk/go-figure",
+      "version": "v0.0.0-20210622060536-734e95fb86be",
+      "purl": "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=ea8047544d96bcce",
+      "type": "library",
+      "name": "github.com/davecgh/go-spew",
+      "version": "v1.1.1",
+      "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/github/go-spdx/v2@v2.3.2?package-id=0ea5596b14c892af",
+      "type": "library",
+      "name": "github.com/github/go-spdx/v2",
+      "version": "v2.3.2",
+      "purl": "pkg:golang/github.com/github/go-spdx/v2@v2.3.2",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.0?package-id=6b1696dac9e32c74",
+      "type": "library",
+      "name": "github.com/go-git/go-billy/v5",
+      "version": "v5.6.0",
+      "purl": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=a1bd766d2d911044",
+      "type": "library",
+      "name": "github.com/google/go-cmp",
+      "version": "v0.6.0",
+      "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/go-github/v52@v52.0.0?package-id=5b00e7ffb17032b5",
+      "type": "library",
+      "name": "github.com/google/go-github/v52",
+      "version": "v52.0.0",
+      "purl": "pkg:golang/github.com/google/go-github/v52@v52.0.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/go-querystring@v1.1.0?package-id=152691471c044e6c",
+      "type": "library",
+      "name": "github.com/google/go-querystring",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/google/go-querystring@v1.1.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/google/uuid@v1.6.0?package-id=079deca07b70be85",
+      "type": "library",
+      "name": "github.com/google/uuid",
+      "version": "v1.6.0",
+      "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=9563fe5b93a0d706",
+      "type": "library",
+      "name": "github.com/inconshreveable/mousetrap",
+      "version": "v1.1.0",
+      "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/interlynk-io/sbomqs?package-id=097e6c76604d3b23",
+      "type": "library",
+      "name": "github.com/interlynk-io/sbomqs",
+      "purl": "pkg:golang/github.com/interlynk-io/sbomqs",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.16?package-id=694d26beb86478f7",
+      "type": "library",
+      "name": "github.com/mattn/go-runewidth",
+      "version": "v0.0.16",
+      "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.16",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@v6.10.0?package-id=966dd3622f1f82bc",
+      "type": "library",
+      "name": "github.com/maxbrunsfeld/counterfeiter/v6",
+      "version": "v6.10.0",
+      "purl": "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@v6.10.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5?package-id=50dc607bdb9392c4",
+      "type": "library",
+      "name": "github.com/olekukonko/tablewriter",
+      "version": "v0.0.5",
+      "purl": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/package-url/packageurl-go@v0.1.3?package-id=004f6c313a59175a",
+      "type": "library",
+      "name": "github.com/package-url/packageurl-go",
+      "version": "v0.1.3",
+      "purl": "pkg:golang/github.com/package-url/packageurl-go@v0.1.3",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=a11cf811149af8d8",
+      "type": "library",
+      "name": "github.com/pkg/errors",
+      "version": "v0.9.1",
+      "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=c2adba4e6eb8b5e7",
+      "type": "library",
+      "name": "github.com/pmezard/go-difflib",
+      "version": "v1.0.0",
+      "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7?package-id=6d9463950131a9b6",
+      "type": "library",
+      "name": "github.com/rivo/uniseg",
+      "version": "v0.4.7",
+      "purl": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/samber/lo@v1.47.0?package-id=d097aae0ee310194",
+      "type": "library",
+      "name": "github.com/samber/lo",
+      "version": "v1.47.0",
+      "purl": "pkg:golang/github.com/samber/lo@v1.47.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spdx/gordf@v0.0.0-20221230105357-b735bd5aac89?package-id=77f7116c9b4b4dde",
+      "type": "library",
+      "name": "github.com/spdx/gordf",
+      "version": "v0.0.0-20221230105357-b735bd5aac89",
+      "purl": "pkg:golang/github.com/spdx/gordf@v0.0.0-20221230105357-b735bd5aac89",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spdx/tools-golang@v0.5.5?package-id=feab36953b593772",
+      "type": "library",
+      "name": "github.com/spdx/tools-golang",
+      "version": "v0.5.5",
+      "purl": "pkg:golang/github.com/spdx/tools-golang@v0.5.5",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/afero@v1.11.0?package-id=a1ebc9cac39f29ef",
+      "type": "library",
+      "name": "github.com/spf13/afero",
+      "version": "v1.11.0",
+      "purl": "pkg:golang/github.com/spf13/afero@v1.11.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.1?package-id=7888d9b1495bfbd6",
+      "type": "library",
+      "name": "github.com/spf13/cobra",
+      "version": "v1.8.1",
+      "purl": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=7cde04e1bd087b20",
+      "type": "library",
+      "name": "github.com/spf13/pflag",
+      "version": "v1.0.5",
+      "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.9.0?package-id=f1059c805906e814",
+      "type": "library",
+      "name": "github.com/stretchr/testify",
+      "version": "v1.9.0",
+      "purl": "pkg:golang/github.com/stretchr/testify@v1.9.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "4bbe8b86398bfa32",
+      "type": "library",
+      "name": "go.mod",
+      "properties": [
+        {
+          "name": "syft:package:type",
+          "value": "UnknownPackage"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/go.uber.org/multierr@v1.11.0?package-id=3750230adfb64ef6",
+      "type": "library",
+      "name": "go.uber.org/multierr",
+      "version": "v1.11.0",
+      "purl": "pkg:golang/go.uber.org/multierr@v1.11.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/go.uber.org/zap@v1.27.0?package-id=e49dc9516951a21e",
+      "type": "library",
+      "name": "go.uber.org/zap",
+      "version": "v1.27.0",
+      "purl": "pkg:golang/go.uber.org/zap@v1.27.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/crypto@v0.28.0?package-id=ba759510f05c62f3",
+      "type": "library",
+      "name": "golang.org/x/crypto",
+      "version": "v0.28.0",
+      "purl": "pkg:golang/golang.org/x/crypto@v0.28.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/mod@v0.21.0?package-id=b5c721159440ecfb",
+      "type": "library",
+      "name": "golang.org/x/mod",
+      "version": "v0.21.0",
+      "purl": "pkg:golang/golang.org/x/mod@v0.21.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.23.0?package-id=b0407144c2f61d0f",
+      "type": "library",
+      "name": "golang.org/x/oauth2",
+      "version": "v0.23.0",
+      "purl": "pkg:golang/golang.org/x/oauth2@v0.23.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sync@v0.8.0?package-id=e515bd01476d778f",
+      "type": "library",
+      "name": "golang.org/x/sync",
+      "version": "v0.8.0",
+      "purl": "pkg:golang/golang.org/x/sync@v0.8.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/sys@v0.26.0?package-id=e6af8a9f9e82414b",
+      "type": "library",
+      "name": "golang.org/x/sys",
+      "version": "v0.26.0",
+      "purl": "pkg:golang/golang.org/x/sys@v0.26.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/text@v0.19.0?package-id=d5e54260dfef41dd",
+      "type": "library",
+      "name": "golang.org/x/text",
+      "version": "v0.19.0",
+      "purl": "pkg:golang/golang.org/x/text@v0.19.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/golang.org/x/tools@v0.26.0?package-id=0cbc583ac40e93ab",
+      "type": "library",
+      "name": "golang.org/x/tools",
+      "version": "v0.26.0",
+      "purl": "pkg:golang/golang.org/x/tools@v0.26.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=50abb98b40862924",
+      "type": "library",
+      "name": "gopkg.in/yaml.v2",
+      "version": "v2.4.0",
+      "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=6642390315db61c4",
+      "type": "library",
+      "name": "gopkg.in/yaml.v3",
+      "version": "v3.0.1",
+      "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/gotest.tools@v2.2.0%2Bincompatible?package-id=b31e43068a759fe6",
+      "type": "library",
+      "name": "gotest.tools",
+      "version": "v2.2.0+incompatible",
+      "purl": "pkg:golang/gotest.tools@v2.2.0%2Bincompatible",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "97edb9434748e34d",
+      "type": "library",
+      "name": "https://github.com/interlynk-io/sbomqs",
+      "properties": [
+        {
+          "name": "syft:package:type",
+          "value": "UnknownPackage"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/sigs.k8s.io/release-utils@v0.8.5?package-id=67644dd65bd152ae",
+      "type": "library",
+      "name": "sigs.k8s.io/release-utils",
+      "version": "v0.8.5",
+      "purl": "pkg:golang/sigs.k8s.io/release-utils@v0.8.5",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=66d65d40366d1944",
+      "type": "library",
+      "name": "sigs.k8s.io/yaml",
+      "version": "v1.4.0",
+      "purl": "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+      "properties": [
+        {
+          "name": "syft:package:language",
+          "value": "go"
+        },
+        {
+          "name": "syft:package:type",
+          "value": "go-module"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "4bbe8b86398bfa32",
+      "dependsOn": [
+        "pkg:golang/github.com/interlynk-io/sbomqs?package-id=097e6c76604d3b23"
+      ]
+    },
+    {
+      "ref": "97edb9434748e34d",
+      "dependsOn": [
+        "4bbe8b86398bfa32"
+      ]
+    },
+    {
+      "ref": "pkg:golang/github.com/interlynk-io/sbomqs?package-id=097e6c76604d3b23",
+      "dependsOn": [
+        "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20240925125616-a0883641c664?package-id=40254925dd04380c",
+        "pkg:golang/github.com/cloudflare/circl@v1.5.0?package-id=869b5b22bc3adc41",
+        "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be?package-id=947709cfb5967325",
+        "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.9.1?package-id=95415202b9cc044d",
+        "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=ea8047544d96bcce",
+        "pkg:golang/github.com/dependencytrack/client-go@v0.13.0?package-id=8fc694278d7f1d70",
+        "pkg:golang/github.com/github/go-spdx/v2@v2.3.2?package-id=0ea5596b14c892af",
+        "pkg:golang/github.com/go-git/go-billy/v5@v5.6.0?package-id=6b1696dac9e32c74",
+        "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=a1bd766d2d911044",
+        "pkg:golang/github.com/google/go-github/v52@v52.0.0?package-id=5b00e7ffb17032b5",
+        "pkg:golang/github.com/google/go-querystring@v1.1.0?package-id=152691471c044e6c",
+        "pkg:golang/github.com/google/uuid@v1.6.0?package-id=079deca07b70be85",
+        "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=9563fe5b93a0d706",
+        "pkg:golang/github.com/masterminds/semver/v3@v3.3.0?package-id=ac3afaf9b18898cc",
+        "pkg:golang/github.com/mattn/go-runewidth@v0.0.16?package-id=694d26beb86478f7",
+        "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@v6.10.0?package-id=966dd3622f1f82bc",
+        "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5?package-id=50dc607bdb9392c4",
+        "pkg:golang/github.com/package-url/packageurl-go@v0.1.3?package-id=004f6c313a59175a",
+        "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=a11cf811149af8d8",
+        "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=c2adba4e6eb8b5e7",
+        "pkg:golang/github.com/protonmail/go-crypto@v1.0.0?package-id=cd70701391522794",
+        "pkg:golang/github.com/rivo/uniseg@v0.4.7?package-id=6d9463950131a9b6",
+        "pkg:golang/github.com/samber/lo@v1.47.0?package-id=d097aae0ee310194",
+        "pkg:golang/github.com/spdx/gordf@v0.0.0-20221230105357-b735bd5aac89?package-id=77f7116c9b4b4dde",
+        "pkg:golang/github.com/spdx/tools-golang@v0.5.5?package-id=feab36953b593772",
+        "pkg:golang/github.com/spf13/afero@v1.11.0?package-id=a1ebc9cac39f29ef",
+        "pkg:golang/github.com/spf13/cobra@v1.8.1?package-id=7888d9b1495bfbd6",
+        "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=7cde04e1bd087b20",
+        "pkg:golang/github.com/stretchr/testify@v1.9.0?package-id=f1059c805906e814",
+        "pkg:golang/go.uber.org/multierr@v1.11.0?package-id=3750230adfb64ef6",
+        "pkg:golang/go.uber.org/zap@v1.27.0?package-id=e49dc9516951a21e",
+        "pkg:golang/golang.org/x/crypto@v0.28.0?package-id=ba759510f05c62f3",
+        "pkg:golang/golang.org/x/mod@v0.21.0?package-id=b5c721159440ecfb",
+        "pkg:golang/golang.org/x/oauth2@v0.23.0?package-id=b0407144c2f61d0f",
+        "pkg:golang/golang.org/x/sync@v0.8.0?package-id=e515bd01476d778f",
+        "pkg:golang/golang.org/x/sys@v0.26.0?package-id=e6af8a9f9e82414b",
+        "pkg:golang/golang.org/x/text@v0.19.0?package-id=d5e54260dfef41dd",
+        "pkg:golang/golang.org/x/tools@v0.26.0?package-id=0cbc583ac40e93ab",
+        "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=50abb98b40862924",
+        "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=6642390315db61c4",
+        "pkg:golang/gotest.tools@v2.2.0%2Bincompatible?package-id=b31e43068a759fe6",
+        "pkg:golang/sigs.k8s.io/release-utils@v0.8.5?package-id=67644dd65bd152ae",
+        "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=66d65d40366d1944"
+      ]
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "id": "CVE-2018-7489",
+      "description": "testing purpose",
+      "created": "2021-01-01T00:00:00.000Z",
+      "published": "2021-01-01T00:00:00.000Z",
+      "updated": "2021-01-01T00:00:00.000Z",
+      "analysis": {
+        "state": "not_affected",
+        "justification": "code_not_reachable",
+        "response": ["will_not_fix", "update"],
+        "detail": "An optional explanation of why the application is not affected by the vulnerable component."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
part of #329 

This PR adds `vuln` field of BSI:2.0. This is how it works:
- If vulnerability is present in CDX, then score 0.0, else 10.0
- For SPDX, score 10.0, as no vulnerability field for SPDX, therefore no vulnerability.

See below:
![image](https://github.com/user-attachments/assets/d9145766-7259-444e-a623-6d9ba6c15e52)
