### PR TITLE
Feat/bsi2:  add bomlinks for BSI:2.0

### DIFF
--- a/pkg/compliance/bsi.go
+++ b/pkg/compliance/bsi.go
@@ -81,6 +81,7 @@ const (
 	SBOM_TYPE
 	PACK_EXT_REF
 	SBOM_VULNERABILITES
+	SBOM_BOM_LINKS
 )
 
 func bsiResult(ctx context.Context, doc sbom.Document, fileName string, outFormat string, colorOutput bool) {

--- a/pkg/compliance/bsiV2.go
+++ b/pkg/compliance/bsiV2.go
@@ -70,6 +70,8 @@ func bsiV2SbomLinks(doc sbom.Document) *db.Record {
 		result = strings.Join(bom, ", ")
 		score = 10.0
 	}
+	wrappedURL := common.WrapText(result, 80)
+	result = wrappedURL
 
 	return db.NewRecordStmt(SBOM_BOM_LINKS, "doc", result, score, "")
 }

--- a/pkg/compliance/bsiV2.go
+++ b/pkg/compliance/bsiV2.go
@@ -44,10 +44,10 @@ func bsiV2Result(ctx context.Context, doc sbom.Document, fileName string, outFor
 	dtb.AddRecord(bsiCreator(doc))
 	dtb.AddRecord(bsiTimestamp(doc))
 	dtb.AddRecord(bsiSbomURI(doc))
+	dtb.AddRecord(bsiV2SbomLinks(doc))
 	dtb.AddRecords(bsiV2Components(doc))
 	// New SBOM fields
 	// dtb.AddRecord(bsiSbomSignature(doc))
-	// dtb.AddRecord(bsiSbomLinks(doc))
 
 	if outFormat == "json" {
 		bsiV2JSONReport(dtb, fileName)
@@ -60,6 +60,18 @@ func bsiV2Result(ctx context.Context, doc sbom.Document, fileName string, outFor
 	if outFormat == "detailed" {
 		bsiV2DetailedReport(dtb, fileName)
 	}
+}
+
+func bsiV2SbomLinks(doc sbom.Document) *db.Record {
+	result, score := "", 0.0
+
+	bom := doc.Spec().GetExtDocRef()
+	if bom != nil {
+		result = strings.Join(bom, ", ")
+		score = 10.0
+	}
+
+	return db.NewRecordStmt(SBOM_BOM_LINKS, "doc", result, score, "")
 }
 
 func bsiV2Vulnerabilities(doc sbom.Document) *db.Record {

--- a/pkg/compliance/bsiV2_test.go
+++ b/pkg/compliance/bsiV2_test.go
@@ -3,6 +3,7 @@ package compliance
 import (
 	"testing"
 
+	"github.com/interlynk-io/sbomqs/pkg/compliance/common"
 	db "github.com/interlynk-io/sbomqs/pkg/compliance/db"
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 	"gotest.tools/assert"
@@ -105,6 +106,165 @@ func TestBSIV2CDXSbomVulnerability(t *testing.T) {
 				score:  0.0,
 				result: "CVE-2018-7489, CVE-2021-44228",
 				key:    SBOM_VULNERABILITES,
+				id:     "doc",
+			},
+		},
+	}
+	for _, test := range testCases {
+		assert.Equal(t, test.expected.score, test.actual.Score, "Score mismatch for %s", test.name)
+		assert.Equal(t, test.expected.key, test.actual.CheckKey, "Key mismatch for %s", test.name)
+		assert.Equal(t, test.expected.id, test.actual.ID, "ID mismatch for %s", test.name)
+		assert.Equal(t, test.expected.result, test.actual.CheckValue, "Result mismatch for %s", test.name)
+	}
+}
+
+func spdxDocWithNoExtDocumentRefs() sbom.Document {
+	s := sbom.NewSpec()
+
+	s.ExternalDocReference = nil
+	doc := sbom.SpdxDoc{
+		SpdxSpec: s,
+	}
+	return doc
+}
+
+func spdxDocWithOneExtDocumentRefs() sbom.Document {
+	s := sbom.NewSpec()
+	spdxDocument := []string{"https://example.com/spdx/docs/toolsetX-v1.2"}
+	s.ExternalDocReference = spdxDocument
+	doc := sbom.SpdxDoc{
+		SpdxSpec: s,
+	}
+	return doc
+}
+
+func spdxDocWithMultipleExtDocumentRefs() sbom.Document {
+	s := sbom.NewSpec()
+	spdxDocument := []string{"https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg", "https://example.com/spdx/docs/toolsetX-v1.2"}
+	s.ExternalDocReference = spdxDocument
+	doc := sbom.SpdxDoc{
+		SpdxSpec: s,
+	}
+	return doc
+}
+
+func TestBSIV2SPDXSbomBomLinks(t *testing.T) {
+	value := "https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg, https://example.com/spdx/docs/toolsetX-v1.2"
+	wrappedURL := common.WrapText(value, 80)
+
+	testCases := []struct {
+		name     string
+		actual   *db.Record
+		expected desired
+	}{
+		{
+			name:   "SPDX SBOM with no bom links",
+			actual: bsiV2SbomLinks(spdxDocWithNoExtDocumentRefs()),
+			expected: desired{
+				score:  0.0,
+				result: "",
+				key:    SBOM_BOM_LINKS,
+				id:     "doc",
+			},
+		},
+		{
+			name:   "SPDX SBOM with one bom links",
+			actual: bsiV2SbomLinks(spdxDocWithOneExtDocumentRefs()),
+			expected: desired{
+				score:  10.0,
+				result: "https://example.com/spdx/docs/toolsetX-v1.2",
+				key:    SBOM_BOM_LINKS,
+				id:     "doc",
+			},
+		},
+		{
+			name:   "SPDX SBOM with two bom links vulnerability",
+			actual: bsiV2SbomLinks(spdxDocWithMultipleExtDocumentRefs()),
+			expected: desired{
+				score:  10.0,
+				result: wrappedURL,
+				key:    SBOM_BOM_LINKS,
+				id:     "doc",
+			},
+		},
+	}
+	for _, test := range testCases {
+		assert.Equal(t, test.expected.score, test.actual.Score, "Score mismatch for %s", test.name)
+		assert.Equal(t, test.expected.key, test.actual.CheckKey, "Key mismatch for %s", test.name)
+		assert.Equal(t, test.expected.id, test.actual.ID, "ID mismatch for %s", test.name)
+		assert.Equal(t, test.expected.result, test.actual.CheckValue, "Result mismatch for %s", test.name)
+	}
+}
+
+func cdxDocWithNoExtDocumentRefs() sbom.Document {
+	s := sbom.NewSpec()
+
+	s.ExternalDocReference = nil
+	doc := sbom.CdxDoc{
+		CdxSpec: s,
+	}
+	return doc
+}
+
+func cxDocWithOneExtDocumentRefs() sbom.Document {
+	s := sbom.NewSpec()
+	extRefs := []string{"https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/app/bomctl_0.3.0_linux_amd64.tar.gz.spdx.json"}
+	s.ExternalDocReference = extRefs
+	doc := sbom.SpdxDoc{
+		SpdxSpec: s,
+	}
+	return doc
+}
+
+func cxDocWithMultipleExtDocumentRefs() sbom.Document {
+	s := sbom.NewSpec()
+	extRefs := []string{"https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/app/bomctl_0.3.0_linux_amd64.tar.gz.spdx.json", "https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg"}
+	s.ExternalDocReference = extRefs
+	doc := sbom.SpdxDoc{
+		SpdxSpec: s,
+	}
+	return doc
+}
+
+func TestBSIV2CDXSbomBomLinks(t *testing.T) {
+	value := "https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/app/bomctl_0.3.0_linux_amd64.tar.gz.spdx.json"
+	wrappedURL := common.WrapText(value, 80)
+
+	value2 := "https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/app/bomctl_0.3.0_linux_amd64.tar.gz.spdx.json, https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg"
+	wrappedURL2 := common.WrapText(value2, 80)
+
+	testCases := []struct {
+		name     string
+		actual   *db.Record
+		expected desired
+	}{
+		{
+			name:   "CDX SBOM with no bom links",
+			actual: bsiV2SbomLinks(cdxDocWithNoExtDocumentRefs()),
+			expected: desired{
+				score:  0.0,
+				result: "",
+				key:    SBOM_BOM_LINKS,
+				id:     "doc",
+			},
+		},
+		{
+			name:   "CDX SBOM with one bom links",
+			actual: bsiV2SbomLinks(cxDocWithOneExtDocumentRefs()),
+			expected: desired{
+				score:  10.0,
+				result: wrappedURL,
+				key:    SBOM_BOM_LINKS,
+				id:     "doc",
+			},
+		},
+		{
+			name:   "CDX SBOM with one bom links",
+			actual: bsiV2SbomLinks(cxDocWithMultipleExtDocumentRefs()),
+			expected: desired{
+				score:  10.0,
+				result: wrappedURL2,
+				key:    SBOM_BOM_LINKS,
 				id:     "doc",
 			},
 		},

--- a/pkg/compliance/bsi_report.go
+++ b/pkg/compliance/bsi_report.go
@@ -47,6 +47,7 @@ var bsiSectionDetails = map[int]bsiSection{
 	COMP_SOURCE_HASH:     {Title: "Additional fields components", ID: "5.3.2", Required: false, DataField: "Hash value of the source code of the component"},
 	COMP_OTHER_UNIQ_IDS:  {Title: "Additional fields components", ID: "5.3.2", Required: false, DataField: "Other unique identifiers"},
 	SBOM_VULNERABILITES:  {Title: "Definition of SBOM", ID: "3.1", Required: true, DataField: "vuln"},
+	SBOM_BOM_LINKS:       {Title: "Optional SBOM fields", ID: "8.1.12", Required: false, DataField: "bomlinks"},
 }
 
 type run struct {

--- a/pkg/compliance/common/common.go
+++ b/pkg/compliance/common/common.go
@@ -448,3 +448,17 @@ func GetScoreColor(score float64) tablewriter.Colors {
 	}
 	return tablewriter.Colors{tablewriter.FgGreenColor, tablewriter.Bold}
 }
+
+func WrapText(input string, maxWidth int) string {
+	var result []string
+	for len(input) > maxWidth {
+		splitPoint := strings.LastIndex(input[:maxWidth], "/")
+		if splitPoint == -1 {
+			splitPoint = maxWidth
+		}
+		result = append(result, input[:splitPoint])
+		input = input[splitPoint:]
+	}
+	result = append(result, input)
+	return strings.Join(result, "\n")
+}

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -213,6 +213,14 @@ func (c *CdxDoc) parseSpec() {
 		sp.Uri = fmt.Sprintf("%s/%d", c.doc.SerialNumber, c.doc.Version)
 	}
 
+	if c.doc.ExternalReferences != nil {
+		for _, extRefs := range *c.doc.ExternalReferences {
+			if extRefs.Type == "bom" {
+				sp.ExternalDocReference = append(sp.ExternalDocReference, extRefs.URL)
+			}
+		}
+	}
+
 	c.CdxSpec = sp
 }
 

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -199,7 +199,7 @@ func (s *SpdxDoc) parseSpec() {
 
 	if s.doc.ExternalDocumentReferences != nil {
 		for _, bom := range s.doc.ExternalDocumentReferences {
-			sp.ExternalDocReference = append(sp.ExternalDocReference, bom.DocumentRefID)
+			sp.ExternalDocReference = append(sp.ExternalDocReference, bom.URI)
 		}
 	}
 

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -197,6 +197,12 @@ func (s *SpdxDoc) parseSpec() {
 	sp.SpecType = string(SBOMSpecSPDX)
 	sp.Name = s.doc.DocumentName
 
+	if s.doc.ExternalDocumentReferences != nil {
+		for _, bom := range s.doc.ExternalDocumentReferences {
+			sp.ExternalDocReference = append(sp.ExternalDocReference, bom.DocumentRefID)
+		}
+	}
+
 	sp.isReqFieldsPresent = s.requiredFields()
 
 	if s.doc.CreationInfo != nil {

--- a/pkg/sbom/spec.go
+++ b/pkg/sbom/spec.go
@@ -32,21 +32,23 @@ type Spec interface {
 	GetOrganization() string
 	GetComment() string
 	GetSpdxID() string
+	GetExtDocRef() []string
 }
 
 type Specs struct {
-	Version            string
-	Format             string
-	SpecType           string
-	Name               string
-	isReqFieldsPresent bool
-	Licenses           []licenses.License
-	CreationTimestamp  string
-	Namespace          string
-	Uri                string
-	Organization       string
-	Comment            string
-	Spdxid             string
+	Version              string
+	Format               string
+	SpecType             string
+	Name                 string
+	isReqFieldsPresent   bool
+	Licenses             []licenses.License
+	CreationTimestamp    string
+	Namespace            string
+	Uri                  string
+	Organization         string
+	Comment              string
+	Spdxid               string
+	ExternalDocReference []string
 }
 
 func NewSpec() *Specs {
@@ -103,4 +105,8 @@ func (s Specs) GetNamespace() string {
 
 func (s Specs) URI() string {
 	return s.Uri
+}
+
+func (s Specs) GetExtDocRef() []string {
+	return s.ExternalDocReference
 }

--- a/samples/sbomqs-dummy-bomlinks-data.cdx.json
+++ b/samples/sbomqs-dummy-bomlinks-data.cdx.json
@@ -870,6 +870,11 @@
       "type": "bom",
       "url" : "https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/app/bomctl_0.3.0_linux_amd64.tar.gz.spdx.json",
       "comment": "This is a reference to an external SBOM for a related component for testing purpose."
+    },
+    {
+      "type": "bom",
+      "url" : "https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg",
+      "comment": "This is a reference to an external SBOM for a related component for testing purpose."
     }
   ]
   }

--- a/samples/sbomqs-dummy-bomlinks-data.cdx.json
+++ b/samples/sbomqs-dummy-bomlinks-data.cdx.json
@@ -1,0 +1,876 @@
+{
+    "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "serialNumber": "urn:uuid:bc16861a-b088-4ebc-a064-0413af2512d8",
+    "version": 1,
+    "metadata": {
+      "timestamp": "2024-11-25T07:03:07Z",
+      "tools": {
+        "components": [
+          {
+            "type": "application",
+            "author": "anchore",
+            "name": "grype",
+            "version": "0.85.0"
+          }
+        ]
+      }
+    },
+    "components": [
+      {
+        "bom-ref": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.9.1?package-id=95415202b9cc044d",
+        "type": "library",
+        "name": "github.com/CycloneDX/cyclonedx-go",
+        "version": "v0.9.1",
+        "purl": "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.9.1",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/dependencytrack/client-go@v0.13.0?package-id=8fc694278d7f1d70",
+        "type": "library",
+        "name": "github.com/DependencyTrack/client-go",
+        "version": "v0.13.0",
+        "purl": "pkg:golang/github.com/dependencytrack/client-go@v0.13.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/masterminds/semver/v3@v3.3.0?package-id=ac3afaf9b18898cc",
+        "type": "library",
+        "name": "github.com/Masterminds/semver/v3",
+        "version": "v3.3.0",
+        "purl": "pkg:golang/github.com/masterminds/semver/v3@v3.3.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/protonmail/go-crypto@v1.0.0?package-id=cd70701391522794",
+        "type": "library",
+        "name": "github.com/ProtonMail/go-crypto",
+        "version": "v1.0.0",
+        "purl": "pkg:golang/github.com/protonmail/go-crypto@v1.0.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20240925125616-a0883641c664?package-id=40254925dd04380c",
+        "type": "library",
+        "name": "github.com/anchore/go-struct-converter",
+        "version": "v0.0.0-20240925125616-a0883641c664",
+        "purl": "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20240925125616-a0883641c664",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/cloudflare/circl@v1.5.0?package-id=869b5b22bc3adc41",
+        "type": "library",
+        "name": "github.com/cloudflare/circl",
+        "version": "v1.5.0",
+        "purl": "pkg:golang/github.com/cloudflare/circl@v1.5.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be?package-id=947709cfb5967325",
+        "type": "library",
+        "name": "github.com/common-nighthawk/go-figure",
+        "version": "v0.0.0-20210622060536-734e95fb86be",
+        "purl": "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=ea8047544d96bcce",
+        "type": "library",
+        "name": "github.com/davecgh/go-spew",
+        "version": "v1.1.1",
+        "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/github/go-spdx/v2@v2.3.2?package-id=0ea5596b14c892af",
+        "type": "library",
+        "name": "github.com/github/go-spdx/v2",
+        "version": "v2.3.2",
+        "purl": "pkg:golang/github.com/github/go-spdx/v2@v2.3.2",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.0?package-id=6b1696dac9e32c74",
+        "type": "library",
+        "name": "github.com/go-git/go-billy/v5",
+        "version": "v5.6.0",
+        "purl": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=a1bd766d2d911044",
+        "type": "library",
+        "name": "github.com/google/go-cmp",
+        "version": "v0.6.0",
+        "purl": "pkg:golang/github.com/google/go-cmp@v0.6.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/google/go-github/v52@v52.0.0?package-id=5b00e7ffb17032b5",
+        "type": "library",
+        "name": "github.com/google/go-github/v52",
+        "version": "v52.0.0",
+        "purl": "pkg:golang/github.com/google/go-github/v52@v52.0.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/google/go-querystring@v1.1.0?package-id=152691471c044e6c",
+        "type": "library",
+        "name": "github.com/google/go-querystring",
+        "version": "v1.1.0",
+        "purl": "pkg:golang/github.com/google/go-querystring@v1.1.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/google/uuid@v1.6.0?package-id=079deca07b70be85",
+        "type": "library",
+        "name": "github.com/google/uuid",
+        "version": "v1.6.0",
+        "purl": "pkg:golang/github.com/google/uuid@v1.6.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=9563fe5b93a0d706",
+        "type": "library",
+        "name": "github.com/inconshreveable/mousetrap",
+        "version": "v1.1.0",
+        "purl": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/interlynk-io/sbomqs?package-id=097e6c76604d3b23",
+        "type": "library",
+        "name": "github.com/interlynk-io/sbomqs",
+        "purl": "pkg:golang/github.com/interlynk-io/sbomqs",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/mattn/go-runewidth@v0.0.16?package-id=694d26beb86478f7",
+        "type": "library",
+        "name": "github.com/mattn/go-runewidth",
+        "version": "v0.0.16",
+        "purl": "pkg:golang/github.com/mattn/go-runewidth@v0.0.16",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@v6.10.0?package-id=966dd3622f1f82bc",
+        "type": "library",
+        "name": "github.com/maxbrunsfeld/counterfeiter/v6",
+        "version": "v6.10.0",
+        "purl": "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@v6.10.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5?package-id=50dc607bdb9392c4",
+        "type": "library",
+        "name": "github.com/olekukonko/tablewriter",
+        "version": "v0.0.5",
+        "purl": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/package-url/packageurl-go@v0.1.3?package-id=004f6c313a59175a",
+        "type": "library",
+        "name": "github.com/package-url/packageurl-go",
+        "version": "v0.1.3",
+        "purl": "pkg:golang/github.com/package-url/packageurl-go@v0.1.3",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=a11cf811149af8d8",
+        "type": "library",
+        "name": "github.com/pkg/errors",
+        "version": "v0.9.1",
+        "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=c2adba4e6eb8b5e7",
+        "type": "library",
+        "name": "github.com/pmezard/go-difflib",
+        "version": "v1.0.0",
+        "purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/rivo/uniseg@v0.4.7?package-id=6d9463950131a9b6",
+        "type": "library",
+        "name": "github.com/rivo/uniseg",
+        "version": "v0.4.7",
+        "purl": "pkg:golang/github.com/rivo/uniseg@v0.4.7",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/samber/lo@v1.47.0?package-id=d097aae0ee310194",
+        "type": "library",
+        "name": "github.com/samber/lo",
+        "version": "v1.47.0",
+        "purl": "pkg:golang/github.com/samber/lo@v1.47.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/spdx/gordf@v0.0.0-20221230105357-b735bd5aac89?package-id=77f7116c9b4b4dde",
+        "type": "library",
+        "name": "github.com/spdx/gordf",
+        "version": "v0.0.0-20221230105357-b735bd5aac89",
+        "purl": "pkg:golang/github.com/spdx/gordf@v0.0.0-20221230105357-b735bd5aac89",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/spdx/tools-golang@v0.5.5?package-id=feab36953b593772",
+        "type": "library",
+        "name": "github.com/spdx/tools-golang",
+        "version": "v0.5.5",
+        "purl": "pkg:golang/github.com/spdx/tools-golang@v0.5.5",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/spf13/afero@v1.11.0?package-id=a1ebc9cac39f29ef",
+        "type": "library",
+        "name": "github.com/spf13/afero",
+        "version": "v1.11.0",
+        "purl": "pkg:golang/github.com/spf13/afero@v1.11.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/spf13/cobra@v1.8.1?package-id=7888d9b1495bfbd6",
+        "type": "library",
+        "name": "github.com/spf13/cobra",
+        "version": "v1.8.1",
+        "purl": "pkg:golang/github.com/spf13/cobra@v1.8.1",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=7cde04e1bd087b20",
+        "type": "library",
+        "name": "github.com/spf13/pflag",
+        "version": "v1.0.5",
+        "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/github.com/stretchr/testify@v1.9.0?package-id=f1059c805906e814",
+        "type": "library",
+        "name": "github.com/stretchr/testify",
+        "version": "v1.9.0",
+        "purl": "pkg:golang/github.com/stretchr/testify@v1.9.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "4bbe8b86398bfa32",
+        "type": "library",
+        "name": "go.mod",
+        "properties": [
+          {
+            "name": "syft:package:type",
+            "value": "UnknownPackage"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/go.uber.org/multierr@v1.11.0?package-id=3750230adfb64ef6",
+        "type": "library",
+        "name": "go.uber.org/multierr",
+        "version": "v1.11.0",
+        "purl": "pkg:golang/go.uber.org/multierr@v1.11.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/go.uber.org/zap@v1.27.0?package-id=e49dc9516951a21e",
+        "type": "library",
+        "name": "go.uber.org/zap",
+        "version": "v1.27.0",
+        "purl": "pkg:golang/go.uber.org/zap@v1.27.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/golang.org/x/crypto@v0.28.0?package-id=ba759510f05c62f3",
+        "type": "library",
+        "name": "golang.org/x/crypto",
+        "version": "v0.28.0",
+        "purl": "pkg:golang/golang.org/x/crypto@v0.28.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/golang.org/x/mod@v0.21.0?package-id=b5c721159440ecfb",
+        "type": "library",
+        "name": "golang.org/x/mod",
+        "version": "v0.21.0",
+        "purl": "pkg:golang/golang.org/x/mod@v0.21.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.23.0?package-id=b0407144c2f61d0f",
+        "type": "library",
+        "name": "golang.org/x/oauth2",
+        "version": "v0.23.0",
+        "purl": "pkg:golang/golang.org/x/oauth2@v0.23.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/golang.org/x/sync@v0.8.0?package-id=e515bd01476d778f",
+        "type": "library",
+        "name": "golang.org/x/sync",
+        "version": "v0.8.0",
+        "purl": "pkg:golang/golang.org/x/sync@v0.8.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/golang.org/x/sys@v0.26.0?package-id=e6af8a9f9e82414b",
+        "type": "library",
+        "name": "golang.org/x/sys",
+        "version": "v0.26.0",
+        "purl": "pkg:golang/golang.org/x/sys@v0.26.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/golang.org/x/text@v0.19.0?package-id=d5e54260dfef41dd",
+        "type": "library",
+        "name": "golang.org/x/text",
+        "version": "v0.19.0",
+        "purl": "pkg:golang/golang.org/x/text@v0.19.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/golang.org/x/tools@v0.26.0?package-id=0cbc583ac40e93ab",
+        "type": "library",
+        "name": "golang.org/x/tools",
+        "version": "v0.26.0",
+        "purl": "pkg:golang/golang.org/x/tools@v0.26.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=50abb98b40862924",
+        "type": "library",
+        "name": "gopkg.in/yaml.v2",
+        "version": "v2.4.0",
+        "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=6642390315db61c4",
+        "type": "library",
+        "name": "gopkg.in/yaml.v3",
+        "version": "v3.0.1",
+        "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/gotest.tools@v2.2.0%2Bincompatible?package-id=b31e43068a759fe6",
+        "type": "library",
+        "name": "gotest.tools",
+        "version": "v2.2.0+incompatible",
+        "purl": "pkg:golang/gotest.tools@v2.2.0%2Bincompatible",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "97edb9434748e34d",
+        "type": "library",
+        "name": "https://github.com/interlynk-io/sbomqs",
+        "properties": [
+          {
+            "name": "syft:package:type",
+            "value": "UnknownPackage"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/sigs.k8s.io/release-utils@v0.8.5?package-id=67644dd65bd152ae",
+        "type": "library",
+        "name": "sigs.k8s.io/release-utils",
+        "version": "v0.8.5",
+        "purl": "pkg:golang/sigs.k8s.io/release-utils@v0.8.5",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      },
+      {
+        "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=66d65d40366d1944",
+        "type": "library",
+        "name": "sigs.k8s.io/yaml",
+        "version": "v1.4.0",
+        "purl": "pkg:golang/sigs.k8s.io/yaml@v1.4.0",
+        "properties": [
+          {
+            "name": "syft:package:language",
+            "value": "go"
+          },
+          {
+            "name": "syft:package:type",
+            "value": "go-module"
+          }
+        ]
+      }
+    ],
+    "dependencies": [
+      {
+        "ref": "4bbe8b86398bfa32",
+        "dependsOn": [
+          "pkg:golang/github.com/interlynk-io/sbomqs?package-id=097e6c76604d3b23"
+        ]
+      },
+      {
+        "ref": "97edb9434748e34d",
+        "dependsOn": [
+          "4bbe8b86398bfa32"
+        ]
+      },
+      {
+        "ref": "pkg:golang/github.com/interlynk-io/sbomqs?package-id=097e6c76604d3b23",
+        "dependsOn": [
+          "pkg:golang/github.com/anchore/go-struct-converter@v0.0.0-20240925125616-a0883641c664?package-id=40254925dd04380c",
+          "pkg:golang/github.com/cloudflare/circl@v1.5.0?package-id=869b5b22bc3adc41",
+          "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be?package-id=947709cfb5967325",
+          "pkg:golang/github.com/cyclonedx/cyclonedx-go@v0.9.1?package-id=95415202b9cc044d",
+          "pkg:golang/github.com/davecgh/go-spew@v1.1.1?package-id=ea8047544d96bcce",
+          "pkg:golang/github.com/dependencytrack/client-go@v0.13.0?package-id=8fc694278d7f1d70",
+          "pkg:golang/github.com/github/go-spdx/v2@v2.3.2?package-id=0ea5596b14c892af",
+          "pkg:golang/github.com/go-git/go-billy/v5@v5.6.0?package-id=6b1696dac9e32c74",
+          "pkg:golang/github.com/google/go-cmp@v0.6.0?package-id=a1bd766d2d911044",
+          "pkg:golang/github.com/google/go-github/v52@v52.0.0?package-id=5b00e7ffb17032b5",
+          "pkg:golang/github.com/google/go-querystring@v1.1.0?package-id=152691471c044e6c",
+          "pkg:golang/github.com/google/uuid@v1.6.0?package-id=079deca07b70be85",
+          "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0?package-id=9563fe5b93a0d706",
+          "pkg:golang/github.com/masterminds/semver/v3@v3.3.0?package-id=ac3afaf9b18898cc",
+          "pkg:golang/github.com/mattn/go-runewidth@v0.0.16?package-id=694d26beb86478f7",
+          "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@v6.10.0?package-id=966dd3622f1f82bc",
+          "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5?package-id=50dc607bdb9392c4",
+          "pkg:golang/github.com/package-url/packageurl-go@v0.1.3?package-id=004f6c313a59175a",
+          "pkg:golang/github.com/pkg/errors@v0.9.1?package-id=a11cf811149af8d8",
+          "pkg:golang/github.com/pmezard/go-difflib@v1.0.0?package-id=c2adba4e6eb8b5e7",
+          "pkg:golang/github.com/protonmail/go-crypto@v1.0.0?package-id=cd70701391522794",
+          "pkg:golang/github.com/rivo/uniseg@v0.4.7?package-id=6d9463950131a9b6",
+          "pkg:golang/github.com/samber/lo@v1.47.0?package-id=d097aae0ee310194",
+          "pkg:golang/github.com/spdx/gordf@v0.0.0-20221230105357-b735bd5aac89?package-id=77f7116c9b4b4dde",
+          "pkg:golang/github.com/spdx/tools-golang@v0.5.5?package-id=feab36953b593772",
+          "pkg:golang/github.com/spf13/afero@v1.11.0?package-id=a1ebc9cac39f29ef",
+          "pkg:golang/github.com/spf13/cobra@v1.8.1?package-id=7888d9b1495bfbd6",
+          "pkg:golang/github.com/spf13/pflag@v1.0.5?package-id=7cde04e1bd087b20",
+          "pkg:golang/github.com/stretchr/testify@v1.9.0?package-id=f1059c805906e814",
+          "pkg:golang/go.uber.org/multierr@v1.11.0?package-id=3750230adfb64ef6",
+          "pkg:golang/go.uber.org/zap@v1.27.0?package-id=e49dc9516951a21e",
+          "pkg:golang/golang.org/x/crypto@v0.28.0?package-id=ba759510f05c62f3",
+          "pkg:golang/golang.org/x/mod@v0.21.0?package-id=b5c721159440ecfb",
+          "pkg:golang/golang.org/x/oauth2@v0.23.0?package-id=b0407144c2f61d0f",
+          "pkg:golang/golang.org/x/sync@v0.8.0?package-id=e515bd01476d778f",
+          "pkg:golang/golang.org/x/sys@v0.26.0?package-id=e6af8a9f9e82414b",
+          "pkg:golang/golang.org/x/text@v0.19.0?package-id=d5e54260dfef41dd",
+          "pkg:golang/golang.org/x/tools@v0.26.0?package-id=0cbc583ac40e93ab",
+          "pkg:golang/gopkg.in/yaml.v2@v2.4.0?package-id=50abb98b40862924",
+          "pkg:golang/gopkg.in/yaml.v3@v3.0.1?package-id=6642390315db61c4",
+          "pkg:golang/gotest.tools@v2.2.0%2Bincompatible?package-id=b31e43068a759fe6",
+          "pkg:golang/sigs.k8s.io/release-utils@v0.8.5?package-id=67644dd65bd152ae",
+          "pkg:golang/sigs.k8s.io/yaml@v1.4.0?package-id=66d65d40366d1944"
+        ]
+      }
+    ],
+    "vulnerabilities": [
+      {
+        "id": "CVE-2018-7489",
+        "description": "testing purpose",
+        "created": "2021-01-01T00:00:00.000Z",
+        "published": "2021-01-01T00:00:00.000Z",
+        "updated": "2021-01-01T00:00:00.000Z",
+        "analysis": {
+          "state": "not_affected",
+          "justification": "code_not_reachable",
+          "response": ["will_not_fix", "update"],
+          "detail": "An optional explanation of why the application is not affected by the vulnerable component."
+        }
+      }
+    ],
+    "externalReferences": [
+    {
+      "type": "bom",
+      "url": "https://example.com/sbom/external-bom.cdx.json",
+      "comment": "This is a reference to an external SBOM for a related component"
+    }
+  ]
+  }
+  

--- a/samples/sbomqs-dummy-bomlinks-data.cdx.json
+++ b/samples/sbomqs-dummy-bomlinks-data.cdx.json
@@ -868,8 +868,8 @@
     "externalReferences": [
     {
       "type": "bom",
-      "url": "https://example.com/sbom/external-bom.cdx.json",
-      "comment": "This is a reference to an external SBOM for a related component"
+      "url" : "https://raw.githubusercontent.com/bomctl/bomctl-playground/main/examples/bomctl-container-image/app/bomctl_0.3.0_linux_amd64.tar.gz.spdx.json",
+      "comment": "This is a reference to an external SBOM for a related component for testing purpose."
     }
   ]
   }

--- a/samples/sbomqs-dummy-bomlinks-data.spdx.json
+++ b/samples/sbomqs-dummy-bomlinks-data.spdx.json
@@ -1,0 +1,967 @@
+{
+    "spdxVersion": "SPDX-2.2",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "./sbomqs",
+    "documentNamespace": "https://anchore.com/syft/dir/sbomqs-6ec18b03-96cb-4951-b299-929890c1cfc8",
+    "creationInfo": {
+     "licenseListVersion": "3.20",
+     "creators": [
+      "Organization: Anchore, Inc",
+      "Tool: syft-0.79.0"
+     ],
+     "created": "2023-05-04T09:33:40Z"
+    },
+    "externalDocumentRefs": [
+    {
+      "externalDocumentId": "DocumentRef-LibraryA-v2.3",
+      "spdxDocumentNamespace": "https://example.com/spdx/docs/libraryA-v2.3",
+      "checksum": {
+        "algorithm": "SHA256",
+        "checksumValue": "a3c123d8aebbbcf737bc5c41d04fb0f8c4d3285a29a3b94eabca3c123f6c6c35"
+      }
+    },
+    {
+      "externalDocumentId": "DocumentRef-ToolsetX-v1.2",
+      "spdxDocumentNamespace": "https://example.com/spdx/docs/toolsetX-v1.2",
+      "checksum": {
+        "algorithm": "SHA256",
+        "checksumValue": "4a9c983fd1ae8347dd53c897bc9c38df2f7d6ab98775bf8c36c1237cd123b4e6"
+      }
+    }
+  ],
+    "packages": [
+     {
+      "name": "github.com/CycloneDX/cyclonedx-go",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-CycloneDX-cyclonedx-go-21b8492723f5584d",
+      "versionInfo": "v0.7.1",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:CycloneDX:cyclonedx-go:v0.7.1:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:CycloneDX:cyclonedx_go:v0.7.1:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.7.1"
+       }
+      ]
+     },
+     {
+      "name": "github.com/DependencyTrack/client-go",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-DependencyTrack-client-go-70f2a4e4fda94ec4",
+      "versionInfo": "v0.9.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:DependencyTrack:client-go:v0.9.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:DependencyTrack:client_go:v0.9.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/DependencyTrack/client-go@v0.9.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/common-nighthawk/go-figure",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-common-nighthawk-go-figure-1a42671655d87692",
+      "versionInfo": "v0.0.0-20210622060536-734e95fb86be",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:common-nighthawk:go-figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:common-nighthawk:go_figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:common_nighthawk:go-figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:common_nighthawk:go_figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:common:go-figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:common:go_figure:v0.0.0-20210622060536-734e95fb86be:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/common-nighthawk/go-figure@v0.0.0-20210622060536-734e95fb86be"
+       }
+      ]
+     },
+     {
+      "name": "github.com/google/uuid",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-google-uuid-b03a1ea2b628a550",
+      "versionInfo": "v1.3.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:google:uuid:v1.3.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/google/uuid@v1.3.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/inconshreveable/mousetrap",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-inconshreveable-mousetrap-37c82ad2116f18d1",
+      "versionInfo": "v1.1.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:inconshreveable:mousetrap:v1.1.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/inconshreveable/mousetrap@v1.1.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/kr/text",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-kr-text-f0f8091ed4379f33",
+      "versionInfo": "v0.2.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:kr:text:v0.2.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/kr/text@v0.2.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/mattn/go-runewidth",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-mattn-go-runewidth-c45a0032148e8e8b",
+      "versionInfo": "v0.0.14",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:mattn:go-runewidth:v0.0.14:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:mattn:go_runewidth:v0.0.14:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/mattn/go-runewidth@v0.0.14"
+       }
+      ]
+     },
+     {
+      "name": "github.com/maxbrunsfeld/counterfeiter/v6",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-maxbrunsfeld-counterfeiter-v6-7ea7c94ccd5e7cb",
+      "versionInfo": "v6.6.1",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:maxbrunsfeld:counterfeiter\\/v6:v6.6.1:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/maxbrunsfeld/counterfeiter/v6@v6.6.1"
+       }
+      ]
+     },
+     {
+      "name": "github.com/olekukonko/tablewriter",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-olekukonko-tablewriter-b752a0b7be180e6e",
+      "versionInfo": "v0.0.5",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:olekukonko:tablewriter:v0.0.5:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/olekukonko/tablewriter@v0.0.5"
+       }
+      ]
+     },
+     {
+      "name": "github.com/package-url/packageurl-go",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-package-url-packageurl-go-fa612e2da9ecafd7",
+      "versionInfo": "v0.1.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:package-url:packageurl-go:v0.1.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:package-url:packageurl_go:v0.1.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:package_url:packageurl-go:v0.1.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:package_url:packageurl_go:v0.1.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:package:packageurl-go:v0.1.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:package:packageurl_go:v0.1.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/package-url/packageurl-go@v0.1.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/rivo/uniseg",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-rivo-uniseg-bcfc864b206a884",
+      "versionInfo": "v0.4.4",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:rivo:uniseg:v0.4.4:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/rivo/uniseg@v0.4.4"
+       }
+      ]
+     },
+     {
+      "name": "github.com/rogpeppe/go-internal",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-rogpeppe-go-internal-44cec8815431fbe3",
+      "versionInfo": "v1.9.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:rogpeppe:go-internal:v1.9.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:rogpeppe:go_internal:v1.9.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/samber/lo",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-samber-lo-f75a39aa3ed00ce8",
+      "versionInfo": "v1.38.1",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:samber:lo:v1.38.1:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/samber/lo@v1.38.1"
+       }
+      ]
+     },
+     {
+      "name": "github.com/spdx/gordf",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-spdx-gordf-e5adf96897f94895",
+      "versionInfo": "v0.0.0-20221230105357-b735bd5aac89",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:spdx:gordf:v0.0.0-20221230105357-b735bd5aac89:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/spdx/gordf@v0.0.0-20221230105357-b735bd5aac89"
+       }
+      ]
+     },
+     {
+      "name": "github.com/spdx/tools-golang",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-spdx-tools-golang-ea8d0e770955a070",
+      "versionInfo": "v0.4.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:spdx:tools-golang:v0.4.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:spdx:tools_golang:v0.4.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/spdx/tools-golang@v0.4.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/spf13/cobra",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-spf13-cobra-2304181945444e71",
+      "versionInfo": "v1.7.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:spf13:cobra:v1.7.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/spf13/cobra@v1.7.0"
+       }
+      ]
+     },
+     {
+      "name": "github.com/spf13/pflag",
+      "SPDXID": "SPDXRef-Package-go-module-github.com-spf13-pflag-54d28db4ae4c8937",
+      "versionInfo": "v1.0.5",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:spf13:pflag:v1.0.5:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+       }
+      ]
+     },
+     {
+      "name": "go.uber.org/atomic",
+      "SPDXID": "SPDXRef-Package-go-module-go.uber.org-atomic-620fbaf9c02864ad",
+      "versionInfo": "v1.10.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/go.uber.org/atomic@v1.10.0"
+       }
+      ]
+     },
+     {
+      "name": "go.uber.org/multierr",
+      "SPDXID": "SPDXRef-Package-go-module-go.uber.org-multierr-3b78ee04b0ccb057",
+      "versionInfo": "v1.11.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/go.uber.org/multierr@v1.11.0"
+       }
+      ]
+     },
+     {
+      "name": "go.uber.org/zap",
+      "SPDXID": "SPDXRef-Package-go-module-go.uber.org-zap-ab6435ef08bfee9",
+      "versionInfo": "v1.24.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/go.uber.org/zap@v1.24.0"
+       }
+      ]
+     },
+     {
+      "name": "golang.org/x/exp",
+      "SPDXID": "SPDXRef-Package-go-module-golang.org-x-exp-e0c2ccbeae28976b",
+      "versionInfo": "v0.0.0-20230321023759-10a507213a29",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:golang:x\\/exp:v0.0.0-20230321023759-10a507213a29:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/golang.org/x/exp@v0.0.0-20230321023759-10a507213a29"
+       }
+      ]
+     },
+     {
+      "name": "golang.org/x/mod",
+      "SPDXID": "SPDXRef-Package-go-module-golang.org-x-mod-c373557e6051f4c1",
+      "versionInfo": "v0.9.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:golang:x\\/mod:v0.9.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/golang.org/x/mod@v0.9.0"
+       }
+      ]
+     },
+     {
+      "name": "golang.org/x/sys",
+      "SPDXID": "SPDXRef-Package-go-module-golang.org-x-sys-ca3c49ab7bce06e6",
+      "versionInfo": "v0.6.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:golang:x\\/sys:v0.6.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/golang.org/x/sys@v0.6.0"
+       }
+      ]
+     },
+     {
+      "name": "golang.org/x/tools",
+      "SPDXID": "SPDXRef-Package-go-module-golang.org-x-tools-adf3fdd30af85794",
+      "versionInfo": "v0.7.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "SECURITY",
+        "referenceType": "cpe23Type",
+        "referenceLocator": "cpe:2.3:a:golang:x\\/tools:v0.7.0:*:*:*:*:*:*:*"
+       },
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/golang.org/x/tools@v0.7.0"
+       }
+      ]
+     },
+     {
+      "name": "gopkg.in/yaml.v2",
+      "SPDXID": "SPDXRef-Package-go-module-gopkg.in-yaml.v2-bd73a1dddee3e578",
+      "versionInfo": "v2.4.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+       }
+      ]
+     },
+     {
+      "name": "sigs.k8s.io/release-utils",
+      "SPDXID": "SPDXRef-Package-go-module-sigs.k8s.io-release-utils-c18e6029648f5bab",
+      "versionInfo": "v0.7.3",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/sigs.k8s.io/release-utils@v0.7.3"
+       }
+      ]
+     },
+     {
+      "name": "sigs.k8s.io/yaml",
+      "SPDXID": "SPDXRef-Package-go-module-sigs.k8s.io-yaml-3eda2dffa3632991",
+      "versionInfo": "v1.3.0",
+      "downloadLocation": "NOASSERTION",
+      "packageVerificationCode": {
+       "packageVerificationCodeValue": ""
+      },
+      "sourceInfo": "acquired package info from go module information: go.mod",
+      "licenseConcluded": "NONE",
+      "licenseInfoFromFiles": null,
+      "licenseDeclared": "NONE",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+       {
+        "referenceCategory": "PACKAGE_MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
+       }
+      ]
+     }
+    ],
+    "files": [
+     {
+      "fileName": "go.mod",
+      "SPDXID": "SPDXRef-ed9ca1d5b0eb32bc",
+      "checksums": [
+       {
+        "algorithm": "SHA1",
+        "checksumValue": "0000000000000000000000000000000000000000"
+       }
+      ],
+      "licenseConcluded": "NOASSERTION",
+      "licenseInfoInFiles": null,
+      "copyrightText": ""
+     }
+    ],
+    "relationships": [
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-common-nighthawk-go-figure-1a42671655d87692",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-CycloneDX-cyclonedx-go-21b8492723f5584d",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-cobra-2304181945444e71",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-inconshreveable-mousetrap-37c82ad2116f18d1",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-go.uber.org-multierr-3b78ee04b0ccb057",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-sigs.k8s.io-yaml-3eda2dffa3632991",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-rogpeppe-go-internal-44cec8815431fbe3",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-spf13-pflag-54d28db4ae4c8937",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-go.uber.org-atomic-620fbaf9c02864ad",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-DependencyTrack-client-go-70f2a4e4fda94ec4",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-maxbrunsfeld-counterfeiter-v6-7ea7c94ccd5e7cb",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-go.uber.org-zap-ab6435ef08bfee9",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-tools-adf3fdd30af85794",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-google-uuid-b03a1ea2b628a550",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-olekukonko-tablewriter-b752a0b7be180e6e",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-rivo-uniseg-bcfc864b206a884",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-gopkg.in-yaml.v2-bd73a1dddee3e578",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-sigs.k8s.io-release-utils-c18e6029648f5bab",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-mod-c373557e6051f4c1",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-mattn-go-runewidth-c45a0032148e8e8b",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-sys-ca3c49ab7bce06e6",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-golang.org-x-exp-e0c2ccbeae28976b",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-spdx-gordf-e5adf96897f94895",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-spdx-tools-golang-ea8d0e770955a070",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-kr-text-f0f8091ed4379f33",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-samber-lo-f75a39aa3ed00ce8",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-Package-go-module-github.com-package-url-packageurl-go-fa612e2da9ecafd7",
+      "relatedSpdxElement": "SPDXRef-ed9ca1d5b0eb32bc",
+      "relationshipType": "OTHER",
+      "comment": "evident-by: indicates the package's existence is evident by the given file"
+     },
+     {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES"
+     }
+    ]
+   }
+   

--- a/samples/sbomqs-dummy-bomlinks-data.spdx.json
+++ b/samples/sbomqs-dummy-bomlinks-data.spdx.json
@@ -14,11 +14,11 @@
     },
     "externalDocumentRefs": [
     {
-      "externalDocumentId": "DocumentRef-LibraryA-v2.3",
-      "spdxDocumentNamespace": "https://example.com/spdx/docs/libraryA-v2.3",
+      "externalDocumentId": "DocumentRef-InterlynkSBOM",
+      "spdxDocumentNamespace": "https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg",
       "checksum": {
         "algorithm": "SHA256",
-        "checksumValue": "a3c123d8aebbbcf737bc5c41d04fb0f8c4d3285a29a3b94eabca3c123f6c6c35"
+        "checksumValue": "09e46d45422cc6ab9a6dc1d57ad4d27687fc47fcfac5b732d8bb07327c11e8c3"
       }
     },
     {

--- a/samples/sbomqs-dummy-bomlinks-data.spdx.json
+++ b/samples/sbomqs-dummy-bomlinks-data.spdx.json
@@ -15,7 +15,7 @@
     "externalDocumentRefs": [
     {
       "externalDocumentId": "DocumentRef-InterlynkSBOM",
-      "spdxDocumentNamespace": "https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg",
+      "spdxDocument": "https://interlynk.io/github.com%2Finterlynk-io%2Fsbomqs/0.0.15/qIP32aoJi0u5M_EjHeJHAg",
       "checksum": {
         "algorithm": "SHA256",
         "checksumValue": "09e46d45422cc6ab9a6dc1d57ad4d27687fc47fcfac5b732d8bb07327c11e8c3"
@@ -23,7 +23,7 @@
     },
     {
       "externalDocumentId": "DocumentRef-ToolsetX-v1.2",
-      "spdxDocumentNamespace": "https://example.com/spdx/docs/toolsetX-v1.2",
+      "spdxDocument": "https://example.com/spdx/docs/toolsetX-v1.2",
       "checksum": {
         "algorithm": "SHA256",
         "checksumValue": "4a9c983fd1ae8347dd53c897bc9c38df2f7d6ab98775bf8c36c1237cd123b4e6"


### PR DESCRIPTION
part of https://github.com/interlynk-io/sbomqs/issues/329

This PR introduces a new field, `bomlinks`, to support the optional requirements of BSI:2.0 for SBOMs. The `bomlinks` field facilitates linking one SBOM to another by providing a reference to an external SBOM. This feature enables better traceability across multiple SBOMs in a software supply chain.

Corresponding fields for SPDX format sbom:
- `externalDocumentRefs`:  https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#66-external-document-references-field

Corresponding fields for CDX format sbom:
- `externalReferences` (type `bom`) : https://cyclonedx.org/docs/1.5/json/#components_items_externalReferences_items_url
