### PR TITLE
Bunch of fixes to diplay and scoring.

### DIFF
--- a/pkg/scorer/v2/extractors/completeness.go
+++ b/pkg/scorer/v2/extractors/completeness.go
@@ -81,14 +81,14 @@ func SBOMWithPrimaryComponent(doc sbom.Document) catalog.ComprFeatScore {
 	if !commonV2.HasSBOMPrimaryComponent(doc) {
 		return catalog.ComprFeatScore{
 			Score:  formulae.PerComponentScore(0, len(comps)),
-			Desc:   "absent",
+			Desc:   "add primary component",
 			Ignore: true,
 		}
 	}
 
 	return catalog.ComprFeatScore{
 		Score:  formulae.BooleanScore(commonV2.HasSBOMPrimaryComponent(doc)),
-		Desc:   "identified",
+		Desc:   "complete",
 		Ignore: false,
 	}
 }

--- a/pkg/scorer/v2/extractors/structural.go
+++ b/pkg/scorer/v2/extractors/structural.go
@@ -70,7 +70,7 @@ func SBOMSpecVersion(doc sbom.Document) catalog.ComprFeatScore {
 		if ver == v {
 			return catalog.ComprFeatScore{
 				Score:  formulae.BooleanScore(true),
-				Desc:   ver,
+				Desc:   "v" + ver,
 				Ignore: false,
 			}
 		}
@@ -119,13 +119,13 @@ func SBOMSchemaValid(doc sbom.Document) catalog.ComprFeatScore {
 	if doc.SchemaValidation() {
 		return catalog.ComprFeatScore{
 			Score:  formulae.BooleanScore(true),
-			Desc:   "schema valid",
+			Desc:   "complete",
 			Ignore: false,
 		}
 	}
 	return catalog.ComprFeatScore{
 		Score:  formulae.BooleanScore(false),
-		Desc:   "schema invalid",
+		Desc:   "fix schema errors",
 		Ignore: false,
 	}
 }

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -169,9 +169,9 @@ var CompKeyToEvaluatingFunction = map[string]catalog.ComprFeatEval{
 	"sbom_namespace":          extractors.SBOMNamespace,
 	"sbom_lifecycle":          extractors.SBOMLifeCycle,
 
-	"comp_with_checksums": extractors.CompWithSHA1Plus,
-	"comp_with_sha256":    extractors.CompWithSHA256Plus,
-	"sbom_signature":      extractors.SBOMSignature,
+	"comp_with_strong_checksums": extractors.CompWithStrongChecksums,
+	"comp_with_weak_checksums":   extractors.CompWithWeakChecksums,
+	"sbom_signature":             extractors.SBOMSignature,
 
 	"comp_with_dependencies":     extractors.CompWithDependencies,
 	"sbom_completeness_declared": extractors.CompWithCompleteness,
@@ -522,8 +522,8 @@ var CatIntegritySpec = catalog.ComprCatSpec{
 	Description: "Allows for verification if artifacts were altered",
 	Weight:      15,
 	Features: []catalog.ComprFeatSpec{
-		{Key: "comp_with_checksums", Name: "Component With Checksums", Weight: 0.60, Ignore: false, Evaluate: extractors.CompWithSHA1Plus},
-		{Key: "comp_with_sha256", Name: "Component With SHA-256+", Weight: 0.30, Ignore: false, Evaluate: extractors.CompWithSHA256Plus},
+		{Key: "comp_with_strong_checksums", Name: "Component With Strong Checksums", Weight: 0.50, Ignore: false, Evaluate: extractors.CompWithStrongChecksums},
+		{Key: "comp_with_weak_checksums", Name: "Component With Weak Checksums", Weight: 0.40, Ignore: false, Evaluate: extractors.CompWithWeakChecksums},
 		{Key: "sbom_signature", Name: "Document Signature", Weight: 0.10, Ignore: false, Evaluate: extractors.SBOMSignature},
 	},
 }


### PR DESCRIPTION
Improves the detailed score report by adding inline weight percentages to categories and features, introducing a Category Summary table, and marking PURL/CPE as OR conditions. Descriptions are now action-oriented (e.g., "add to 3 components" instead of "3/117 have names"). The checksum scoring was split into comp_with_strong_checksums (SHA-224+,  SHA-3, BLAKE, Streebog, post-quantum) and comp_with_weak_checksums (MD2-6, SHA-1, Adler-32), where a component with at least one strong checksum gets full credit. Fixed inverted  scoring logic for deprecated/restrictive licenses (now scores components WITHOUT issues), and capped PerComponentScore at 9.9 when incomplete to prevent false 10.0/10.0 display.