### PR TITLE
fix vuln nil derefernce error

### DIFF
--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -218,12 +218,14 @@ func (c *CdxDoc) parseSpec() {
 
 func (c *CdxDoc) parseVulnerabilities() {
 	vuln := Vulnerability{}
-	for _, v := range *c.doc.Vulnerabilities {
-		if v.ID != "" {
-			vuln.Id = v.ID
+	if c.doc.Vulnerabilities != nil {
+		for _, v := range *c.doc.Vulnerabilities {
+			if v.ID != "" {
+				vuln.Id = v.ID
+			}
 		}
+		c.vuln = vuln
 	}
-	c.vuln = vuln
 }
 
 func (c *CdxDoc) requiredFields() bool {


### PR DESCRIPTION
part of #329 

Fix vulnerability nil error, i.e handling vulnerability field when it's a nil value.