### PR TITLE
add show flag to show values for resp features

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -40,6 +40,7 @@ type userListCmd struct {
 	json     bool
 	detailed bool
 	color    bool
+	show     bool
 
 	// Debug control
 	debug bool
@@ -67,11 +68,13 @@ var listCmd = &cobra.Command{
   # Component features: 
   [comp_with_name, comp_with_version, comp_with_supplier, comp_with_uniq_ids, comp_valid_licenses, comp_with_any_vuln_lookup_id, 
   comp_with_deprecated_licenses, comp_with_multi_vuln_lookup_id, comp_with_primary_purpose, comp_with_restrictive_licenses, 
-  comp_with_checksums, comp_with_licenses]
+  comp_with_checksums, comp_with_licenses, comp_with_checksums_sha256, comp_with_source_code_uri, comp_with_source_code_hash, 
+  comp_with_executable_uri, comp_with_associated_license, comp_with_concluded_license, comp_with_declared_license]
   
   # SBOM features:
   [sbom_creation_timestamp, sbom_authors, sbom_with_creator_and_version, sbom_with_primary_component, sbom_dependencies, 
-  sbom_sharable, sbom_parsable, sbom_spec, sbom_spec_file_format, sbom_spec_version]
+  sbom_sharable, sbom_parsable, sbom_spec, sbom_file_format, sbom_spec_version, spec_with_version_compliant, sbom_with_uri,
+  sbom_with_vuln, sbom_build_process]
 `,
 
 	Args: func(_ *cobra.Command, args []string) error {
@@ -130,6 +133,9 @@ func parseListParams(cmd *cobra.Command, args []string) *userListCmd {
 	color, _ := cmd.Flags().GetBool("color")
 	uCmd.color = color
 
+	show, _ := cmd.Flags().GetBool("show")
+	uCmd.show = show
+
 	// Debug control
 	debug, _ := cmd.Flags().GetBool("debug")
 	uCmd.debug = debug
@@ -147,6 +153,7 @@ func fromListToEngineParams(uCmd *userListCmd) *engine.Params {
 		Detailed: uCmd.detailed,
 		Color:    uCmd.color,
 		Debug:    uCmd.debug,
+		Show:     uCmd.show,
 	}
 }
 
@@ -166,6 +173,7 @@ func init() {
 	listCmd.Flags().BoolP("json", "j", false, "Results in JSON")
 	listCmd.Flags().BoolP("detailed", "d", true, "Results in table format, default")
 	listCmd.Flags().BoolP("color", "l", false, "Output in color")
+	listCmd.Flags().BoolP("show", "s", false, "Show values of features, (default: false)")
 
 	// Debug Control
 	listCmd.Flags().BoolP("debug", "D", false, "Enable debug logging")

--- a/pkg/engine/list.go
+++ b/pkg/engine/list.go
@@ -31,6 +31,7 @@ func parseListParams(ep *Params) *list.Params {
 		Color:    ep.Color,
 		Missing:  ep.Missing,
 		Debug:    ep.Debug,
+		Show:     ep.Show,
 	}
 }
 

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -52,6 +52,7 @@ type Params struct {
 	Missing bool
 
 	Debug bool
+	Show  bool
 
 	ConfigPath string
 

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -146,6 +146,8 @@ func parseSBOMDocument(ctx context.Context, filePath string) (sbom.Document, err
 // processFeatureForSBOM processes a single feature for an SBOM document and returns a ListResult
 func processFeatureForSBOM(ctx context.Context, ep *Params, doc sbom.Document, filePath, feature string) (*Result, error) {
 	log := logger.FromContext(ctx)
+	log.Debug("list.processFeatureForSBOM()")
+	log.Debug("processing feature: ", feature)
 	feature = strings.TrimSpace(feature)
 
 	// Validate the feature
@@ -175,6 +177,7 @@ func processFeatureForSBOM(ctx context.Context, ep *Params, doc sbom.Document, f
 // processComponentFeature processes a component-based feature for an SBOM document
 func processComponentFeature(ctx context.Context, ep *Params, doc sbom.Document, result *Result) (*Result, error) {
 	log := logger.FromContext(ctx)
+	log.Debug("processing component feature: ", result.Feature)
 	result.Components = []ComponentResult{}
 	var totalComponents int
 
@@ -243,8 +246,9 @@ func generateReport(ctx context.Context, results []*Result, ep *Params) error {
 		reportFormat = "json"
 	}
 	coloredOutput := ep.Color
+	show := ep.Show
 
-	lnr := NewListReport(ctx, results, WithFormat(strings.ToLower(reportFormat)), WithColor(coloredOutput))
+	lnr := NewListReport(ctx, results, WithFormat(strings.ToLower(reportFormat)), WithColor(coloredOutput), WithValues(show))
 	lnr.Report()
 	return nil
 }

--- a/pkg/list/types.go
+++ b/pkg/list/types.go
@@ -47,6 +47,7 @@ type Params struct {
 	Basic    bool
 	Detailed bool
 	Color    bool
+	Show     bool
 
 	Missing bool
 


### PR DESCRIPTION
closes: https://github.com/interlynk-io/sbomqs/issues/436

This PR adds the following changes:
- It add `show` flag which represents values of the respective feature.

For examples:
`comp_with_licenses`: on specifying a `show` flag, it will show the values of each components that has license:
```bash
$ go run main.go list --feature comp_with_licenses ../../viveksahu26/workspace/sboms/VulnCon-SBOM-Workshop/kubectl-v0.31.1.cdx.json --show

File: ../../viveksahu26/workspace/sboms/VulnCon-SBOM-Workshop/kubectl-v0.31.1.cdx.json	Feature: comp_with_licenses (present)
+----------------------------+----------------------------------------+--------------------------------------+--------------------------------+
|          FEATURE           |             COMPONENT NAME             |               VERSION                |             VALUE              |
+----------------------------+----------------------------------------+--------------------------------------+--------------------------------+
| comp_with_licenses (66/89) | github.com/blang/semver/v4             | 4.0.0                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/json-iterator/go            | 1.1.12                               | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/MakeNowJust/heredoc         | 1.0.0                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | gopkg.in/yaml.v3                       | 3.0.1                                | Apache License 2.0,MIT License |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/davecgh/go-spew             | 1.1.2-0.20180830191138-d8f796af33cc  | ISC License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/go-openapi/jsonreference    | 0.20.2                               | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/go-openapi/swag             | 0.22.4                               | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/jonboulle/clockwork         | 0.2.2                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/moby/term                   | 0.5.0                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/oauth2                    | 0.21.0                               | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/term                      | 0.21.0                               | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/tools                     | 0.21.1-0.20240508182429-e35e4ccd0d2d | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/gogo/protobuf               | 1.3.2                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/google/gnostic-models       | 0.6.8                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/google/go-cmp               | 0.6.0                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/modern-go/concurrent        | 0.0.0-20180306012644-bacd9c7ef1dd    | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/spf13/cobra                 | 1.8.1                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | sigs.k8s.io/json                       | 0.0.0-20221116044647-bc3834ca7abd    | Apache License 2.0,BSD         |
|                            |                                        |                                      | 3-Clause "New" or "Revised"    |
|                            |                                        |                                      | License                        |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/distribution/reference      | 0.5.0                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/emicklei/go-restful/v3      | 3.11.0                               | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/liggitt/tabwriter           | 0.0.0-20181228230101-89fcab3d43de    | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/modern-go/reflect2          | 1.0.2                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/opencontainers/go-digest    | 1.0.0                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/net                       | 0.26.0                               | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/mxk/go-flowrate             | 0.0.0-20140419014527-cca7078d478f    | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/peterbourgon/diskv          | 2.0.1+incompatible                   | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/imdario/mergo               | 0.3.6                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/inconshreveable/mousetrap   | 1.1.0                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/fatih/camelcase             | 1.0.0                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/russross/blackfriday/v2     | 2.1.0                                | BSD 2-Clause "Simplified"      |
|                            |                                        |                                      | License                        |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/sys                       | 0.21.0                               | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/monochromegane/go-gitignore | 0.0.0-20200626010858-205db1a8cc00    | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/Azure/go-ansiterm           | 0.0.0-20210617225240-d185dfc1b5a1    | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/go-logr/logr                | 1.4.2                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/stretchr/testify            | 1.9.0                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/time                      | 0.3.0                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/lithammer/dedent            | 1.1.0                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/mitchellh/go-wordwrap       | 1.0.1                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/munnerz/goautoneg           | 0.0.0-20191010083416-a7dc8b61c822    | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | gopkg.in/yaml.v2                       | 2.4.0                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/exponent-io/jsonpath        | 0.0.0-20151013193312-d6023ce2651d    | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/google/uuid                 | 1.6.0                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/mailru/easyjson             | 0.7.7                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | go.starlark.net                        | 0.0.0-20230525235612-a134d8f9ddca    | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/chai2010/gettext-go         | 1.0.2                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/go-errors/errors            | 1.4.2                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/google/shlex                | 0.0.0-20191202100458-e7afc7fbc510    | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/josharian/intern            | 1.0.0                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | sigs.k8s.io/yaml                       | 1.4.0                                | Apache License 2.0,BSD         |
|                            |                                        |                                      | 3-Clause "New" or "Revised"    |
|                            |                                        |                                      | License,MIT License            |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/golang/protobuf             | 1.5.4                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/spf13/pflag                 | 1.0.5                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/xlab/treeprint              | 1.2.0                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | sigs.k8s.io/structured-merge-diff/v4   | 4.4.1                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/gorilla/websocket           | 1.5.0                                | BSD 2-Clause "Simplified"      |
|                            |                                        |                                      | License                        |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/pmezard/go-difflib          | 1.0.1-0.20181226105442-5d4384ee4fb2  | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/sync                      | 0.7.0                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | golang.org/x/text                      | 0.16.0                               | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | gopkg.in/inf.v0                        | 0.9.1                                | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | kubectl-0.31.1                         |                                      | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/google/btree                | 1.0.1                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/google/gofuzz               | 1.2.0                                | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/x448/float16                | 0.8.4                                | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/go-openapi/jsonpointer      | 0.19.6                               | Apache License 2.0             |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/gregjones/httpcache         | 0.0.0-20180305231024-9cad4c3443a7    | MIT License                    |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | github.com/pkg/errors                  | 0.9.1                                | BSD 2-Clause "Simplified"      |
|                            |                                        |                                      | License                        |
+                            +----------------------------------------+--------------------------------------+--------------------------------+
|                            | google.golang.org/protobuf             | 1.34.2                               | BSD 3-Clause "New" or          |
|                            |                                        |                                      | "Revised" License              |
+----------------------------+----------------------------------------+--------------------------------------+--------------------------------+


```