### PR TITLE
fix spec version value

### DIFF
--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -185,7 +185,7 @@ func (s *SpdxDoc) parseDoc() {
 func (s *SpdxDoc) parseSpec() {
 	sp := NewSpec()
 	sp.Format = string(s.format)
-	sp.Version = string(s.version)
+	sp.Version = s.doc.SPDXVersion
 
 	if s.doc.CreationInfo != nil {
 		for _, c := range s.doc.CreationInfo.Creators {


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomqs/issues/463

This PR adds the following changes:
- fixes spec version

It works nos:
```bash
go run main.go  score -c Structural  SPDXTagExample-v2.3.spdx
SBOM Quality by Interlynk Score:10.0	components:1	SPDXTagExample-v2.3.spdx
+------------+-------------------+-----------+--------------------------------+
|  CATEGORY  |      FEATURE      |   SCORE   |              DESC              |
+------------+-------------------+-----------+--------------------------------+
| Structural | sbom_spec         | 10.0/10.0 | provided sbom is in a          |
|            |                   |           | supported sbom format of       |
|            |                   |           | spdx,cyclonedx                 |
+            +-------------------+-----------+--------------------------------+
|            | sbom_spec_version | 10.0/10.0 | provided sbom should be in     |
|            |                   |           | supported spec version for     |
|            |                   |           | spec:SPDX-2.3 and versions:    |
|            |                   |           | SPDX-2.1,SPDX-2.2,SPDX-2.3     |
+            +-------------------+-----------+--------------------------------+
|            | sbom_file_format  | 10.0/10.0 | provided sbom should be in     |
|            |                   |           | supported file format for      |
|            |                   |           | spec: tag-value and version:   |
|            |                   |           | json,yaml,rdf,tag-value        |
+            +-------------------+-----------+--------------------------------+
|            | sbom_parsable     | 10.0/10.0 | provided sbom is parsable      |
+------------+-------------------+-----------+--------------------------------+


```
and sbom is present here: https://github.com/spdx/ntia-conformance-checker/blob/main/tests/data/missing_author_name/SPDXTagExample-v2.3.spdx