### PR TITLE
add dt as alias of dtrackScore cmd

### DIFF
--- a/cmd/dtrackScore.go
+++ b/cmd/dtrackScore.go
@@ -27,6 +27,7 @@ import (
 // dtrackScoreCmd represents the dtrackScore command
 var dtrackScoreCmd = &cobra.Command{
 	Use:          "dtrackScore <project-id>",
+	Aliases:      []string{"dt"},
 	Short:        "generate an sbom quality score for a given project id from dependency track",
 	Long:         `dtrackScore allows your to score the sbom quality of a project from dependency track.`,
 	SilenceUsage: true,


### PR DESCRIPTION
This PR adds the following changes:
- adds `dt` as the alias of `dtrackScore` command