### PR TITLE
Feat/bsi2 add vuln test cases

### DIFF
--- a/pkg/compliance/bsiV2.go
+++ b/pkg/compliance/bsiV2.go
@@ -68,13 +68,12 @@ func bsiV2Vulnerabilities(doc sbom.Document) *db.Record {
 	vulns := doc.Vulnerabilities()
 	var allVulnIDs []string
 
-	if vulns != nil {
-		for _, v := range vulns {
-			if vulnID := v.GetID(); vulnID != "" {
-				allVulnIDs = append(allVulnIDs, vulnID)
-			}
+	for _, v := range vulns {
+		if vulnID := v.GetID(); vulnID != "" {
+			allVulnIDs = append(allVulnIDs, vulnID)
 		}
 	}
+
 	if len(allVulnIDs) > 0 {
 		result = strings.Join(allVulnIDs, ", ")
 		score = 0.0

--- a/pkg/compliance/bsiV2.go
+++ b/pkg/compliance/bsiV2.go
@@ -16,6 +16,7 @@ package compliance
 
 import (
 	"context"
+	"strings"
 
 	"github.com/interlynk-io/sbomqs/pkg/compliance/common"
 	db "github.com/interlynk-io/sbomqs/pkg/compliance/db"
@@ -64,13 +65,18 @@ func bsiV2Result(ctx context.Context, doc sbom.Document, fileName string, outFor
 func bsiV2Vulnerabilities(doc sbom.Document) *db.Record {
 	result, score := "no-vulnerability", 10.0
 
-	vuln := doc.Vulnerabilities()
+	vulns := doc.Vulnerabilities()
+	var allVulnIDs []string
 
-	if vuln != nil {
-		vulnId := vuln.GetID()
-		if vulnId != "" {
-			result = vulnId
+	if vulns != nil {
+		for _, v := range vulns {
+			if vulnID := v.GetID(); vulnID != "" {
+				allVulnIDs = append(allVulnIDs, vulnID)
+			}
 		}
+	}
+	if len(allVulnIDs) > 0 {
+		result = strings.Join(allVulnIDs, ", ")
 		score = 0.0
 	}
 	return db.NewRecordStmt(SBOM_VULNERABILITES, "doc", result, score, "")

--- a/pkg/compliance/bsiV2_test.go
+++ b/pkg/compliance/bsiV2_test.go
@@ -1,0 +1,118 @@
+package compliance
+
+import (
+	"testing"
+
+	db "github.com/interlynk-io/sbomqs/pkg/compliance/db"
+	"github.com/interlynk-io/sbomqs/pkg/sbom"
+	"gotest.tools/assert"
+)
+
+func spdxDocWithNoVulnerability() sbom.Document {
+	doc := sbom.SpdxDoc{
+		Vuln: nil,
+	}
+	return doc
+}
+
+func TestBSIV2SPDXSbomVulnerability(t *testing.T) {
+	testCases := []struct {
+		name     string
+		actual   *db.Record
+		expected desired
+	}{
+		{
+			name:   "SPDX SBOM with no vulnerability",
+			actual: bsiV2Vulnerabilities(spdxDocWithNoVulnerability()),
+			expected: desired{
+				score:  10.0,
+				result: "no-vulnerability",
+				key:    SBOM_VULNERABILITES,
+				id:     "doc",
+			},
+		},
+	}
+	for _, test := range testCases {
+		assert.Equal(t, test.expected.score, test.actual.Score, "Score mismatch for %s", test.name)
+		assert.Equal(t, test.expected.key, test.actual.CheckKey, "Key mismatch for %s", test.name)
+		assert.Equal(t, test.expected.id, test.actual.ID, "ID mismatch for %s", test.name)
+		assert.Equal(t, test.expected.result, test.actual.CheckValue, "Result mismatch for %s", test.name)
+	}
+}
+
+func cdxDocWithZeroVulnerability() sbom.Document {
+	doc := sbom.CdxDoc{
+		Vuln: nil,
+	}
+	return doc
+}
+
+func cdxDocWithOneVulnerability() sbom.Document {
+	vuln := sbom.Vulnerability{
+		Id: "CVE-2018-7489",
+	}
+
+	doc := sbom.CdxDoc{
+		Vuln: []sbom.GetVulnerabilities{vuln},
+	}
+	return doc
+}
+
+func cdxDocWithMultipleVulnerability() sbom.Document {
+	vuln1 := sbom.Vulnerability{
+		Id: "CVE-2018-7489",
+	}
+	vuln2 := sbom.Vulnerability{
+		Id: "CVE-2021-44228",
+	}
+
+	doc := sbom.CdxDoc{
+		Vuln: []sbom.GetVulnerabilities{vuln1, vuln2},
+	}
+	return doc
+}
+
+func TestBSIV2CDXSbomVulnerability(t *testing.T) {
+	testCases := []struct {
+		name     string
+		actual   *db.Record
+		expected desired
+	}{
+		{
+			name:   "CDX SBOM with zero vulnerability",
+			actual: bsiV2Vulnerabilities(cdxDocWithZeroVulnerability()),
+			expected: desired{
+				score:  10.0,
+				result: "no-vulnerability",
+				key:    SBOM_VULNERABILITES,
+				id:     "doc",
+			},
+		},
+		{
+			name:   "CDX SBOM with One vulnerability",
+			actual: bsiV2Vulnerabilities(cdxDocWithOneVulnerability()),
+			expected: desired{
+				score:  0.0,
+				result: "CVE-2018-7489",
+				key:    SBOM_VULNERABILITES,
+				id:     "doc",
+			},
+		},
+		{
+			name:   "CDX SBOM with Multiple vulnerability",
+			actual: bsiV2Vulnerabilities(cdxDocWithMultipleVulnerability()),
+			expected: desired{
+				score:  0.0,
+				result: "CVE-2018-7489, CVE-2021-44228",
+				key:    SBOM_VULNERABILITES,
+				id:     "doc",
+			},
+		},
+	}
+	for _, test := range testCases {
+		assert.Equal(t, test.expected.score, test.actual.Score, "Score mismatch for %s", test.name)
+		assert.Equal(t, test.expected.key, test.actual.CheckKey, "Key mismatch for %s", test.name)
+		assert.Equal(t, test.expected.id, test.actual.ID, "ID mismatch for %s", test.name)
+		assert.Equal(t, test.expected.result, test.actual.CheckValue, "Result mismatch for %s", test.name)
+	}
+}

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -55,7 +55,7 @@ type CdxDoc struct {
 	PrimaryComponent PrimaryComp
 	Dependencies     map[string][]string
 	composition      map[string]string
-	vuln             GetVulnerabilities
+	Vuln             []GetVulnerabilities
 }
 
 func newCDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat) (Document, error) {
@@ -143,8 +143,8 @@ func (c CdxDoc) GetComposition(componentID string) string {
 	return c.composition[componentID]
 }
 
-func (s CdxDoc) Vulnerabilities() GetVulnerabilities {
-	return s.vuln
+func (s CdxDoc) Vulnerabilities() []GetVulnerabilities {
+	return s.Vuln
 }
 
 func (c *CdxDoc) parse() {
@@ -217,14 +217,14 @@ func (c *CdxDoc) parseSpec() {
 }
 
 func (c *CdxDoc) parseVulnerabilities() {
-	vuln := Vulnerability{}
 	if c.doc.Vulnerabilities != nil {
 		for _, v := range *c.doc.Vulnerabilities {
 			if v.ID != "" {
+				vuln := Vulnerability{}
 				vuln.Id = v.ID
+				c.Vuln = append(c.Vuln, vuln)
 			}
 		}
-		c.vuln = vuln
 	}
 }
 

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -32,5 +32,5 @@ type Document interface {
 	PrimaryComp() GetPrimaryComp
 	GetRelationships(string) []string
 
-	Vulnerabilities() GetVulnerabilities
+	Vulnerabilities() []GetVulnerabilities
 }

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -57,7 +57,7 @@ type SpdxDoc struct {
 	Lifecycle        string
 	Dependencies     map[string][]string
 	composition      map[string]string
-	vuln             GetVulnerabilities
+	Vuln             []GetVulnerabilities
 }
 
 func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version FormatVersion) (Document, error) {
@@ -153,8 +153,8 @@ func (s SpdxDoc) GetComposition(componentID string) string {
 	return s.composition[componentID]
 }
 
-func (s SpdxDoc) Vulnerabilities() GetVulnerabilities {
-	return s.vuln
+func (s SpdxDoc) Vulnerabilities() []GetVulnerabilities {
+	return s.Vuln
 }
 
 func (s *SpdxDoc) parse() {
@@ -214,7 +214,7 @@ func (s *SpdxDoc) parseSpec() {
 	if s.doc.DocumentNamespace != "" {
 		sp.uri = s.doc.DocumentNamespace
 	}
-	s.vuln = nil
+	s.Vuln = nil
 
 	s.SpdxSpec = sp
 }

--- a/samples/sbomqs-sbomsh-with-vuln.cdx.json
+++ b/samples/sbomqs-sbomsh-with-vuln.cdx.json
@@ -863,6 +863,10 @@
         "response": ["will_not_fix", "update"],
         "detail": "An optional explanation of why the application is not affected by the vulnerable component."
       }
+    },
+    {
+      "id": "CVE-2021-44228",
+      "description": " Apache Log4j logging library,"
     }
   ]
 }


### PR DESCRIPTION
part of https://github.com/interlynk-io/sbomqs/issues/329

This PR adds test cases for following cases:
- **SPDX doc**:
   - with zero vulnerability ( score would be 10.0)

- **CDX doc**:
   - with zero vulnerability ( score would be 10.0)
   - with One vulnerability ( score would be 0.0)
   - with Multiple vulnerability ( score would be 0.0)