### PR TITLE
add timeout flag for cutomization(default to 60s)

### DIFF
--- a/cmd/dtrackScore.go
+++ b/cmd/dtrackScore.go
@@ -83,6 +83,8 @@ func extractArgs(cmd *cobra.Command, args []string) (*engine.DtParams, error) {
 		params.ProjectIDs = append(params.ProjectIDs, argID)
 	}
 
+	params.Timeout, _ = cmd.Flags().GetInt("timeout")
+
 	return params, nil
 }
 
@@ -108,4 +110,5 @@ func init() {
 	dtrackScoreCmd.Flags().BoolP("basic", "b", false, "results in single line format")
 
 	dtrackScoreCmd.Flags().BoolP("tag-project-with-score", "t", false, "tag project with sbomqs score")
+	dtrackScoreCmd.Flags().IntP("timeout", "i", 60, "Timeout in seconds for Dependency-Track API requests")
 }

--- a/pkg/engine/dtrack.go
+++ b/pkg/engine/dtrack.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	dtrack "github.com/DependencyTrack/client-go"
 	"github.com/google/uuid"
@@ -39,6 +40,7 @@ type DtParams struct {
 	Detailed bool
 
 	TagProjectWithScore bool
+	Timeout             int // handle cutom timeout
 }
 
 func DtrackScore(ctx context.Context, dtP *DtParams) error {
@@ -47,8 +49,12 @@ func DtrackScore(ctx context.Context, dtP *DtParams) error {
 
 	log.Debugf("Config: %+v", dtP)
 
+	timeout := time.Duration(dtP.Timeout) * time.Second
+
+	log.Debug("Timeout set to: ", timeout)
+
 	dTrackClient, err := dtrack.NewClient(dtP.URL,
-		dtrack.WithAPIKey(dtP.APIKey), dtrack.WithDebug(false))
+		dtrack.WithAPIKey(dtP.APIKey), dtrack.WithTimeout(timeout), dtrack.WithDebug(false))
 	if err != nil {
 		log.Fatalf("Failed to create Dependency-Track client: %s", err)
 	}


### PR DESCRIPTION
closes #394 

This PR adds the following changes:
- Allows users to set a custom timeout (in seconds) for Dependency-Track API requests, defaulting to 60s.
- Added a `--timeout` flag for more cutomization.

Command:
```bash
$ sbomqs dtrackScore --url "${DEPENDENCY_TRACK_URL}" --api-key "${DEPENDENCY_TRACK_API_KEY}" ${DEPENDENCY_TRACK_PROJECT_ID} --tag-project-with-score --timeout=5 -D
2025-03-17T11:08:24.376+0530	DEBUG	engine/dtrack.go:48	engine.DtrackScore()
2025-03-17T11:08:24.376+0530	DEBUG	engine/dtrack.go:50	Config: &{URL:http://localhost:8081 APIKey:odt_LU1VVtDHFtSPkGOtr8QE84CFshZBCWXh ProjectIDs:[e37ece8e-d496-45e3-8bf1-dcdb93867d43] JSON:false Basic:false Detailed:false TagProjectWithScore:true Timeout:5}
2025-03-17T11:08:24.376+0530	DEBUG	engine/dtrack.go:54	Timeout set to: 5s
2025-03-17T11:08:24.383+0530	DEBUG	engine/dtrack.go:63	Processing project e37ece8e-d496-45e3-8bf1-dcdb93867d43
2025-03-17T11:08:24.490+0530	DEBUG	engine/score.go:253	Processing file :/tmp/tmpfile-e37ece8e-d496-45e3-8bf1-dcdb93867d432500027641
```