### PR TITLE
fix bomlinks field

### DIFF
--- a/pkg/compliance/bsiV2.go
+++ b/pkg/compliance/bsiV2.go
@@ -46,11 +46,10 @@ func bsiV2Result(ctx context.Context, doc sbom.Document, fileName string, outFor
 	dtb.AddRecord(bsiCreator(doc))
 	dtb.AddRecord(bsiTimestamp(doc))
 	dtb.AddRecord(bsiSbomURI(doc))
-	dtb.AddRecord(bsiV2SbomLinks(doc))
 	dtb.AddRecords(bsiV2Components(doc))
 	// New SBOM fields
 	dtb.AddRecord(bsiV2SbomSignature(doc))
-	// dtb.AddRecord(bsiSbomLinks(doc))
+	dtb.AddRecord(bsiV2SbomLinks(doc))
 
 	if outFormat == "json" {
 		bsiV2JSONReport(dtb, fileName)

--- a/pkg/compliance/bsi_report.go
+++ b/pkg/compliance/bsi_report.go
@@ -51,6 +51,7 @@ var bsiSectionDetails = map[int]bsiSection{
 	COMP_DECLARED_LICENSE:   {Title: "Optional components fields", ID: "5.4.1", Required: false, DataField: "declared license"},
 	SBOM_VULNERABILITIES:    {Title: "Definition of SBOM", ID: "3.1", Required: true, DataField: "vuln"},
 	SBOM_SIGNATURE:          {Title: "Optional sboms fields", ID: "8.1.11", Required: false, DataField: "signature"},
+	SBOM_BOM_LINKS:          {Title: "Optional sboms fields", ID: "8.1.12", Required: false, DataField: "bomlinks"},
 }
 
 type run struct {


### PR DESCRIPTION
This PR add `bomlinks`, which was missing in the compliance report.