### PR TITLE
update few license as free to use

### DIFF
--- a/pkg/licenses/embed_licenses.go
+++ b/pkg/licenses/embed_licenses.go
@@ -36,6 +36,7 @@ type spdxLicenseDetail struct {
 	SeeAlso            []string `json:"seeAlso"`
 	IsOsiApproved      bool     `json:"isOsiApproved"`
 	IsFsfLibre         bool     `json:"isFsfLibre"`
+	IsFreeAnyUse       bool     `json:"isFreeAnyUse"`
 }
 
 type aboutCodeLicenseDetail struct {
@@ -78,7 +79,7 @@ func loadSpdxLicense() error {
 			fsfLibre:    l.IsFsfLibre,
 			restrictive: false,
 			exception:   false,
-			freeAnyUse:  false,
+			freeAnyUse:  l.IsFreeAnyUse,
 			source:      "spdx",
 		}
 	}

--- a/pkg/licenses/files/licenses_spdx.json
+++ b/pkg/licenses/files/licenses_spdx.json
@@ -12,7 +12,8 @@
         "http://landley.net/toybox/license.html",
         "https://opensource.org/licenses/0BSD"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFreeAnyUse":true
     },
     {
       "reference": "https://spdx.org/licenses/3D-Slicer-1.0.html",
@@ -2018,7 +2019,8 @@
         "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
       ],
       "isOsiApproved": false,
-      "isFsfLibre": true
+      "isFsfLibre": true,
+      "isFreeAnyUse": true
     },
     {
       "reference": "https://spdx.org/licenses/CDDL-1.0.html",
@@ -7850,7 +7852,8 @@
         "https://unlicense.org/"
       ],
       "isOsiApproved": true,
-      "isFsfLibre": true
+      "isFsfLibre": true,
+      "isFreeAnyUse": true
     },
     {
       "reference": "https://spdx.org/licenses/UPL-1.0.html",


### PR DESCRIPTION
This PR adds the following changes:
- Enables `true` as `freeAnyUse` for licenses [CC0](https://spdx.org/licenses/CC0-1.0), [Unlicense](https://spdx.org/licenses/Unlicense.html), [0BSD](https://spdx.org/licenses/0BSD.html)