### PR TITLE
convert long text into multi lines

### DIFF
--- a/pkg/compliance/bsi.go
+++ b/pkg/compliance/bsi.go
@@ -456,6 +456,7 @@ func bsiComponentOtherUniqIDs(component sbom.GetComponent) *db.Record {
 
 	if len(purl) > 0 {
 		result = string(purl[0])
+		result := common.WrapLongTextIntoMulti(result, 100)
 		score = 10.0
 
 		return db.NewRecordStmtOptional(COMP_OTHER_UNIQ_IDS, common.UniqueElementID(component), result, score)
@@ -465,6 +466,7 @@ func bsiComponentOtherUniqIDs(component sbom.GetComponent) *db.Record {
 
 	if len(cpes) > 0 {
 		result = string(cpes[0])
+		result := common.WrapLongTextIntoMulti(result, 100)
 		score = 10.0
 
 		return db.NewRecordStmtOptional(COMP_OTHER_UNIQ_IDS, common.UniqueElementID(component), result, score)

--- a/pkg/compliance/common/common.go
+++ b/pkg/compliance/common/common.go
@@ -470,6 +470,17 @@ func WrapText(input string, maxWidth int) string {
 	return strings.Join(result, "\n")
 }
 
+// convert long text into multiple lines
+func WrapLongTextIntoMulti(input string, maxWidth int) string {
+	var result []string
+	for len(input) > maxWidth {
+		result = append(result, input[:maxWidth])
+		input = input[maxWidth:]
+	}
+	result = append(result, input)
+	return strings.Join(result, "\n")
+}
+
 func AreLicensesValid(licenses []licenses.License) bool {
 	var spdx, aboutcode, custom int
 

--- a/pkg/compliance/fsct/fsct.go
+++ b/pkg/compliance/fsct/fsct.go
@@ -241,30 +241,35 @@ func fsctPackageUniqIDs(component sbom.GetComponent) *db.Record {
 	if purl := component.GetPurls(); len(purl) > 0 {
 		if uniqIDResult, uniqIDPresent := common.CheckPurls(purl); uniqIDPresent {
 			uniqIDCount++
+			uniqIDResult = common.WrapLongTextIntoMulti(uniqIDResult, 100)
 			uniqIDResults = append(uniqIDResults, uniqIDResult)
 		}
 	}
 	if cpe := component.GetCpes(); len(cpe) > 0 {
 		if uniqIDResult, uniqIDPresent := common.CheckCpes(cpe); uniqIDPresent {
 			uniqIDCount++
+			uniqIDResult = common.WrapLongTextIntoMulti(uniqIDResult, 100)
 			uniqIDResults = append(uniqIDResults, uniqIDResult)
 		}
 	}
 	if omni := component.OmniborIDs(); len(omni) > 0 {
 		if uniqIDResult, uniqIDPresent := common.CheckOmnibor(omni); uniqIDPresent {
 			uniqIDCount++
+			uniqIDResult = common.WrapLongTextIntoMulti(uniqIDResult, 100)
 			uniqIDResults = append(uniqIDResults, uniqIDResult)
 		}
 	}
 	if swhid := component.Swhids(); len(swhid) > 0 {
 		if uniqIDResult, uniqIDPresent := common.CheckSwhid(swhid); uniqIDPresent {
 			uniqIDCount++
+			uniqIDResult = common.WrapLongTextIntoMulti(uniqIDResult, 100)
 			uniqIDResults = append(uniqIDResults, uniqIDResult)
 		}
 	}
 	if swids := component.Swids(); len(swids) > 0 {
 		if uniqIDResult, uniqIDPresent := common.CheckSwid(swids); uniqIDPresent {
 			uniqIDCount++
+			uniqIDResult = common.WrapLongTextIntoMulti(uniqIDResult, 100)
 			uniqIDResults = append(uniqIDResults, uniqIDResult)
 		}
 	}

--- a/pkg/compliance/ntia.go
+++ b/pkg/compliance/ntia.go
@@ -392,7 +392,7 @@ func ntiaComponentOtherUniqIDs(doc sbom.Document, component sbom.GetComponent) *
 
 		if len(purl) > 0 {
 			result = string(purl[0])
-
+			result = common.WrapLongTextIntoMulti(result, 100)
 			return db.NewRecordStmtOptional(COMP_OTHER_UNIQ_IDS, common.UniqueElementID(component), result, SCORE_FULL)
 		}
 
@@ -400,7 +400,7 @@ func ntiaComponentOtherUniqIDs(doc sbom.Document, component sbom.GetComponent) *
 
 		if len(cpes) > 0 {
 			result = string(cpes[0])
-
+			result = common.WrapLongTextIntoMulti(result, 100)
 			return db.NewRecordStmtOptional(COMP_OTHER_UNIQ_IDS, common.UniqueElementID(component), result, SCORE_FULL)
 		}
 


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomqs/issues/399

This PR adds the following changes:
- It  wraps the long text into multi line text.
- It wraps text of length more than 100 character.


This is how it looks like on wrapping:
![image](https://github.com/user-attachments/assets/af6e8eae-f8ff-41bb-9d38-cd2397e5465f)
