### PR TITLE
small fix

### DIFF
--- a/pkg/reporter/v2/detailed.go
+++ b/pkg/reporter/v2/detailed.go
@@ -78,7 +78,7 @@ func (r *Reporter) detailedReport() {
 				var prs proTable
 
 				prs.profilesHeader = []string{"PROFILE", "FEATURE", "STATUS", "DESC"}
-				prs.messages = fmt.Sprintf("\n SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s\n", proResult.Score, proResult.Grade, r.Meta.NumComponents, EngineVersion, r.Meta.Filename)
+				prs.messages = fmt.Sprintf("\n SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s", proResult.InterlynkScore, proResult.Grade, r.Meta.NumComponents, EngineVersion, r.Meta.Filename)
 
 				for _, pFeatResult := range proResult.Items {
 					l := []string{proResult.Name, pFeatResult.Key, fmt.Sprintf("%.1f/10.0", pFeatResult.Score), pFeatResult.Desc}
@@ -98,8 +98,8 @@ func (r *Reporter) detailedReport() {
 
 		if len(pros) > 0 {
 			for _, prs := range pros {
-				fmt.Println(prs.messages)
-				newTable(prs.profilesDoc, prs.profilesHeader, "Profile Detailed Score:")
+				fmt.Print(prs.messages)
+				newTable(prs.profilesDoc, prs.profilesHeader, "")
 			}
 		}
 

--- a/pkg/scorer/v2/profiles/profile.go
+++ b/pkg/scorer/v2/profiles/profile.go
@@ -82,7 +82,6 @@ func evaluateEachProfile(ctx context.Context, doc sbom.Document, profile catalog
 	}
 	proResult.InterlynkScore = formulae.ComputeInterlynkProfScore(proResult)
 	proResult.Grade = formulae.ToGrade(proResult.InterlynkScore)
-
 	if countNonNA > 0 {
 		proResult.Score = sumScore / float64(countNonNA)
 	}

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -410,10 +410,14 @@ func filterProfiles(ctx context.Context, profiles []string) []catalog.ProfSpec {
 		case "oct":
 			log.Debugf("filterProfiles: selecting profile %q", profile)
 			finalProfiles = append(finalProfiles, profileOCTSpec)
+
+		case "interlynk":
+			log.Debugf("filterProfiles: selecting profile %q", profile)
+			finalProfiles = append(finalProfiles, profileInterlynkSpec)
+
 		default:
 			unknown = append(unknown, profile)
 			log.Debugf("filterProfiles: unknown profile %q, skip", profile)
-			//
 		}
 
 	}
@@ -550,7 +554,7 @@ var defaultProfiles = []catalog.ProfSpec{
 
 var profileInterlynkSpec = catalog.ProfSpec{
 	Key:         ProfileNTIA,
-	Name:        "Interlynk",
+	Name:        "Interlynk Profile",
 	Description: "Interlynk Default Scoring Profile",
 	Features: []catalog.ProfFeatSpec{
 		{Key: "comp_with_name", Description: "components with name", Required: false, Evaluate: profiles.CompWithName},

--- a/pkg/scorer/v2/score/score.go
+++ b/pkg/scorer/v2/score/score.go
@@ -166,9 +166,6 @@ func evaluateProfiles(ctx context.Context, catal *catalog.Catalog, doc sbom.Docu
 
 	// Evaluate all profiles and get the results
 	profResults := profiles.Evaluate(ctx, catal, doc)
-
-	// result.InterlynkScore = formulae.ComputeInterlynkProfScore(profResults)
-	// result.Grade = formulae.ToGrade(result.InterlynkScore)
 	result.Profiles = &profResults
 
 	return *result, nil


### PR DESCRIPTION
This PR fix following changes:
- fix some layout issue, correct grading
- also support profile flag for interlynk

Beow 3 explicti profiles(ntia,bsi-v1.1,interlynk) are scored in seperated table, and also interlynk is added as profile
```bash
go run main.go score --profile ntia,bsi-v1.1,interlynk  samples/policy/complete-sbom.spdx.json 

 SBOM Quality Score: 10.0/10.0	 Grade: A	Components: 5 	 EngineVersion: 1	File: samples/policy/complete-sbom.spdx.json
+-----------------------+---------------------+-----------+--------------------------------+
|        PROFILE        |       FEATURE       |  STATUS   |              DESC              |
+-----------------------+---------------------+-----------+--------------------------------+
| NTIA Minimum Elements | sbom_machine_format | 10.0/10.0 | present json                   |
+                       +---------------------+-----------+--------------------------------+
|                       | comp_with_name      | 10.0/10.0 | 5/5 have name                  |
+                       +---------------------+-----------+--------------------------------+
|                       | comp_with_version   | 10.0/10.0 | 5/5 have versions              |
+                       +---------------------+-----------+--------------------------------+
|                       | comp_other_uniq_ids | 10.0/10.0 | 5/5 have unique ID             |
+                       +---------------------+-----------+--------------------------------+
|                       | sbom_dependencies   | 10.0/10.0 | primary comp has 0             |
|                       |                     |           | dependencies                   |
+                       +---------------------+-----------+--------------------------------+
|                       | sbom_creator        | 10.0/10.0 | present 5 legal authors        |
+                       +---------------------+-----------+--------------------------------+
|                       | sbom_timestamp      | 10.0/10.0 | present 2025-06-06T05:52:18Z   |
+-----------------------+---------------------+-----------+--------------------------------+


 SBOM Quality Score: 7.7/10.0	 Grade: C	Components: 5 	 EngineVersion: 1	File: samples/policy/complete-sbom.spdx.json
+---------------------+----------------------+-----------+--------------------------------+
|       PROFILE       |       FEATURE        |  STATUS   |              DESC              |
+---------------------+----------------------+-----------+--------------------------------+
| BSI TR-03183-2 v1.1 | sbom_spec            | 10.0/10.0 | present spdx                   |
+                     +----------------------+-----------+--------------------------------+
|                     | sbom_spec_version    | 10.0/10.0 | present SPDX-2.3               |
+                     +----------------------+-----------+--------------------------------+
|                     | sbom_build           | 0.0/10.0  | N/A (SPDX)                     |
+                     +----------------------+-----------+--------------------------------+
|                     | sbom_depth           | 10.0/10.0 | primary comp has 0             |
|                     |                      |           | dependencies                   |
+                     +----------------------+-----------+--------------------------------+
|                     | sbom_creator         | 10.0/10.0 | present 5 legal authors        |
+                     +----------------------+-----------+--------------------------------+
|                     | sbom_timestamp       | 10.0/10.0 | present 2025-06-06T05:52:18Z   |
+                     +----------------------+-----------+--------------------------------+
|                     | sbom_uri             | 10.0/10.0 | present namespace              |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_name            | 10.0/10.0 | 5/5 have name                  |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_version         | 10.0/10.0 | 5/5 have versions              |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_license         | 10.0/10.0 | 5/5 have licenses              |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_hash            | 10.0/10.0 | 5/5 have hash                  |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_source_code_url | 0.0/10.0  | 0/5 have source code repo      |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_download_url    | 10.0/10.0 | 5/5 have download URIs         |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_source_hash     | 0.0/10.0  | 0/5 have source code hash      |
+                     +----------------------+-----------+--------------------------------+
|                     | comp_depth           | 6.0/10.0  | 3/5 have dependencies          |
+---------------------+----------------------+-----------+--------------------------------+


 SBOM Quality Score: 7.8/10.0	 Grade: C	Components: 5 	 EngineVersion: 1	File: samples/policy/complete-sbom.spdx.json
+-------------------+-----------------------------+-----------+------------------------------+
|      PROFILE      |           FEATURE           |  STATUS   |             DESC             |
+-------------------+-----------------------------+-----------+------------------------------+
| Interlynk Profile | comp_with_name              | 10.0/10.0 | 5/5 have name                |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_version           | 10.0/10.0 | 5/5 have versions            |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_identifiers       | 10.0/10.0 | 5/5 have unique ID           |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_creation_timestamp     | 10.0/10.0 | present 2025-06-06T05:52:18Z |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_authors                | 10.0/10.0 | present 5 legal authors      |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_tool_version           | 10.0/10.0 | present 2025-06-06T05:52:18Z |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_supplier               | 0.0/10.0  | missing authors              |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_namespace              | 10.0/10.0 | present namespace            |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_lifecycle              | 0.0/10.0  | N/A (SPDX)                   |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_checksums         | 10.0/10.0 | 5/5 have hash256             |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_sha256            | 10.0/10.0 | 5/5 have SHA-256+            |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_signature              | 0.0/10.0  | missing signature bundle     |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_dependencies      | 6.0/10.0  | 3/5 have dependencies        |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_source_code       | 0.0/10.0  | 0/5 have source code repo    |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_supplier          | 10.0/10.0 | 5/5 have names               |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_licenses          | 10.0/10.0 | 5/5 have licenses            |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_valid_licenses    | 10.0/10.0 | 5/5 have licenses            |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_declared_licenses | 0.0/10.0  | 0/5 have declared license    |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_purl              | 10.0/10.0 | 5/5 have unique ID           |
+                   +-----------------------------+-----------+------------------------------+
|                   | comp_with_cpe               | 10.0/10.0 | 5/5 have unique ID           |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_spec_declared          | 10.0/10.0 | present spdx                 |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_spec_version           | 10.0/10.0 | present SPDX-2.3             |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_file_format            | 10.0/10.0 | present json                 |
+                   +-----------------------------+-----------+------------------------------+
|                   | sbom_schema_valid           | 10.0/10.0 | present valid schema         |
+-------------------+-----------------------------+-----------+------------------------------+



Feedback form on enhancing the SBOM quality:  https://forms.gle/anFSspwrk7uSfD7Q6


```