### PR TITLE
[specs/SBOMQS-2.0-SPEC.md] Minor fixes and suggestions

### DIFF
--- a/specs/SBOMQS-2.0-SPEC.md
+++ b/specs/SBOMQS-2.0-SPEC.md
@@ -839,8 +839,6 @@ Improvements needed:
 - CC-BY-ND (no derivatives)
 - Proprietary licenses
 
-- https://github.com/interlynk-io/sbomqs/blob/main/specs/SBOMQS-2.0-SPEC.md#permissive-licenses-examples
-
 ### Permissive Licenses (Examples)
 - MIT
 - Apache-2.0


### PR DESCRIPTION
Just some minor fixes after a quick review (i.e. not at all thorough).

--------

IMO, a few other flaws exist or may exist:

- https://github.com/interlynk-io/sbomqs/blob/main/specs/SBOMQS-2.0-SPEC.md#important-differences , bullet point 3: "BSI v2.0 requires signature files"

  Really as a hard requirement, i.e. the whole check / evaluation fails, when no signature file is provided?  IMO this would raise this requirement above all other requirements, instead of simply lowering the score if it is missing or the signature check fails.

- Licences https://github.com/interlynk-io/sbomqs/blob/main/specs/SBOMQS-2.0-SPEC.md#deprecated-licenses-examples

  Out of these, **only** GPL-1.0, LGPL-2.0 and AGPL-1.0 have become obsolete (i.e, are really deprecated), because not only GPL, LGPL and AGPL are significantly different licences, also the v2.x and v3.0 versions contain fundamental differences which practically renders them as "different licenses", too.  Consequently some projects have switched to `GPL-v2-only` (from `GPL-v2-or-later`), the Linux kernel was always licensed `GPL-v2`, and the `LGPL-2.1` still is widely adopted; furthermore, all three points seeem gain followers who see to have realised the drawbacks of `*PLv3*`.  Lastly the v3.0 versions of the `*GPL` licences are the most recent verions of `*GPL*`-licenses documents availablöe
  
- Licences, again https://github.com/interlynk-io/sbomqs/blob/main/specs/SBOMQS-2.0-SPEC.md#permissive-licenses-examples
  
  CC0-1.0 is **not** a permissive licence, **`CC0`** puts the so licensed good into the public domain.