### PR TITLE
fix(cli): Improve NTIA profile output consistency

### DIFF
--- a/pkg/reporter/v2/detailed.go
+++ b/pkg/reporter/v2/detailed.go
@@ -91,7 +91,7 @@ func (r *Reporter) detailedReport() {
 				var prs proTable
 
 				prs.profilesHeader = []string{"PROFILE", "FEATURE", "STATUS", "DESC"}
-				prs.messages = fmt.Sprintf("\n SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s", proResult.InterlynkScore, proResult.Grade, r.Meta.NumComponents, EngineVersion, r.Meta.Filename)
+				prs.messages = fmt.Sprintf("SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s", proResult.InterlynkScore, proResult.Grade, r.Meta.NumComponents, EngineVersion, r.Meta.Filename)
 
 				for _, pFeatResult := range proResult.Items {
 					l := []string{proResult.Name, pFeatResult.Key, fmt.Sprintf("%.1f/10.0", pFeatResult.Score), pFeatResult.Desc}
@@ -118,7 +118,8 @@ func (r *Reporter) detailedReport() {
 
 		if len(pros) > 0 {
 			for _, prs := range pros {
-				fmt.Print(prs.messages)
+				fmt.Println(prs.messages)
+				fmt.Println() 
 				newTable(prs.profilesDoc, prs.profilesHeader, "")
 			}
 		}

--- a/pkg/scorer/config.go
+++ b/pkg/scorer/config.go
@@ -46,7 +46,7 @@ type Features struct {
 // Category descriptions
 var categoryDescriptions = map[string]string{
 	"Structural":            "Features related to the SBOM's spec and format",
-	"NTIA-minimum-elements": "Features ensuring compliance with NTIA minimum elements for SBOMs",
+	"NTIA-minimum-elements": "Features ensuring compliance with NTIA minimum elements (2021) for SBOMs",
 	"bsi-v1.1":              "Features ensuring compliance with BSI v1.1 SBOM requirements",
 	"bsi-v2.0":              "Features ensuring compliance with BSI v2.0 SBOM requirements",
 	"Semantic":              "Features related to the meaning and completeness of SBOM data",

--- a/pkg/scorer/v2/profiles/common.go
+++ b/pkg/scorer/v2/profiles/common.go
@@ -227,7 +227,7 @@ func SBOMDepedencies(doc sbom.Document) catalog.ProfFeatScore {
 
 	return catalog.ProfFeatScore{
 		Score:  formulae.BooleanScore(true),
-		Desc:   fmt.Sprintf("primary comp has %d dependencies", have),
+		Desc:   "complete",
 		Ignore: false,
 	}
 }

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -660,7 +660,7 @@ var profileInterlynkSpec = catalog.ProfSpec{
 
 var profileNTIASpec = catalog.ProfSpec{
 	Key:         ProfileNTIA,
-	Name:        "NTIA Minimum Elements",
+	Name:        "NTIA Minimum Elements (2021)",
 	Description: "NTIA Minimum Elements Profile",
 	Features: []catalog.ProfFeatSpec{
 		{Key: "sbom_machine_format", Name: "Automation Support", Required: true, Description: "Valid spec (SPDX/CycloneDX) and format (JSON/XML)", Evaluate: profiles.SBOMAutomationSpec},


### PR DESCRIPTION
- Remove leading blank line in score report.
- Add blank line between score summary and profile table.
- Update NTIA profile name to 'NTIA Minimum Elements (2021)'.
- Standardize 'sbom_dependencies' description to 'complete' when score is 10.0/10.0.