### PR TITLE
fix correct file format parsing

### DIFF
--- a/pkg/compliance/common/sig.go
+++ b/pkg/compliance/common/sig.go
@@ -54,7 +54,7 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 
 	data, err := os.ReadFile(sbomFile)
 	if err != nil {
-		log.Debug("error reading SBOM file: %w", err)
+		log.Debug("error reading SBOM file: ", err)
 		return "", "", "", fmt.Errorf("error reading SBOM file: %w", err)
 	}
 
@@ -67,7 +67,7 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 	extracted_publick_key := "extracted_public_key.pem"
 
 	if err := json.Unmarshal(data, &sbom); err != nil {
-		log.Debug("Error parsing SBOM JSON: %w", err)
+		log.Debug("Error parsing SBOM JSON: ", err)
 		return "", "", "", fmt.Errorf("error unmarshalling SBOM JSON: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 
 	signatureValue, err := base64.StdEncoding.DecodeString(sbom.Signature.Value)
 	if err != nil {
-		log.Debug("error decoding signature: %w", err)
+		log.Debug("error decoding signature: ", err)
 		return "", "", "", fmt.Errorf("error decoding signature: %w", err)
 	}
 
@@ -106,18 +106,18 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 
 	pubKeyPEM := PublicKeyToPEM(pubKey)
 	if err := os.WriteFile(extracted_publick_key, pubKeyPEM, 0o600); err != nil {
-		log.Debug("error writing public key to file: %w", err)
+		log.Debug("error writing public key to file: ", err)
 	}
 
 	// remove the "signature" section
 	modifiedSBOM, err := sjson.DeleteBytes(data, "signature")
 	if err != nil {
-		log.Debug("Error removing signature section: %w", err)
+		log.Debug("Error removing signature section: ", err)
 	}
 
 	var normalizedSBOM bytes.Buffer
 	if err := json.Indent(&normalizedSBOM, modifiedSBOM, "", "  "); err != nil {
-		log.Debug("Error normalizing SBOM JSON: %w", err)
+		log.Debug("Error normalizing SBOM JSON: ", err)
 	}
 
 	// save the modified SBOM to a new file without a trailing newline

--- a/pkg/engine/compliance.go
+++ b/pkg/engine/compliance.go
@@ -91,7 +91,7 @@ func getSbomDocument(ctx context.Context, ep *Params) (*sbom.Document, error) {
 	signature := ep.Signature
 	publicKey := ep.PublicKey
 
-	if signature == "" && publicKey == "" {
+	if signature == "" && publicKey == "" && ep.BsiV2 {
 		standaloneSBOMFile, signatureRetrieved, publicKeyRetrieved, err := common.RetrieveSignatureFromSBOM(ctx, blob)
 		if err != nil {
 			log.Debug("failed to retrieve signature and public key from embedded sbom: %w", err)


### PR DESCRIPTION
closes: https://github.com/interlynk-io/sbomqs/issues/353

This PR addresses the following:

Previously, it was assumed that if decoding failed, the file format must be incorrect. However, decoding failures can occur for several reasons:
- Invalid format (expected case).
- Structural or syntax errors in the content (unexpected case).
- Empty or malformed content (e.g., newline-only content).

For example, a user-provided SBOM in JSON format with a content error (`newline characters`) was incorrectly assumed to be a non-JSON file because decoding failed. This was a misconception.

To address this, the format is now validated first:
- If the content starts with `"{"` or `"["`, it is identified as JSON.
- If the content starts with `":"` or `"-"`, it is identified as YAML.

Once the format is determined, the corresponding switch-case for JSON or YAML is executed. Any subsequent decoding failures are correctly identified as content issues rather than format misidentification. This ensures more robust and accurate handling of SBOM files.