### PR TITLE
Feature/sbomqs list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -50,19 +50,27 @@ var listCmd = &cobra.Command{
 	Use:          "list",
 	Short:        "List components or SBOM properties based on features",
 	SilenceUsage: true,
-	Example: `  sbomqs list --feature <feature> --option  <path-to-sbom-file> 
+	Example: `  sbomqs list --features <features> --option  <path-to-sbom-file> 
 	
   # List all components with suppliers
-  sbomqs list --feature comp_with_supplier samples/sbomqs-spdx-syft.json
+  sbomqs list --features comp_with_supplier samples/sbomqs-spdx-syft.json
 
   # List all components missing suppliers
-  sbomqs list --feature comp_with_supplier --missing samples/sbomqs-spdx-syft.json
+  sbomqs list --features comp_with_supplier --missing samples/sbomqs-spdx-syft.json
 
   # List all components with valid licenses
-  sbomqs list --feature comp_valid_licenses samples/sbomqs-spdx-syft.json
+  sbomqs list --features comp_valid_licenses samples/sbomqs-spdx-syft.json
 
   # List all components with invalid licenses
-  sbomqs list --feature comp_valid_licenses --missing samples/sbomqs-spdx-syft.json
+  sbomqs list --features comp_valid_licenses --missing samples/sbomqs-spdx-syft.json
+
+  # List all components of SBOM with comp_with_licenses as well as comp_with_version
+  sbomqs list --features="comp_with_licenses,comp_with_version"  samples/photon.spdx.json
+
+# List all components for both SBOM with comp_with_licenses as well as comp_with_version
+  sbomqs list --features="comp_with_licenses,comp_with_version"  samples/photon.spdx.json samples/sbomqs-cdx-cgomod.json
+
+  # 
 `,
 
 	Args: func(_ *cobra.Command, args []string) error {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -81,7 +81,6 @@ var listCmd = &cobra.Command{
 
 		ctx := logger.WithLogger(context.Background())
 		uCmd := parseListParams(cmd, args)
-		validateparsedListCmd(uCmd)
 		if err := validateparsedListCmd(uCmd); err != nil {
 			logger.FromContext(ctx).Errorf("Invalid command parameters: %v", err)
 			return err
@@ -147,7 +146,10 @@ func init() {
 
 	// Filter Control
 	listCmd.Flags().StringP("features", "f", "", "filter by feature (e.g. 'sbom_authors',  'comp_with_name', 'sbom_creation_timestamp') ")
-	listCmd.MarkFlagRequired("features")
+	err := listCmd.MarkFlagRequired("features")
+	if err != nil {
+		log.Fatal(err)
+	}
 	listCmd.Flags().BoolP("missing", "m", false, "list components or properties missing the specified feature")
 
 	// Output Control

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/interlynk-io/sbomqs/pkg/engine"
+	"github.com/interlynk-io/sbomqs/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+// userListCmd holds the configuration for the list command
+type userListCmd struct {
+	// Input control
+	path string
+
+	// Filter control
+	feature string
+	missing bool
+
+	// Output control
+	basic bool
+
+	// Debug control
+	debug bool
+}
+
+// listCmd lists components or SBOM properties based on specified features
+var listCmd = &cobra.Command{
+	Use:          "list",
+	Short:        "List components or SBOM properties based on features",
+	SilenceUsage: true,
+	Example: `  # List all components with suppliers
+  sbomqs list --feature comp_with_supplier samples/sbomqs-spdx-syft.json
+
+  # List all components missing suppliers
+  sbomqs list --feature comp_with_supplier --missing samples/sbomqs-spdx-syft.json
+
+  # List all components with valid licenses
+  sbomqs list --feature comp_valid_licenses samples/sbomqs-spdx-syft.json
+
+  # List all components with invalid licenses
+  sbomqs list --feature comp_valid_licenses --missing samples/sbomqs-spdx-syft.json
+`,
+
+	Args: func(_ *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("requires a path to an SBOM file or directory of SBOM files")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Initialize logger based on debug flag
+		if debug, _ := cmd.Flags().GetBool("debug"); debug {
+			logger.InitDebugLogger()
+		} else {
+			logger.InitProdLogger()
+		}
+
+		ctx := logger.WithLogger(context.Background())
+		uCmd := parseListParams(cmd, args)
+
+		engParams := fromListToEngineParams(uCmd)
+		return engine.ListRun(ctx, engParams)
+	},
+}
+
+func parseListParams(cmd *cobra.Command, args []string) *userListCmd {
+	uCmd := &userListCmd{}
+
+	// Input control
+	uCmd.path = args[0]
+
+	// Filter control
+	feature, _ := cmd.Flags().GetString("feature")
+	uCmd.feature = feature
+	missing, _ := cmd.Flags().GetBool("missing")
+	uCmd.missing = missing
+
+	// Output control
+	basic, _ := cmd.Flags().GetBool("basic")
+	uCmd.basic = basic
+
+	// Debug control
+	debug, _ := cmd.Flags().GetBool("debug")
+	uCmd.debug = debug
+
+	return uCmd
+}
+
+func fromListToEngineParams(uCmd *userListCmd) *engine.Params {
+	return &engine.Params{
+		Path:     []string{uCmd.path},
+		Features: []string{uCmd.feature},
+		Missing:  uCmd.missing,
+		Basic:    uCmd.basic,
+		Debug:    uCmd.debug,
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+	// Filter Control
+	listCmd.Flags().StringP("feature", "f", "", "filter by feature (e.g., 'comp_with_supplier', 'sbom_authors')")
+	listCmd.MarkFlagRequired("feature")
+	listCmd.Flags().BoolP("missing", "m", false, "list components or properties missing the specified feature")
+
+	// Output Control
+	listCmd.Flags().BoolP("basic", "b", true, "results in single-line format")
+
+	// Debug Control
+	listCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,7 +35,10 @@ type userListCmd struct {
 	missing bool
 
 	// Output control
-	basic bool
+	basic    bool
+	json     bool
+	detailed bool
+	color    bool
 
 	// Debug control
 	debug bool
@@ -106,6 +109,16 @@ func parseListParams(cmd *cobra.Command, args []string) *userListCmd {
 	basic, _ := cmd.Flags().GetBool("basic")
 	uCmd.basic = basic
 
+	json, _ := cmd.Flags().GetBool("json")
+	uCmd.json = json
+
+	detailed, _ := cmd.Flags().GetBool("detailed")
+
+	uCmd.detailed = detailed
+
+	color, _ := cmd.Flags().GetBool("color")
+	uCmd.color = color
+
 	// Debug control
 	debug, _ := cmd.Flags().GetBool("debug")
 	uCmd.debug = debug
@@ -119,6 +132,9 @@ func fromListToEngineParams(uCmd *userListCmd) *engine.Params {
 		Features: []string{uCmd.feature},
 		Missing:  uCmd.missing,
 		Basic:    uCmd.basic,
+		JSON:     uCmd.json,
+		Detailed: uCmd.detailed,
+		Color:    uCmd.color,
 		Debug:    uCmd.debug,
 	}
 }
@@ -133,7 +149,9 @@ func init() {
 
 	// Output Control
 	listCmd.Flags().BoolP("basic", "b", true, "results in single-line format")
-
+	listCmd.Flags().BoolP("json", "j", false, "results in json")
+	listCmd.Flags().BoolP("detailed", "d", false, "results in table format, default")
+	listCmd.Flags().BoolP("color", "l", false, "output in colorful")
 	// Debug Control
 	listCmd.Flags().BoolP("debug", "D", false, "enable debug logging")
 }
@@ -155,7 +173,6 @@ func validateparsedListCmd(uCmd *userListCmd) error {
 	// 3. --feature="comp_with_name comp_with_version" ---> this is not fine as it has 2 features
 	// 4. --feature="comp_with_name, comp_with_version" ---> this is also not fine as it has 2 features
 
-	fmt.Println("Feature: ", uCmd.feature)
 	feature := strings.TrimSpace(uCmd.feature)
 	if feature == "" {
 		fmt.Println("Error: feature cannot be empty")

--- a/docs/list.md
+++ b/docs/list.md
@@ -1,0 +1,119 @@
+# `sbomqs list` Command
+
+The `sbomqs list` command allows users to list components or SBOM fileds based on a specified feature, making it easier to identify which components or properties(SBOM metadata) meet (or fail to meet) certain criteria. This command is particularly useful for pinpointing missing fields in SBOM components (e.g., suppliers, licenses) or verifying SBOM metadata (e.g., authors, creation timestamp).
+
+## Usage
+
+```bash
+sbomqs list [flags] <SBOM file>
+```
+
+### Flags
+
+- `--feature, -f <feature>`: Specifies the feature to list (required). See supported features below.
+- `--missing, -m`: Lists components or properties that do not have the specified feature (default: false).
+- `--basic, -b`: Outputs results in a single-line format (default: false).
+- `--detailed, -d`: Outputs results in a detailed table format (default: true).
+- `--json, -j`: Outputs results in JSON format (default: false).
+- `--color, -l`: Enables colored output for the detailed format (default: false).
+- `--debug, -D`: Enables debug logging (default: false).
+
+### Supported Features
+
+The list command supports the following features, categorized into **component-based** (`comp_`) and **SBOM-based** (`sbom_`) features:
+
+#### Component-Based Features (comp_)
+
+These features evaluate individual components in the SBOM:
+
+- `comp_with_name`: Lists components with a name.
+- `comp_with_version`: Lists components with a version.
+- `comp_with_supplier`: Lists components with a supplier.
+- `comp_with_uniq_ids`: Lists components with unique IDs.
+- `comp_valid_licenses`: Lists components with at least one valid SPDX license.
+- `comp_with_any_vuln_lookup_id`: Lists components with any vulnerability lookup ID (CPE or PURL).
+- `comp_with_deprecated_licenses`: Lists components with deprecated licenses.
+- `comp_with_multi_vuln_lookup_id`: Lists components with both CPE and PURL (multiple vulnerability lookup IDs).
+- `comp_with_primary_purpose`: Lists components with a supported primary purpose.
+- `comp_with_restrictive_licenses`: Lists components with restrictive licenses.
+- `comp_with_checksums`: Lists components with checksums.
+- `comp_with_licenses`: Lists components with licenses.
+
+#### SBOM-Based Features (sbom_)
+
+These features evaluate document-level properties of the SBOM:
+
+- `sbom_creation_timestamp`: Lists the SBOM’s creation timestamp.
+- `sbom_authors`: Lists the SBOM’s authors.
+- `sbom_with_creator_and_version`: Lists the creator tool and its version.
+- `sbom_with_primary_component`: Lists the primary component of the SBOM.
+- `sbom_dependencies`: Lists the dependencies of the primary component.
+- `sbom_sharable`: Lists whether the SBOM has a sharable license (all licenses must be free for any use).
+- `sbom_parsable`: Lists whether the SBOM is parsable.
+- `sbom_spec`: Lists the SBOM specification (e.g., SPDX, CycloneDX).
+- `sbom_spec_file_format`: Lists the SBOM file format (e.g., JSON, YAML).
+- `sbom_spec_version`: Lists the SBOM specification version (e.g., SPDX-2.2).
+
+## Examples
+
+### 1. List Components with Suppliers (Basic Format)
+
+```bash
+$ sbomqs list --feature comp_with_supplier --basic samples/photon.spdx.json
+
+samples/photon.spdx.json:	 comp_with_supplier 	(present):	 0/39 components
+```
+
+### 2. List Components Missing Suppliers (Detailed Format)
+
+```bash
+$ sbomqs list --feature comp_with_supplier --missing samples/photon.spdx.json
+
+File: samples/photon.spdx.json
+Feature: comp_with_supplier (missing)
++----------------------------+-----------------+-----------------+
+| Feature                    | Component Name  | Version         |
++----------------------------+-----------------+-----------------+
+| comp_with_supplier (39/39) | abc             | v1              |
+|                            | abe             | v2              |
+|                            | abf             | v3              |
+|                            | abg             | v4              |
+|                            | abh             | v5              |
+|                            | abi             | v6              |
+|                            | abz             | v26             |
++----------------------------+-----------------+-----------------+
+```
+
+### 3. List SBOM Authors (JSON Format)
+
+```bash
+$ sbomqs list --feature sbom_authors --json samples/photon.spdx.json
+
+{
+  "run_id": "8af142e2-822f-4005-9612-42ddeb9394bf",
+  "timestamp": "2025-04-03T10:00:00Z",
+  "creation_info": {
+    "name": "sbomqs",
+    "version": "v1.0.0",
+    "vendor": "Interlynk (support@interlynk.io)"
+  },
+  "files": [
+    {
+      "file_name": "samples/photon.spdx.json",
+      "feature": "sbom_authors",
+      "missing": false,
+      "document_property": {
+        "property": "Authors",
+        "value": "John Doe",
+        "present": true
+      },
+      "errors": []
+    }
+  ]
+}
+```
+
+## Notes
+
+- The `--missing` flag is particularly useful for identifying gaps in your SBOM, such as components missing suppliers or licenses, helping you improve compliance and quality.
+- The `list` command supports the same input sources as the score command: local files, directories, and GitHub URLs.

--- a/docs/list.md
+++ b/docs/list.md
@@ -10,7 +10,7 @@ sbomqs list [flags] <SBOM file>
 
 ### Flags
 
-- `--feature, -f <feature>`: Specifies the feature to list (required). See supported features below.
+- `--features, -f <feature>`: Specifies the feature to list (required). See supported features below.
 - `--missing, -m`: Lists components or properties that do not have the specified feature (default: false).
 - `--basic, -b`: Outputs results in a single-line format (default: false).
 - `--detailed, -d`: Outputs results in a detailed table format (default: true).
@@ -59,7 +59,7 @@ These features evaluate document-level properties of the SBOM:
 ### 1. List Components with Suppliers (Basic Format)
 
 ```bash
-$ sbomqs list --feature comp_with_supplier --basic samples/photon.spdx.json
+$ sbomqs list --features comp_with_supplier --basic samples/photon.spdx.json
 
 samples/photon.spdx.json:	 comp_with_supplier 	(present):	 0/39 components
 ```
@@ -67,7 +67,7 @@ samples/photon.spdx.json:	 comp_with_supplier 	(present):	 0/39 components
 ### 2. List Components Missing Suppliers (Detailed Format)
 
 ```bash
-$ sbomqs list --feature comp_with_supplier --missing samples/photon.spdx.json
+$ sbomqs list --features comp_with_supplier --missing samples/photon.spdx.json
 
 File: samples/photon.spdx.json
 Feature: comp_with_supplier (missing)
@@ -87,7 +87,7 @@ Feature: comp_with_supplier (missing)
 ### 3. List SBOM Authors (JSON Format)
 
 ```bash
-$ sbomqs list --feature sbom_authors --json samples/photon.spdx.json
+$ sbomqs list --features sbom_authors --json samples/photon.spdx.json
 
 {
   "run_id": "8af142e2-822f-4005-9612-42ddeb9394bf",

--- a/pkg/engine/list.go
+++ b/pkg/engine/list.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/interlynk-io/sbomqs/pkg/list"
+	"github.com/interlynk-io/sbomqs/pkg/logger"
+	"github.com/interlynk-io/sbomqs/pkg/sbom"
+)
+
+func ListRun(ctx context.Context, ep *Params) error {
+	path := ep.Path[0]
+
+	log := logger.FromContext(ctx)
+	log.Debug("engine.ListRun()")
+
+	if len(ep.Path) <= 0 {
+		log.Fatal("path is required")
+	}
+
+	log.Debugf("Config: %+v", ep)
+
+	if _, err := os.Stat(path); err != nil {
+		log.Debugf("os.Stat failed for file :%s\n", path)
+		fmt.Printf("failed to stat %s\n", path)
+		return err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		log.Debugf("os.Open failed for file :%s\n", path)
+		fmt.Printf("failed to open %s\n", path)
+		return err
+	}
+	defer f.Close()
+
+	doc, err := sbom.NewSBOMDocument(ctx, f, sbom.Signature{})
+	if err != nil {
+		log.Debugf("failed to create sbom document for  :%s\n", path)
+		log.Debugf("%s\n", err)
+		fmt.Printf("failed to parse %s : %s\n", path, err)
+		return err
+	}
+
+	result, err := list.ComponentsListResult(ctx, ep.Features, doc, path, ep.Missing)
+	if err != nil {
+		log.Debugf("ListComponents failed for file :%s\n", ep.Path[0])
+		fmt.Printf("failed to list components for %s\n", ep.Path[0])
+		return err
+	}
+
+	fmt.Println("Components: ", result.Components)
+	return nil
+}

--- a/pkg/engine/list.go
+++ b/pkg/engine/list.go
@@ -21,8 +21,8 @@ import (
 	"github.com/interlynk-io/sbomqs/pkg/logger"
 )
 
-func parseListParams(ep *Params) *list.ListParams {
-	return &list.ListParams{
+func parseListParams(ep *Params) *list.Params {
+	return &list.Params{
 		Path:     ep.Path,
 		Features: ep.Features,
 		JSON:     ep.JSON,

--- a/pkg/engine/list.go
+++ b/pkg/engine/list.go
@@ -57,14 +57,22 @@ func ListRun(ctx context.Context, ep *Params) error {
 		return err
 	}
 
-	result, err := list.ComponentsListResult(ctx, ep.Features, doc, path, ep.Missing)
+	listParams := list.ListParams{
+		Path:     ep.Path,
+		Features: ep.Features,
+		JSON:     ep.JSON,
+		Basic:    ep.Basic,
+		Detailed: ep.Detailed,
+		Color:    ep.Color,
+		Missing:  ep.Missing,
+		Debug:    ep.Debug,
+	}
+	_, err = list.ComponentsListResult(ctx, listParams, doc)
 	if err != nil {
 		log.Debugf("ListComponents failed for SBOM document :%s\n", ep.Path[0])
 		fmt.Printf("failed to list components for SBOM document :%s\n", ep.Path[0])
 		return err
 	}
 
-	fmt.Println("Components: ", result.Components)
-	fmt.Println("Properties: ", result.DocumentProperty.Value)
 	return nil
 }

--- a/pkg/engine/list.go
+++ b/pkg/engine/list.go
@@ -25,8 +25,6 @@ import (
 )
 
 func ListRun(ctx context.Context, ep *Params) error {
-	path := ep.Path[0]
-
 	log := logger.FromContext(ctx)
 	log.Debug("engine.ListRun()")
 
@@ -34,7 +32,7 @@ func ListRun(ctx context.Context, ep *Params) error {
 		log.Fatal("path is required")
 	}
 
-	log.Debugf("Config: %+v", ep)
+	path := ep.Path[0]
 
 	if _, err := os.Stat(path); err != nil {
 		log.Debugf("os.Stat failed for file :%s\n", path)
@@ -50,21 +48,23 @@ func ListRun(ctx context.Context, ep *Params) error {
 	}
 	defer f.Close()
 
+	// parse SBOM file into SBOM document
 	doc, err := sbom.NewSBOMDocument(ctx, f, sbom.Signature{})
 	if err != nil {
-		log.Debugf("failed to create sbom document for  :%s\n", path)
+		log.Debugf("failed to create sbom document for  SBOM file path:%s\n", path)
 		log.Debugf("%s\n", err)
-		fmt.Printf("failed to parse %s : %s\n", path, err)
+		fmt.Printf("failed to parse sbom document from SBOM file path %s: %s\n", path, err)
 		return err
 	}
 
 	result, err := list.ComponentsListResult(ctx, ep.Features, doc, path, ep.Missing)
 	if err != nil {
-		log.Debugf("ListComponents failed for file :%s\n", ep.Path[0])
-		fmt.Printf("failed to list components for %s\n", ep.Path[0])
+		log.Debugf("ListComponents failed for SBOM document :%s\n", ep.Path[0])
+		fmt.Printf("failed to list components for SBOM document :%s\n", ep.Path[0])
 		return err
 	}
 
 	fmt.Println("Components: ", result.Components)
+	fmt.Println("Properties: ", result.DocumentProperty.Value)
 	return nil
 }

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -48,6 +48,7 @@ type Params struct {
 	Cdx  bool
 
 	Recurse bool
+	Missing bool
 
 	Debug bool
 

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/interlynk-io/sbomqs/pkg/logger"
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
+	"github.com/samber/lo" // Added for lo.Contains
 )
 
 func ComponentsListResult(ctx context.Context, features []string, doc sbom.Document, path string, missing bool) (*ListResult, error) {
@@ -45,7 +46,9 @@ func ComponentsListResult(ctx context.Context, features []string, doc sbom.Docum
 	}
 
 	feature := features[0]
+
 	result.Feature = feature
+	strings.TrimSpace(feature)
 
 	// determine if the feature is component-based or SBOM-based
 	if strings.HasPrefix(feature, "comp_") {
@@ -55,7 +58,10 @@ func ComponentsListResult(ctx context.Context, features []string, doc sbom.Docum
 
 		// evaluate the feature for each component
 		for _, comp := range doc.Components() {
-			hasFeature, err := evaluateComponentFeature(feature, comp)
+			log.Debugf("evaluating feature %s for component %s", feature, comp.GetName())
+
+			// evaluate the feature for the component
+			hasFeature, value, err := evaluateComponentFeature(feature, comp, doc)
 			if err != nil {
 				log.Debugf("failed to evaluate feature %s for component: %v", feature, err)
 				result.Errors = append(result.Errors, fmt.Sprintf("failed to evaluate feature %s for component: %v", feature, err))
@@ -67,6 +73,7 @@ func ComponentsListResult(ctx context.Context, features []string, doc sbom.Docum
 				result.Components = append(result.Components, ComponentResult{
 					Name:    comp.GetName(),
 					Version: comp.GetVersion(),
+					Values:  value,
 				})
 			}
 		}
@@ -103,49 +110,163 @@ func ComponentsListResult(ctx context.Context, features []string, doc sbom.Docum
 }
 
 // evaluateComponentFeature evaluates a component-based feature for a single component
-func evaluateComponentFeature(feature string, comp sbom.GetComponent) (bool, error) {
+func evaluateComponentFeature(feature string, comp sbom.GetComponent, doc sbom.Document) (bool, string, error) {
 	switch feature {
+
 	case "comp_with_name":
-		return comp.GetName() != "", nil
+		return comp.GetName() != "", comp.GetName(), nil
+
 	case "comp_with_version":
-		return comp.GetVersion() != "", nil
+		return comp.GetVersion() != "", comp.GetVersion(), nil
+
 	case "comp_with_supplier":
-		return comp.Suppliers().IsPresent(), nil
+		return comp.Suppliers().IsPresent(), comp.Suppliers().GetName(), nil
+
 	case "comp_with_uniq_ids":
-		return comp.GetID() != "", nil
+		return comp.GetID() != "", comp.GetID(), nil
+
 	case "comp_valid_licenses":
 		licenses := comp.Licenses()
-		return len(licenses) > 0 && licenses[0].Name() != "NOASSERTION", nil
+		if len(licenses) == 0 {
+			return false, "", nil
+		}
+
+		// check if at least one license is a valid SPDX license
+		for _, l := range licenses {
+			if l != nil && l.Spdx() {
+				return true, l.Name(), nil
+			}
+		}
+		return false, "", nil
+
 	case "comp_with_any_vuln_lookup_id":
-		// TODO: Implement logic to check for any vulnerability lookup ID
-		return false, nil
+		cpes := comp.GetCpes()
+		purls := comp.GetPurls()
+		hasFeature := len(cpes) > 0 || len(purls) > 0
+		value := ""
+		if hasFeature {
+			allIDs := make([]string, 0, len(cpes)+len(purls))
+			for _, cpe := range cpes {
+				allIDs = append(allIDs, cpe.String()) // Assuming cpe.CPE has a String() method
+			}
+			for _, purl := range purls {
+				allIDs = append(allIDs, purl.String()) // Assuming purl.PURL has a String() method
+			}
+			value = strings.Join(allIDs, ",")
+		}
+		return hasFeature, value, nil
+
 	case "comp_with_deprecated_licenses":
-		// TODO: Implement logic to check for any deprecated licenses
-		return false, nil
+		licenses := comp.Licenses()
+		if len(licenses) == 0 {
+			return false, "", nil
+		}
+		deprecatedLicenses := []string{}
+		licenseNames := make([]string, 0, len(licenses))
+		for _, l := range licenses {
+			if l != nil {
+				licenseNames = append(licenseNames, l.Name())
+				if l.Deprecated() {
+					deprecatedLicenses = append(deprecatedLicenses, l.Name())
+				}
+			}
+		}
+		hasFeature := len(deprecatedLicenses) > 0
+		value := ""
+		if hasFeature {
+			value = strings.Join(deprecatedLicenses, ",")
+		} else {
+			value = strings.Join(licenseNames, ",")
+		}
+		return hasFeature, value, nil
+
 	case "comp_with_multi_vuln_lookup_id":
-		// TODO: Implement logic to check for any multi vulnerability lookup ID
-		return false, nil
+		cpes := comp.GetCpes()
+		purls := comp.GetPurls()
+		hasFeature := len(cpes) > 0 && len(purls) > 0
+		value := ""
+		if hasFeature {
+			allIDs := make([]string, 0, len(cpes)+len(purls))
+			for _, cpe := range cpes {
+				allIDs = append(allIDs, cpe.String()) // Assuming cpe.CPE has a String() method
+			}
+			for _, purl := range purls {
+				allIDs = append(allIDs, purl.String()) // Assuming purl.PURL has a String() method
+			}
+			value = strings.Join(allIDs, ",")
+		}
+		return hasFeature, value, nil
+
 	case "comp_with_primary_purpose":
-		// TODO: Implement logic to check for any primary purpose
-		return false, nil
+		purpose := comp.PrimaryPurpose()
+		hasFeature := purpose != "" && lo.Contains(sbom.SupportedPrimaryPurpose(doc.Spec().GetSpecType()), strings.ToLower(purpose))
+		return hasFeature, purpose, nil
+
 	case "comp_with_restrictive_licenses":
-		// TODO: Implement logic to check for any restrictive licenses
-		return false, nil
+		licenses := comp.Licenses()
+		if len(licenses) == 0 {
+			return false, "", nil
+		}
+		restrictiveLicenses := []string{}
+		licenseNames := make([]string, 0, len(licenses))
+
+		for _, l := range licenses {
+			if l != nil {
+				licenseNames = append(licenseNames, l.Name())
+				if l.Restrictive() {
+					restrictiveLicenses = append(restrictiveLicenses, l.Name())
+				}
+			}
+		}
+		hasFeature := len(restrictiveLicenses) > 0
+		value := ""
+		if hasFeature {
+			value = strings.Join(restrictiveLicenses, ",")
+		} else {
+			value = strings.Join(licenseNames, ",")
+		}
+		return hasFeature, value, nil
+
 	case "comp_with_checksums":
-		return len(comp.GetChecksums()) > 0, nil
+		checksums := comp.GetChecksums()
+		hasFeature := len(checksums) > 0
+		value := ""
+		if hasFeature {
+			checksumValues := make([]string, 0, len(checksums))
+			for _, checksum := range checksums {
+				checksumValues = append(checksumValues, checksum.GetAlgo()) // Assuming sbom.GetChecksum has a Value() method
+			}
+			value = strings.Join(checksumValues, ",")
+		}
+		return hasFeature, value, nil
+
 	case "comp_with_licenses":
-		return len(comp.Licenses()) > 0, nil
+		licenses := comp.Licenses()
+		hasFeature := len(licenses) > 0
+		licenseNames := make([]string, 0, len(licenses))
+
+		for _, l := range licenses {
+			licenseNames = append(licenseNames, l.Name())
+		}
+		value := ""
+		if hasFeature {
+			value = strings.Join(licenseNames, ",")
+		}
+		return hasFeature, value, nil
+
 	default:
-		return false, fmt.Errorf("unsupported component feature: %s", feature)
+		return false, "", fmt.Errorf("unsupported component feature: %s", feature)
 	}
 }
 
 // evaluateSBOMFeature evaluates an SBOM-based feature for the document
 func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error) {
 	switch feature {
+
 	case "sbom_creation_timestamp":
 		timestamp := doc.Spec().GetCreationTimestamp()
 		return timestamp != "", timestamp, nil
+
 	case "sbom_authors":
 		authors := doc.Authors()
 		hasAuthors := len(authors) > 0
@@ -158,6 +279,7 @@ func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error
 			value = strings.Join(authorNames, ", ")
 		}
 		return hasAuthors, value, nil
+
 	case "sbom_with_creator_and_version":
 		if len(doc.Tools()) > 0 {
 			tool := doc.Tools()[0]
@@ -165,32 +287,55 @@ func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error
 			return true, value, nil
 		}
 		return false, "", nil
+
 	case "sbom_with_primary_component":
 		if doc.PrimaryComp() != nil {
 			return true, doc.PrimaryComp().GetName(), nil
 		}
 		return false, "", nil
+
 	case "sbom_dependencies":
 		if doc.PrimaryComp() != nil {
 			count := doc.PrimaryComp().GetTotalNoOfDependencies()
 			return count > 0, fmt.Sprintf("%d dependencies", count), nil
 		}
 		return false, "", nil
-	case "sbom_required_fields":
-		// TODO: Implement logic to check for sbom_required_fields
-		return true, "Document fields present", nil
+
 	case "sbom_sharable":
-		// TODO: Implement logic to check for a sharable license
-		return false, "", nil
+		lics := doc.Spec().GetLicenses()
+		if len(lics) == 0 {
+			return false, "", nil
+		}
+
+		licenseNames := make([]string, 0, len(lics))
+		freeLicCount := 0
+		for _, l := range lics {
+			if l != nil {
+				licenseNames = append(licenseNames, l.Name())
+				if l.FreeAnyUse() {
+					freeLicCount++
+				}
+			}
+		}
+		hasFeature := len(lics) > 0 && freeLicCount == len(lics)
+		value := strings.Join(licenseNames, ",")
+		if !hasFeature {
+			value = "Not present"
+		}
+		return hasFeature, value, nil
+
 	case "sbom_parsable":
-		// TODO: Implement logic to check for parsability
-		return true, "SBOM is parsable", nil
+		return doc.Spec().Parsable(), "SBOM is parsable", nil
+
 	case "sbom_spec":
 		return doc.Spec().GetSpecType() != "", doc.Spec().GetSpecType(), nil
+
 	case "sbom_spec_file_format":
 		return doc.Spec().FileFormat() != "", doc.Spec().FileFormat(), nil
+
 	case "sbom_spec_version":
 		return doc.Spec().GetVersion() != "", doc.Spec().GetVersion(), nil
+
 	default:
 		return false, "", fmt.Errorf("unsupported SBOM feature: %s", feature)
 	}
@@ -199,28 +344,40 @@ func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error
 // featureToPropertyName converts a feature name to a human-readable property name
 func featureToPropertyName(feature string) string {
 	switch feature {
+
 	case "sbom_creation_timestamp":
 		return "Creation Timestamp"
+
 	case "sbom_authors":
 		return "Authors"
+
 	case "sbom_with_creator_and_version":
 		return "Creator and Version"
+
 	case "sbom_with_primary_component":
 		return "Primary Component"
+
 	case "sbom_dependencies":
 		return "Dependencies"
+
 	case "sbom_required_fields":
 		return "Required Fields"
+
 	case "sbom_sharable":
 		return "Sharable License"
+
 	case "sbom_parsable":
 		return "Parsable"
+
 	case "sbom_spec":
 		return "Specification"
+
 	case "sbom_spec_file_format":
 		return "File Format"
+
 	case "sbom_spec_version":
 		return "Spec Version"
+
 	default:
 		return strings.ReplaceAll(strings.TrimPrefix(feature, "sbom_"), "_", " ")
 	}

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -47,12 +47,13 @@ func ComponentsListResult(ctx context.Context, features []string, doc sbom.Docum
 	feature := features[0]
 	result.Feature = feature
 
-	// Determine if the feature is component-based or SBOM-based
+	// determine if the feature is component-based or SBOM-based
 	if strings.HasPrefix(feature, "comp_") {
-		// Component-based feature
+
+		// component-based feature
 		result.Components = []ComponentResult{}
 
-		// Evaluate the feature for each component
+		// evaluate the feature for each component
 		for _, comp := range doc.Components() {
 			hasFeature, err := evaluateComponentFeature(feature, comp)
 			if err != nil {
@@ -70,6 +71,7 @@ func ComponentsListResult(ctx context.Context, features []string, doc sbom.Docum
 			}
 		}
 	} else if strings.HasPrefix(feature, "sbom_") {
+
 		// SBOM-based feature
 		hasFeature, value, err := evaluateSBOMFeature(feature, doc)
 		if err != nil {
@@ -112,24 +114,23 @@ func evaluateComponentFeature(feature string, comp sbom.GetComponent) (bool, err
 	case "comp_with_uniq_ids":
 		return comp.GetID() != "", nil
 	case "comp_valid_licenses":
-		// Assuming a method to check if the license is valid (simplified for now)
 		licenses := comp.Licenses()
 		return len(licenses) > 0 && licenses[0].Name() != "NOASSERTION", nil
 	case "comp_with_any_vuln_lookup_id":
-		// Simplified: assuming a method to check for vulnerability lookup IDs
-		return false, nil // Placeholder
+		// TODO: Implement logic to check for any vulnerability lookup ID
+		return false, nil
 	case "comp_with_deprecated_licenses":
-		// Simplified: assuming a method to check for deprecated licenses
-		return false, nil // Placeholder
+		// TODO: Implement logic to check for any deprecated licenses
+		return false, nil
 	case "comp_with_multi_vuln_lookup_id":
-		// Simplified: assuming a method to check for multiple vulnerability lookup IDs
-		return false, nil // Placeholder
+		// TODO: Implement logic to check for any multi vulnerability lookup ID
+		return false, nil
 	case "comp_with_primary_purpose":
-		// Simplified: assuming a method to check for primary purpose
-		return false, nil // Placeholder
+		// TODO: Implement logic to check for any primary purpose
+		return false, nil
 	case "comp_with_restrictive_licenses":
-		// Simplified: assuming a method to check for restrictive licenses
-		return false, nil // Placeholder
+		// TODO: Implement logic to check for any restrictive licenses
+		return false, nil
 	case "comp_with_checksums":
 		return len(comp.GetChecksums()) > 0, nil
 	case "comp_with_licenses":
@@ -152,7 +153,7 @@ func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error
 		if hasAuthors {
 			authorNames := make([]string, len(authors))
 			for i, author := range authors {
-				authorNames[i] = author.GetName() // Assuming GetName() retrieves the author's name as a string
+				authorNames[i] = author.GetName()
 			}
 			value = strings.Join(authorNames, ", ")
 		}
@@ -176,13 +177,13 @@ func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error
 		}
 		return false, "", nil
 	case "sbom_required_fields":
-		// Simplified: assuming required fields are always present if the document is parsed
+		// TODO: Implement logic to check for sbom_required_fields
 		return true, "Document fields present", nil
 	case "sbom_sharable":
-		// Simplified: assuming a method to check for a sharable license
-		return false, "", nil // Placeholder
+		// TODO: Implement logic to check for a sharable license
+		return false, "", nil
 	case "sbom_parsable":
-		// Assuming the document is parsable if it was successfully parsed
+		// TODO: Implement logic to check for parsability
 		return true, "SBOM is parsable", nil
 	case "sbom_spec":
 		return doc.Spec().GetSpecType() != "", doc.Spec().GetSpecType(), nil

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/interlynk-io/sbomqs/pkg/logger"
+	"github.com/interlynk-io/sbomqs/pkg/sbom"
+)
+
+func ComponentsListResult(ctx context.Context, features []string, doc sbom.Document, path string, missing bool) (*ListResult, error) {
+	log := logger.FromContext(ctx)
+	log.Debug("list.ComponentsListResult()")
+
+	result := &ListResult{
+		FilePath: path,
+		Missing:  missing,
+	}
+
+	if doc == nil {
+		log.Debugf("sbom document is nil\n")
+		return result, fmt.Errorf("sbom document is nil")
+	}
+
+	// Validate the feature
+	if len(features) != 1 {
+		log.Debug("exactly one feature must be specified")
+		result.Errors = append(result.Errors, "exactly one feature must be specified")
+		return result, fmt.Errorf("exactly one feature must be specified")
+	}
+
+	feature := features[0]
+	result.Feature = feature
+
+	// Determine if the feature is component-based or SBOM-based
+	if strings.HasPrefix(feature, "comp_") {
+		// Component-based feature
+		result.Components = []ComponentResult{}
+
+		// Evaluate the feature for each component
+		for _, comp := range doc.Components() {
+			hasFeature, err := evaluateComponentFeature(feature, comp)
+			if err != nil {
+				log.Debugf("failed to evaluate feature %s for component: %v", feature, err)
+				result.Errors = append(result.Errors, fmt.Sprintf("failed to evaluate feature %s for component: %v", feature, err))
+				continue
+			}
+
+			matchesCriteria := (hasFeature && !missing) || (!hasFeature && missing)
+			if matchesCriteria {
+				result.Components = append(result.Components, ComponentResult{
+					Name:    comp.GetName(),
+					Version: comp.GetVersion(),
+				})
+			}
+		}
+	} else if strings.HasPrefix(feature, "sbom_") {
+		// SBOM-based feature
+		hasFeature, value, err := evaluateSBOMFeature(feature, doc)
+		if err != nil {
+			log.Debugf("failed to evaluate feature %s for document: %v", feature, err)
+			result.Errors = append(result.Errors, fmt.Sprintf("failed to evaluate feature %s for document: %v", feature, err))
+			return result, err
+		}
+
+		matchesCriteria := (hasFeature && !missing) || (!hasFeature && missing)
+		result.DocumentProperty = DocumentPropertyResult{
+			Property: featureToPropertyName(feature),
+			Present:  hasFeature,
+		}
+
+		if matchesCriteria {
+			if hasFeature {
+				result.DocumentProperty.Value = value
+			} else {
+				result.DocumentProperty.Value = "Not present"
+			}
+		}
+	} else {
+		log.Debugf("feature %s must start with 'comp_' or 'sbom_'", feature)
+		result.Errors = append(result.Errors, fmt.Sprintf("feature %s must start with 'comp_' or 'sbom_'", feature))
+		return result, fmt.Errorf("feature %s must start with 'comp_' or 'sbom_'", feature)
+	}
+
+	return result, nil
+}
+
+// evaluateComponentFeature evaluates a component-based feature for a single component
+func evaluateComponentFeature(feature string, comp sbom.GetComponent) (bool, error) {
+	switch feature {
+	case "comp_with_name":
+		return comp.GetName() != "", nil
+	case "comp_with_version":
+		return comp.GetVersion() != "", nil
+	case "comp_with_supplier":
+		return comp.Suppliers().IsPresent(), nil
+	case "comp_with_uniq_ids":
+		return comp.GetID() != "", nil
+	case "comp_valid_licenses":
+		// Assuming a method to check if the license is valid (simplified for now)
+		licenses := comp.Licenses()
+		return len(licenses) > 0 && licenses[0].Name() != "NOASSERTION", nil
+	case "comp_with_any_vuln_lookup_id":
+		// Simplified: assuming a method to check for vulnerability lookup IDs
+		return false, nil // Placeholder
+	case "comp_with_deprecated_licenses":
+		// Simplified: assuming a method to check for deprecated licenses
+		return false, nil // Placeholder
+	case "comp_with_multi_vuln_lookup_id":
+		// Simplified: assuming a method to check for multiple vulnerability lookup IDs
+		return false, nil // Placeholder
+	case "comp_with_primary_purpose":
+		// Simplified: assuming a method to check for primary purpose
+		return false, nil // Placeholder
+	case "comp_with_restrictive_licenses":
+		// Simplified: assuming a method to check for restrictive licenses
+		return false, nil // Placeholder
+	case "comp_with_checksums":
+		return len(comp.GetChecksums()) > 0, nil
+	case "comp_with_licenses":
+		return len(comp.Licenses()) > 0, nil
+	default:
+		return false, fmt.Errorf("unsupported component feature: %s", feature)
+	}
+}
+
+// evaluateSBOMFeature evaluates an SBOM-based feature for the document
+func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error) {
+	switch feature {
+	case "sbom_creation_timestamp":
+		timestamp := doc.Spec().GetCreationTimestamp()
+		return timestamp != "", timestamp, nil
+	case "sbom_authors":
+		authors := doc.Authors()
+		hasAuthors := len(authors) > 0
+		value := ""
+		if hasAuthors {
+			authorNames := make([]string, len(authors))
+			for i, author := range authors {
+				authorNames[i] = author.GetName() // Assuming GetName() retrieves the author's name as a string
+			}
+			value = strings.Join(authorNames, ", ")
+		}
+		return hasAuthors, value, nil
+	case "sbom_with_creator_and_version":
+		if len(doc.Tools()) > 0 {
+			tool := doc.Tools()[0]
+			value := fmt.Sprintf("%s v%s", tool.GetName(), tool.GetVersion())
+			return true, value, nil
+		}
+		return false, "", nil
+	case "sbom_with_primary_component":
+		if doc.PrimaryComp() != nil {
+			return true, doc.PrimaryComp().GetName(), nil
+		}
+		return false, "", nil
+	case "sbom_dependencies":
+		if doc.PrimaryComp() != nil {
+			count := doc.PrimaryComp().GetTotalNoOfDependencies()
+			return count > 0, fmt.Sprintf("%d dependencies", count), nil
+		}
+		return false, "", nil
+	case "sbom_required_fields":
+		// Simplified: assuming required fields are always present if the document is parsed
+		return true, "Document fields present", nil
+	case "sbom_sharable":
+		// Simplified: assuming a method to check for a sharable license
+		return false, "", nil // Placeholder
+	case "sbom_parsable":
+		// Assuming the document is parsable if it was successfully parsed
+		return true, "SBOM is parsable", nil
+	case "sbom_spec":
+		return doc.Spec().GetSpecType() != "", doc.Spec().GetSpecType(), nil
+	case "sbom_spec_file_format":
+		return doc.Spec().FileFormat() != "", doc.Spec().FileFormat(), nil
+	case "sbom_spec_version":
+		return doc.Spec().GetVersion() != "", doc.Spec().GetVersion(), nil
+	default:
+		return false, "", fmt.Errorf("unsupported SBOM feature: %s", feature)
+	}
+}
+
+// featureToPropertyName converts a feature name to a human-readable property name
+func featureToPropertyName(feature string) string {
+	switch feature {
+	case "sbom_creation_timestamp":
+		return "Creation Timestamp"
+	case "sbom_authors":
+		return "Authors"
+	case "sbom_with_creator_and_version":
+		return "Creator and Version"
+	case "sbom_with_primary_component":
+		return "Primary Component"
+	case "sbom_dependencies":
+		return "Dependencies"
+	case "sbom_required_fields":
+		return "Required Fields"
+	case "sbom_sharable":
+		return "Sharable License"
+	case "sbom_parsable":
+		return "Parsable"
+	case "sbom_spec":
+		return "Specification"
+	case "sbom_spec_file_format":
+		return "File Format"
+	case "sbom_spec_version":
+		return "Spec Version"
+	default:
+		return strings.ReplaceAll(strings.TrimPrefix(feature, "sbom_"), "_", " ")
+	}
+}

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ComponentsListResult lists components or SBOM properties based on the specified features for multiple local SBOMs
-func ComponentsListResult(ctx context.Context, ep *ListParams) (*ListResult, error) {
+func ComponentsListResult(ctx context.Context, ep *Params) (*Result, error) {
 	log := logger.FromContext(ctx)
 	log.Debug("list.ComponentsListResult()")
 
@@ -53,9 +53,9 @@ func ComponentsListResult(ctx context.Context, ep *ListParams) (*ListResult, err
 }
 
 // processPaths processes all local paths (files, directories) and generates ListResult for each SBOM and feature
-func processPaths(ctx context.Context, ep *ListParams) ([]*ListResult, error) {
+func processPaths(ctx context.Context, ep *Params) ([]*Result, error) {
 	log := logger.FromContext(ctx)
-	var results []*ListResult
+	var results []*Result
 
 	for _, path := range ep.Path {
 		// Get all file paths (handles files and directories)
@@ -139,7 +139,7 @@ func parseSBOMDocument(ctx context.Context, filePath string) (sbom.Document, err
 }
 
 // processFeatureForSBOM processes a single feature for an SBOM document and returns a ListResult
-func processFeatureForSBOM(ctx context.Context, ep *ListParams, doc sbom.Document, filePath, feature string) (*ListResult, error) {
+func processFeatureForSBOM(ctx context.Context, ep *Params, doc sbom.Document, filePath, feature string) (*Result, error) {
 	log := logger.FromContext(ctx)
 	feature = strings.TrimSpace(feature)
 
@@ -149,7 +149,7 @@ func processFeatureForSBOM(ctx context.Context, ep *ListParams, doc sbom.Documen
 		return nil, fmt.Errorf("feature cannot be empty")
 	}
 
-	result := &ListResult{
+	result := &Result{
 		FilePath: filePath,
 		Feature:  feature,
 		Missing:  ep.Missing,
@@ -168,7 +168,7 @@ func processFeatureForSBOM(ctx context.Context, ep *ListParams, doc sbom.Documen
 }
 
 // processComponentFeature processes a component-based feature for an SBOM document
-func processComponentFeature(ctx context.Context, ep *ListParams, doc sbom.Document, result *ListResult) (*ListResult, error) {
+func processComponentFeature(ctx context.Context, ep *Params, doc sbom.Document, result *Result) (*Result, error) {
 	log := logger.FromContext(ctx)
 	result.Components = []ComponentResult{}
 	var totalComponents int
@@ -199,7 +199,7 @@ func processComponentFeature(ctx context.Context, ep *ListParams, doc sbom.Docum
 }
 
 // processSBOMFeature processes an SBOM-based feature for an SBOM document
-func processSBOMFeature(ctx context.Context, ep *ListParams, doc sbom.Document, result *ListResult) (*ListResult, error) {
+func processSBOMFeature(ctx context.Context, ep *Params, doc sbom.Document, result *Result) (*Result, error) {
 	log := logger.FromContext(ctx)
 
 	// SBOM-based feature
@@ -228,7 +228,7 @@ func processSBOMFeature(ctx context.Context, ep *ListParams, doc sbom.Document, 
 }
 
 // generateReport generates the report for the list command results
-func generateReport(ctx context.Context, results []*ListResult, ep *ListParams) error {
+func generateReport(ctx context.Context, results []*Result, ep *Params) error {
 	// log := logger.FromContext(ctx)
 
 	reportFormat := "basic"

--- a/pkg/list/report.go
+++ b/pkg/list/report.go
@@ -28,10 +28,10 @@ import (
 	"sigs.k8s.io/release-utils/version"
 )
 
-type OptionList func(r *ListReport)
+type OptionList func(r *Report)
 
-func NewListReport(ctx context.Context, results []*ListResult, opts ...OptionList) *ListReport {
-	r := &ListReport{
+func NewListReport(ctx context.Context, results []*Result, opts ...OptionList) *Report {
+	r := &Report{
 		Ctx:     ctx,
 		Results: results,
 	}
@@ -43,27 +43,27 @@ func NewListReport(ctx context.Context, results []*ListResult, opts ...OptionLis
 }
 
 func WithFormat(c string) OptionList {
-	return func(r *ListReport) {
+	return func(r *Report) {
 		r.Format = c
 	}
 }
 
 func WithColor(c bool) OptionList {
-	return func(r *ListReport) {
+	return func(r *Report) {
 		r.Color = c
 	}
 }
 
 // listReport holds the state for reporting the list command results
-type ListReport struct {
+type Report struct {
 	Ctx     context.Context
-	Results []*ListResult
+	Results []*Result
 	Format  string
 	Color   bool
 }
 
 // Report renders the list command results in the specified format
-func (r *ListReport) Report() {
+func (r *Report) Report() {
 	if r.Format == "basic" {
 		r.basicReport()
 	} else if r.Format == "detailed" {
@@ -76,7 +76,7 @@ func (r *ListReport) Report() {
 }
 
 // basicReport renders the list command results in basic format
-func (r *ListReport) basicReport() {
+func (r *Report) basicReport() {
 	for _, result := range r.Results {
 		presence := "present"
 		if result.Missing {
@@ -91,7 +91,7 @@ func (r *ListReport) basicReport() {
 }
 
 // detailedReport renders the list command results in detailed (table) format
-func (r *ListReport) detailedReport() {
+func (r *Report) detailedReport() {
 	for _, result := range r.Results {
 		presence := "present"
 		if result.Missing {
@@ -194,7 +194,7 @@ func newJSONReport() *jsonReport {
 }
 
 // jsonReport renders the list command results in JSON format
-func (r *ListReport) jsonReport() {
+func (r *Report) jsonReport() {
 	jr := newJSONReport()
 	for _, result := range r.Results {
 		f := file{

--- a/pkg/list/report.go
+++ b/pkg/list/report.go
@@ -97,7 +97,7 @@ func (r *ListReport) detailedReport() {
 		if result.Missing {
 			presence = "missing"
 		}
-		fmt.Printf("File: %s\nFeature: %s (%s)\n", result.FilePath, result.Feature, presence)
+		fmt.Printf("File: %s\tFeature: %s (%s)\n", result.FilePath, result.Feature, presence)
 
 		// Initialize tablewriter
 		table := tablewriter.NewWriter(os.Stdout)
@@ -146,6 +146,7 @@ func (r *ListReport) detailedReport() {
 		table.SetColWidth(50)                          // Adjust width to accommodate "Feature" column content
 		table.SetAutoMergeCellsByColumnIndex([]int{0}) // Merge "Feature" column for consecutive rows
 		table.Render()
+		fmt.Println()
 	}
 }
 

--- a/pkg/list/report.go
+++ b/pkg/list/report.go
@@ -1,0 +1,233 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/google/uuid"
+	"github.com/olekukonko/tablewriter"
+	"sigs.k8s.io/release-utils/version"
+)
+
+type OptionList func(r *ListReport)
+
+func NewListReport(ctx context.Context, results []*ListResult, opts ...OptionList) *ListReport {
+	r := &ListReport{
+		Ctx:     ctx,
+		Results: results,
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+func WithFormat(c string) OptionList {
+	return func(r *ListReport) {
+		r.Format = c
+	}
+}
+
+func WithColor(c bool) OptionList {
+	return func(r *ListReport) {
+		r.Color = c
+	}
+}
+
+// listReport holds the state for reporting the list command results
+type ListReport struct {
+	Ctx     context.Context
+	Results []*ListResult
+	Format  string
+	Color   bool
+}
+
+// Report renders the list command results in the specified format
+func (r *ListReport) Report() {
+	if r.Format == "basic" {
+		r.basicReport()
+	} else if r.Format == "detailed" {
+		r.detailedReport()
+	} else if r.Format == "json" {
+		r.jsonReport()
+	} else {
+		r.detailedReport()
+	}
+}
+
+// basicReport renders the list command results in basic format
+func (r *ListReport) basicReport() {
+	for _, result := range r.Results {
+		presence := "present"
+		if result.Missing {
+			presence = "missing"
+		}
+		if strings.HasPrefix(result.Feature, "comp_") {
+			fmt.Printf("\n%s: %s (%s): %d/%d components\n", result.FilePath, result.Feature, presence, len(result.Components), result.TotalComponents)
+		} else {
+			fmt.Printf("\n%s: %s (%s): %s\n", result.FilePath, result.Feature, presence, result.DocumentProperty.Value)
+		}
+	}
+}
+
+// detailedReport renders the list command results in detailed (table) format
+func (r *ListReport) detailedReport() {
+	for _, result := range r.Results {
+		presence := "present"
+		if result.Missing {
+			presence = "missing"
+		}
+		fmt.Printf("File: %s\nFeature: %s (%s)\n", result.FilePath, result.Feature, presence)
+
+		// Initialize tablewriter
+		table := tablewriter.NewWriter(os.Stdout)
+		if strings.HasPrefix(result.Feature, "comp_") {
+			// Component-based feature
+			table.SetHeader([]string{"Feature", "Component Name", "Version"})
+			featureCol := fmt.Sprintf("%s (%d/%d)", result.Feature, len(result.Components), result.TotalComponents)
+			if len(result.Components) == 0 {
+				// No components to display
+				if r.Color {
+					featureCol = color.New(color.FgHiCyan).Sprint(featureCol)
+					table.Append([]string{featureCol, "(none)", ""})
+				} else {
+					table.Append([]string{featureCol, "(none)", ""})
+				}
+			} else {
+				// List components
+				for _, comp := range result.Components {
+					if r.Color {
+						featureCol = color.New(color.FgHiCyan).Sprint(featureCol)
+						nameCol := color.New(color.FgHiBlue).Sprint(comp.Name)
+						versionCol := color.New(color.FgHiBlue).Sprint(comp.Version)
+						table.Append([]string{featureCol, nameCol, versionCol})
+					} else {
+						table.Append([]string{featureCol, comp.Name, comp.Version})
+					}
+				}
+			}
+		} else {
+			// SBOM-based feature
+			featureCol := fmt.Sprintf("%s (%s)", result.Feature, presence)
+			if r.Color {
+				featureCol = color.New(color.FgHiCyan).Sprint(featureCol)
+				propertyCol := color.New(color.FgHiBlue).Sprint(result.DocumentProperty.Key)
+				valueCol := color.New(color.FgHiBlue).Sprint(result.DocumentProperty.Value)
+				table.Append([]string{featureCol, propertyCol, valueCol})
+			} else {
+				table.Append([]string{featureCol, result.DocumentProperty.Key, result.DocumentProperty.Value})
+			}
+		}
+
+		// Configure table settings
+		table.SetHeader([]string{"Feature", "Key/Component Name", "Value/Version"})
+		table.SetRowLine(true)
+		// Set column widths to prevent distortion
+		table.SetColWidth(50)                          // Adjust width to accommodate "Feature" column content
+		table.SetAutoMergeCellsByColumnIndex([]int{0}) // Merge "Feature" column for consecutive rows
+		table.Render()
+	}
+}
+
+type component struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+type documentProperty struct {
+	Key     string `json:"key"`
+	Value   string `json:"value"`
+	Present bool   `json:"present"`
+}
+type file struct {
+	Name             string           `json:"file_name"`
+	Feature          string           `json:"feature"`
+	Missing          bool             `json:"missing"`
+	TotalComponents  int              `json:"total_components,omitempty"`
+	Components       []component      `json:"components,omitempty"`
+	DocumentProperty documentProperty `json:"document_property,omitempty"`
+	Errors           []string         `json:"errors"`
+}
+type creation struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Vendor  string `json:"vendor"`
+}
+type jsonReport struct {
+	RunID        string   `json:"run_id"`
+	TimeStamp    string   `json:"timestamp"`
+	CreationInfo creation `json:"creation_info"`
+	Files        []file   `json:"files"`
+}
+
+func newJSONReport() *jsonReport {
+	return &jsonReport{
+		RunID:     uuid.New().String(),
+		TimeStamp: time.Now().UTC().Format(time.RFC3339),
+		CreationInfo: creation{
+			Name:    "sbomqs",
+			Version: version.GetVersionInfo().GitVersion,
+			Vendor:  "Interlynk (support@interlynk.io)",
+		},
+		Files: []file{},
+	}
+}
+
+// jsonReport renders the list command results in JSON format
+func (r *ListReport) jsonReport() {
+	jr := newJSONReport()
+	for _, result := range r.Results {
+		f := file{
+			Name:    result.FilePath,
+			Feature: result.Feature,
+			Missing: result.Missing,
+			Errors:  result.Errors,
+		}
+
+		if strings.HasPrefix(result.Feature, "comp_") {
+			// Component-based feature
+			f.TotalComponents = result.TotalComponents
+			for _, comp := range result.Components {
+				f.Components = append(f.Components, component{
+					Name:    comp.Name,
+					Version: comp.Version,
+				})
+			}
+		} else {
+			// SBOM-based feature
+			f.DocumentProperty = documentProperty{
+				Key:     result.DocumentProperty.Key,
+				Value:   result.DocumentProperty.Value,
+				Present: result.DocumentProperty.Present,
+			}
+		}
+
+		jr.Files = append(jr.Files, f)
+	}
+
+	o, err := json.MarshalIndent(jr, "", "  ")
+	if err != nil {
+		fmt.Printf("Failed to print JSON report: %v\n", err)
+		return
+	}
+	fmt.Println(string(o))
+}

--- a/pkg/list/types.go
+++ b/pkg/list/types.go
@@ -14,7 +14,7 @@
 
 package list
 
-type ListResult struct {
+type Result struct {
 	FilePath         string
 	Feature          string
 	Missing          bool
@@ -36,7 +36,7 @@ type DocumentResult struct {
 	Present bool   // Indicates if the property is present
 }
 
-type ListParams struct {
+type Params struct {
 	Path []string
 
 	// input control

--- a/pkg/list/types.go
+++ b/pkg/list/types.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+type ListResult struct {
+	FilePath         string
+	Feature          string
+	Missing          bool
+	Components       []ComponentResult      // For component-based features
+	DocumentProperty DocumentPropertyResult // For SBOM-based features
+	Errors           []string
+}
+
+type ComponentResult struct {
+	Name    string
+	Version string
+}
+
+type DocumentPropertyResult struct {
+	Property string // e.g., "Authors", "Creation Timestamp"
+	Value    string // e.g., "John Doe", "2023-01-12T22:06:03Z"
+	Present  bool   // Indicates if the property is present
+}

--- a/pkg/list/types.go
+++ b/pkg/list/types.go
@@ -18,8 +18,9 @@ type ListResult struct {
 	FilePath         string
 	Feature          string
 	Missing          bool
-	Components       []ComponentResult      // For component-based features
-	DocumentProperty DocumentPropertyResult // For SBOM-based features
+	TotalComponents  int
+	Components       []ComponentResult // For component-based features
+	DocumentProperty DocumentResult    // For SBOM-based features
 	Errors           []string
 }
 
@@ -29,8 +30,25 @@ type ComponentResult struct {
 	Values  string
 }
 
-type DocumentPropertyResult struct {
-	Property string // e.g., "Authors", "Creation Timestamp"
-	Value    string // e.g., "John Doe", "2023-01-12T22:06:03Z"
-	Present  bool   // Indicates if the property is present
+type DocumentResult struct {
+	Key     string // e.g., "Authors", "Creation Timestamp"
+	Value   string // e.g., "John Doe", "2023-01-12T22:06:03Z"
+	Present bool   // Indicates if the property is present
+}
+
+type ListParams struct {
+	Path []string
+
+	// input control
+	Features []string
+
+	// output control
+	JSON     bool
+	Basic    bool
+	Detailed bool
+	Color    bool
+
+	Missing bool
+
+	Debug bool
 }

--- a/pkg/list/types.go
+++ b/pkg/list/types.go
@@ -26,6 +26,7 @@ type ListResult struct {
 type ComponentResult struct {
 	Name    string
 	Version string
+	Values  string
 }
 
 type DocumentPropertyResult struct {

--- a/pkg/scorer/ntia.go
+++ b/pkg/scorer/ntia.go
@@ -116,7 +116,10 @@ func compWithUniqIDCheck(d sbom.Document, c *check) score {
 
 func docWithDepedenciesCheck(d sbom.Document, c *check) score {
 	s := newScoreFromCheck(c)
-	totalDependencies := d.PrimaryComp().GetTotalNoOfDependencies()
+	var totalDependencies int
+	if d.PrimaryComp() != nil {
+		totalDependencies = d.PrimaryComp().GetTotalNoOfDependencies()
+	}
 	if totalDependencies > 0 {
 		s.setScore(10.0)
 	}


### PR DESCRIPTION
closes #400 

This PR adds the following changes:
- This PR introduces the list command to the sbomqs CLI, enabling users to list components or SBOM properties based on specific features, with support for the  --missing flag to filter for absent features. 

TODO:
- Bit more testing
- O/p in proper format
- Implementation of remaining deature.

Short Demo:
![image](https://github.com/user-attachments/assets/67164016-3478-4def-84ed-e6004b3c7e56)


