### PR TITLE
cleanup and rel fixes

### DIFF
--- a/Compliance.md
+++ b/Compliance.md
@@ -114,7 +114,7 @@ The [OpenChain Telco](https://github.com/OpenChain-Project/Reference-Material/bl
 
 ## NTIA minimum elements: SBOM Requirements for NTIA
 
-The [NTIA](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2.pdf) specifies mandatory properties for an SBOM. Below is how we have derived all the values.
+The [NTIA](https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf) specifies mandatory properties for an SBOM. Below is how we have derived all the values.
 
 - Released:
 - Contact:

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -358,7 +358,7 @@ func (s *SpdxDoc) parsePrimaryCompAndRelationships() {
 	}
 
 	for _, r := range s.doc.Relationships {
-		if strings.ToUpper(r.Relationship) == spdx_common.TypeRelationshipDependsOn {
+		if strings.ToUpper(r.Relationship) == spdx_common.TypeRelationshipContains {
 			aBytes, err = r.RefA.MarshalJSON()
 			if err != nil {
 				continue

--- a/pkg/scorer/scorer.go
+++ b/pkg/scorer/scorer.go
@@ -16,7 +16,6 @@ package scorer
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/interlynk-io/sbomqs/pkg/sbom"
 )
@@ -70,12 +69,10 @@ func (s *Scorer) Score() Scores {
 	}
 
 	if len(s.featFilter) > 0 {
-		fmt.Println("featureScores()")
 		return s.featureScores()
 	}
 
 	if len(s.catFilter) > 0 {
-		fmt.Println("catScores()")
 		return s.catScores()
 	}
 

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -57,13 +57,6 @@ func sentToBenchmark(js string) (string, error) {
 		Body: io.NopCloser(strings.NewReader(js)),
 	}
 
-	// // Save a copy of this request for debugging.
-	///	requestDump, err := httputil.DumpRequest(req, true)
-	//	if err != nil {
-	//		fmt.Println(err)
-	///	}
-	//		fmt.Println(string(requestDump))
-
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This PR adds the following changes:
- It updates the Relationship type from `DEPENDS_ON` to `CONTAINS`. 
- Remove print statement.
- Updated the correct URL for NTIA
- remove commented code

More on why `CONTAINS` fits better for referencing correct dependencies of components.
- https://spdx.github.io/spdx-ntia-sbom-howto/#_3_understanding_an_ntia_minimum_elements_spdx_sbom

![image](https://github.com/user-attachments/assets/80b5fcfd-9f0e-4ff9-9d51-6e051038eba6)

```bash
➜ go run main.go score -c NTIA-minimum-elements  samples/photon.spdx.json
SBOM Quality by Interlynk Score:8.5	components:38	samples/photon.spdx.json
+-----------------------+-------------------------+-----------+--------------------------------+
|       CATEGORY        |         FEATURE         |   SCORE   |              DESC              |
+-----------------------+-------------------------+-----------+--------------------------------+
| NTIA-minimum-elements | comp_with_name          | 10.0/10.0 | 38/38 have names               |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_supplier      | 0.0/10.0  | 0/38 have supplier names       |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_uniq_ids      | 10.0/10.0 | 38/38 have unique ID's         |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_version       | 9.7/10.0  | 37/38 have versions            |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_authors            | 10.0/10.0 | doc has 1 authors              |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_creation_timestamp | 10.0/10.0 | doc has creation timestamp     |
|                       |                         |           | 2023-01-12T22:06:03Z           |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_dependencies       | 10.0/10.0 | doc has 1 dependencies         |
+-----------------------+-------------------------+-----------+--------------------------------+

.../sbomqs on 🌿 cleanup/print_stmt [$] via 🔵🦦🔵 v1.23.1  via 🐍 v3.12.3 (myenv) via 💎 v3.2.0 
➜ sbomqs score -c NTIA-minimum-elements samples/photon.spdx.json                      
catScores()
SBOM Quality by Interlynk Score:7.1	components:38	samples/photon.spdx.json
+-----------------------+-------------------------+-----------+--------------------------------+
|       CATEGORY        |         FEATURE         |   SCORE   |              DESC              |
+-----------------------+-------------------------+-----------+--------------------------------+
| NTIA-minimum-elements | comp_with_name          | 10.0/10.0 | 38/38 have names               |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_supplier      | 0.0/10.0  | 0/38 have supplier names       |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_uniq_ids      | 10.0/10.0 | 38/38 have unique ID's         |
+                       +-------------------------+-----------+--------------------------------+
|                       | comp_with_version       | 9.7/10.0  | 37/38 have versions            |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_authors            | 10.0/10.0 | doc has 1 authors              |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_creation_timestamp | 10.0/10.0 | doc has creation timestamp     |
|                       |                         |           | 2023-01-12T22:06:03Z           |
+                       +-------------------------+-----------+--------------------------------+
|                       | sbom_dependencies       | 0.0/10.0  | doc has 0 dependencies         |
+-----------------------+-------------------------+-----------+--------------------------------+

```