### PR TITLE
add primary comp version

### DIFF
--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -425,7 +425,7 @@ func evaluateSBOMFeature(feature string, doc sbom.Document) (bool, string, error
 
 	case "sbom_with_primary_component":
 		if doc.PrimaryComp() != nil {
-			return true, doc.PrimaryComp().GetName(), nil
+			return true, doc.PrimaryComp().GetName() + "  " + doc.PrimaryComp().GetVersion(), nil
 		}
 		return false, "", nil
 
@@ -490,7 +490,7 @@ func featureToPropertyName(feature string) string {
 		return "Creator and Version"
 
 	case "sbom_with_primary_component":
-		return "Primary Component"
+		return "Primary Component and Version"
 
 	case "sbom_dependencies":
 		return "Dependencies"

--- a/pkg/sbom/primarycomp.go
+++ b/pkg/sbom/primarycomp.go
@@ -18,6 +18,7 @@ type GetPrimaryComp interface {
 	IsPresent() bool
 	GetID() string
 	GetName() string
+	GetVersion() string
 	GetTotalNoOfDependencies() int
 	HasDependencies() bool
 	GetDependencies() []string
@@ -29,6 +30,7 @@ type PrimaryComp struct {
 	Dependecies     int
 	HasDependency   bool
 	Name            string
+	Version         string
 	AllDependencies []string
 }
 
@@ -42,6 +44,10 @@ func (pc PrimaryComp) GetID() string {
 
 func (pc PrimaryComp) GetName() string {
 	return pc.Name
+}
+
+func (pc PrimaryComp) GetVersion() string {
+	return pc.Version
 }
 
 func (pc PrimaryComp) GetTotalNoOfDependencies() int {

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -352,6 +352,7 @@ func (s *SpdxDoc) parsePrimaryCompAndRelationships() {
 			for _, pack := range s.doc.Packages {
 				if string(pack.PackageSPDXIdentifier) == modified {
 					s.PrimaryComponent.Name = pack.PackageName
+					s.PrimaryComponent.Version = pack.PackageVersion
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds the following changes:
- Adds the primary comp version.
- When list command look for a feature `--feature=sbom_with_primary_component`, it should return primary comp as well as it's version.