### PR TITLE
report non-violation as well

### DIFF
--- a/pkg/policy/result.go
+++ b/pkg/policy/result.go
@@ -18,21 +18,30 @@ import "time"
 
 // Result represent the evaluation result of policay against SBOM
 type Result struct {
-	Name         string      `json:"name,omitempty"`
-	Type         string      `json:"type,omitempty"`
-	Action       string      `json:"action,omitempty"`
-	Result       string      `json:"result"`
-	Violations   []Violation `json:"violations,omitempty"`
-	TotalChecked int         `json:"total_checked,omitempty"`
-	ViolationCnt int         `json:"violation_count,omitempty"`
-	GeneratedAt  time.Time   `json:"generated_at,omitempty"`
+	Name          string         `json:"name,omitempty"`
+	Type          string         `json:"type,omitempty"`
+	Action        string         `json:"action,omitempty"`
+	Result        string         `json:"result"`                    // overall: pass|warn|fail
+	PolicyResults []PolicyResult `json:"policy_results,omitempty"`  // both passes & fails
+	TotalChecked  int            `json:"total_checked,omitempty"`   // number of components scanned
+	ViolationCnt  int            `json:"violation_count,omitempty"` // number of failed policy_results
+	GeneratedAt   time.Time      `json:"generated_at,omitempty"`
 }
 
-type Violation struct {
-	ComponentName string   `json:"component_name"`
-	Field         string   `json:"field"`
-	Actual        []string `json:"actual,omitempty"`
-	Reason        string   `json:"reason"`
+// type Violation struct {
+// 	ComponentName string   `json:"component_name"`
+// 	Field         string   `json:"field"`
+// 	Actual        []string `json:"actual,omitempty"`
+// 	Reason        string   `json:"reason"`
+// }
+
+type PolicyResult struct {
+	ComponentID   string   `json:"component_id,omitempty"`   // component unique id (or "<document>")
+	ComponentName string   `json:"component_name,omitempty"` // friendly name
+	Field         string   `json:"field"`                    // the field evaluated (e.g., license)
+	Actual        []string `json:"actual,omitempty"`         // actual values seen on SBOM
+	Outcome       string   `json:"outcome"`                  // "pass" | "fail"
+	Reason        string   `json:"reason,omitempty"`         // human-friendly reason for failure
 }
 
 func NewResult(p Policy) *Result {


### PR DESCRIPTION
This PR adds the following changes:
- Earlier for multiple policies, the result for violation were shown but not for  non-violation.
- Therefore, now it also shows non-violation as well as violation results.
- Each policy represent one table with respective rules in it.

### BASIC REPORT
<img width="1335" height="334" alt="image" src="https://github.com/user-attachments/assets/c8fd3e82-e0d8-4c0b-a5d4-7deb903b7147" />

### Table Report
<img width="1643" height="985" alt="image" src="https://github.com/user-attachments/assets/bf600d0d-9ee7-470f-9c51-497b65948fb0" />
<img width="1637" height="654" alt="image" src="https://github.com/user-attachments/assets/c91d4450-d080-4427-8c4e-dbc13513c9ec" />
