### PR TITLE
Complete NTIA Minimum Elements (2021) Implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,20 +95,15 @@ lint: ## Run golangci-lint (requires golangci-lint installed)
 
 .PHONY: test
 test: generate ## Run all tests (unit tests first, then integration tests)
-	@echo "Running unit tests..."
+	@echo "Running tests..."
 	@set +e; \
-	go test -v -cover -race -failfast -p 1 $$(go list ./... | grep -v integration_test); \
+	go test -cover -race -failfast -p 1 $$(go list ./... | grep -v integration_test) 2>&1 | grep -E "^(ok|FAIL|coverage:)" | sed 's/github.com\/interlynk-io\/sbomqs\/v2\///' ; \
 	UNIT_EXIT_CODE=$$?; \
 	echo ""; \
-	echo "=========================================="; \
-	echo "Running SBOM Scoring Integration Tests"; \
-	echo "=========================================="; \
-	echo ""; \
-	go test -v -run Test_ScoreForStaticSBOMFiles_Summary ./pkg/scorer/v2/...; \
+	echo "Running integration tests..."; \
+	go test -run "Test_ScoreForStaticSBOMFiles_Summary|Test_NTIAProfile" ./pkg/scorer/v2/... 2>&1 | grep -E "(PASS|FAIL|ok|NTIA Profile:)" ; \
 	INTEGRATION_EXIT_CODE=$$?; \
 	echo ""; \
-	echo "=========================================="; \
-	echo "Test Summary"; \
 	echo "=========================================="; \
 	if [ $$UNIT_EXIT_CODE -ne 0 ]; then \
 		echo "✗ Unit tests: FAILED"; \
@@ -228,17 +223,14 @@ tidy: ## Run go mod tidy
 
 .PHONY: ci
 ci: deps generate vet ## Run CI pipeline locally with test summary
-	@echo "Running CI tests..."
+	@echo "Running CI pipeline..."
 	@set +e; \
-	echo "Running unit tests..."; \
-	go test -v -cover -race -failfast -p 1 $$(go list ./... | grep -v integration_test); \
+	echo "Unit tests:"; \
+	go test -cover -race -failfast -p 1 $$(go list ./... | grep -v integration_test) 2>&1 | grep -E "^(ok|FAIL|coverage:)" | sed 's/github.com\/interlynk-io\/sbomqs\/v2\///' ; \
 	UNIT_EXIT_CODE=$$?; \
 	echo ""; \
-	echo "=========================================="; \
-	echo "Running SBOM Scoring Integration Tests"; \
-	echo "=========================================="; \
-	echo ""; \
-	go test -v -run Test_ScoreForStaticSBOMFiles_Summary ./pkg/scorer/v2/...; \
+	echo "Integration tests:"; \
+	go test -run "Test_ScoreForStaticSBOMFiles_Summary|Test_NTIAProfile" ./pkg/scorer/v2/... 2>&1 | grep -E "(PASS|FAIL|ok|NTIA Profile:)" ; \
 	INTEGRATION_EXIT_CODE=$$?; \
 	echo ""; \
 	echo "=========================================="; \

--- a/pkg/reporter/v2/basic.go
+++ b/pkg/reporter/v2/basic.go
@@ -31,7 +31,14 @@ func (r *Reporter) basicReport() {
 			version = strings.Replace(version, "SPDX-", "", 1)
 		}
 
-		fmt.Printf("%0.1f\t%s\t%s\t%s\t%s\n", r.Comprehensive.InterlynkScore, r.Comprehensive.Grade, version, format, r.Meta.Filename)
-
+		// Handle profile mode
+		if r.Profiles != nil && len(r.Profiles.ProfResult) > 0 {
+			for _, prof := range r.Profiles.ProfResult {
+				fmt.Printf("%0.1f\t%s\t%s\t%s\t%s\t%s\n", prof.InterlynkScore, prof.Grade, prof.Name, version, format, r.Meta.Filename)
+			}
+		} else if r.Comprehensive != nil {
+			// Handle comprehensive mode
+			fmt.Printf("%0.1f\t%s\t%s\t%s\t%s\n", r.Comprehensive.InterlynkScore, r.Comprehensive.Grade, version, format, r.Meta.Filename)
+		}
 	}
 }

--- a/pkg/scorer/v2/formulae/farmulas.go
+++ b/pkg/scorer/v2/formulae/farmulas.go
@@ -236,8 +236,14 @@ func ComputeInterlynkProfScore(result api.ProfileResult) float64 {
 
 	var total int
 	for _, res := range result.Items {
-		total++
-		totalScore += res.Score
+		// Only include required fields in the score calculation
+		if res.Required {
+			total++
+			totalScore += res.Score
+		}
+	}
+	if total == 0 {
+		return 0.0
 	}
 	return totalScore / float64(total)
 }

--- a/pkg/scorer/v2/ntia_integration_test.go
+++ b/pkg/scorer/v2/ntia_integration_test.go
@@ -1,0 +1,354 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"math"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/config"
+	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/registry"
+	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/score"
+	"github.com/stretchr/testify/require"
+)
+
+type expectedNTIAScore struct {
+	Score    float64
+	Grade    string
+	Required int  // Number of required fields compliant (out of 8)
+	Optional int  // Number of optional fields present (out of 4)
+}
+
+func Test_NTIAProfileForStaticSBOMFiles(t *testing.T) {
+	base := filepath.Join("..", "..", "..", "testdata", "fixtures")
+
+	testCases := map[string]expectedNTIAScore{
+		// SPDX test cases
+		filepath.Join(base, "spdx-perfect-score.json"):    {Score: 8.8, Grade: "B", Required: 7, Optional: 3},
+		filepath.Join(base, "spdx-minimal.json"):          {Score: 3.8, Grade: "F", Required: 3, Optional: 1},
+		filepath.Join(base, "spdx-no-version.json"):       {Score: 3.8, Grade: "F", Required: 3, Optional: 2},
+		filepath.Join(base, "spdx-no-checksums.json"):     {Score: 7.5, Grade: "C", Required: 6, Optional: 2},
+		filepath.Join(base, "spdx-weak-checksums.json"):   {Score: 5.0, Grade: "D", Required: 4, Optional: 3},
+		filepath.Join(base, "spdx-no-dependencies.json"):  {Score: 7.5, Grade: "C", Required: 6, Optional: 3},
+		filepath.Join(base, "spdx-invalid-licenses.json"): {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		filepath.Join(base, "spdx-no-authors.json"):       {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		filepath.Join(base, "spdx-no-timestamp.json"):     {Score: 3.8, Grade: "F", Required: 3, Optional: 2},
+		filepath.Join(base, "spdx-old-version.json"):      {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		
+		// CycloneDX test cases  
+		filepath.Join(base, "cdx-perfect-score.json"):    {Score: 10.0, Grade: "A", Required: 8, Optional: 3},
+		filepath.Join(base, "cdx-minimal.json"):          {Score: 2.5, Grade: "F", Required: 2, Optional: 0},
+		filepath.Join(base, "cdx-no-version.json"):       {Score: 3.8, Grade: "F", Required: 3, Optional: 1},
+		filepath.Join(base, "cdx-no-checksums.json"):     {Score: 7.5, Grade: "C", Required: 6, Optional: 1},
+		filepath.Join(base, "cdx-weak-checksums.json"):   {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		filepath.Join(base, "cdx-no-dependencies.json"):  {Score: 7.5, Grade: "C", Required: 6, Optional: 2},
+		filepath.Join(base, "cdx-invalid-licenses.json"): {Score: 5.0, Grade: "D", Required: 4, Optional: 1},
+		filepath.Join(base, "cdx-no-authors.json"):       {Score: 5.0, Grade: "D", Required: 4, Optional: 1},
+		filepath.Join(base, "cdx-no-timestamp.json"):     {Score: 3.8, Grade: "F", Required: 3, Optional: 1},
+		filepath.Join(base, "cdx-old-version.json"):      {Score: 5.0, Grade: "D", Required: 4, Optional: 1},
+	}
+
+	for path, want := range testCases {
+		filename := filepath.Base(path)
+		testName := "NTIA_" + filename
+		
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.Config{
+				Profile: []string{string(registry.ProfileNTIA)},
+			}
+			paths := []string{path}
+
+			ctx := context.Background()
+
+			results, err := score.ScoreSBOM(ctx, cfg, paths)
+			require.NoError(t, err)
+
+			for _, r := range results {
+				require.NotNil(t, r.Profiles, "Profile results should not be nil")
+				require.Len(t, r.Profiles.ProfResult, 1, "Should have exactly one profile result")
+				
+				profResult := r.Profiles.ProfResult[0]
+				require.Equal(t, "NTIA Minimum Elements (2021)", profResult.Name)
+				
+				gotRaw := profResult.InterlynkScore
+				gotRounded := math.Round(gotRaw*10) / 10
+
+				// Count required and optional fields
+				requiredCompliant := 0
+				optionalPresent := 0
+				
+				for _, item := range profResult.Items {
+					if item.Required {
+						if item.Score >= 10.0 {
+							requiredCompliant++
+						}
+					} else {
+						if item.Score >= 10.0 {
+							optionalPresent++
+						}
+					}
+				}
+
+				// Log the score for visibility
+				t.Logf("File: %s | Score: %.1f/10.0 | Grade: %s | Required: %d/8 | Optional: %d/4", 
+					filename, gotRounded, profResult.Grade, requiredCompliant, optionalPresent)
+				t.Logf("  Expected: Score: %.1f | Grade: %s | Required: %d/8 | Optional: %d/4",
+					want.Score, want.Grade, want.Required, want.Optional)
+
+				// compare NTIA score
+				require.InDelta(t, want.Score, gotRounded, 1e-9,
+					"NTIA score (rounded to 1 decimal) mismatch for %s", filename)
+
+				// compare grade
+				require.Equal(t, want.Grade, profResult.Grade,
+					"Grade mismatch for %s", filename)
+					
+				// compare required fields count
+				require.Equal(t, want.Required, requiredCompliant,
+					"Required fields compliance count mismatch for %s", filename)
+					
+				// compare optional fields count
+				require.Equal(t, want.Optional, optionalPresent,
+					"Optional fields present count mismatch for %s", filename)
+			}
+		})
+	}
+}
+
+func Test_NTIAProfileForStaticSBOMFiles_Summary(t *testing.T) {
+	base := filepath.Join("..", "..", "..", "testdata", "fixtures")
+
+	testCases := map[string]expectedNTIAScore{
+		// SPDX test cases
+		filepath.Join(base, "spdx-perfect-score.json"):    {Score: 8.8, Grade: "B", Required: 7, Optional: 3},
+		filepath.Join(base, "spdx-minimal.json"):          {Score: 3.8, Grade: "F", Required: 3, Optional: 1},
+		filepath.Join(base, "spdx-no-version.json"):       {Score: 3.8, Grade: "F", Required: 3, Optional: 2},
+		filepath.Join(base, "spdx-no-checksums.json"):     {Score: 7.5, Grade: "C", Required: 6, Optional: 2},
+		filepath.Join(base, "spdx-weak-checksums.json"):   {Score: 5.0, Grade: "D", Required: 4, Optional: 3},
+		filepath.Join(base, "spdx-no-dependencies.json"):  {Score: 7.5, Grade: "C", Required: 6, Optional: 3},
+		filepath.Join(base, "spdx-invalid-licenses.json"): {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		filepath.Join(base, "spdx-no-authors.json"):       {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		filepath.Join(base, "spdx-no-timestamp.json"):     {Score: 3.8, Grade: "F", Required: 3, Optional: 2},
+		filepath.Join(base, "spdx-old-version.json"):      {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		
+		// CycloneDX test cases  
+		filepath.Join(base, "cdx-perfect-score.json"):    {Score: 10.0, Grade: "A", Required: 8, Optional: 3},
+		filepath.Join(base, "cdx-minimal.json"):          {Score: 2.5, Grade: "F", Required: 2, Optional: 0},
+		filepath.Join(base, "cdx-no-version.json"):       {Score: 3.8, Grade: "F", Required: 3, Optional: 1},
+		filepath.Join(base, "cdx-no-checksums.json"):     {Score: 7.5, Grade: "C", Required: 6, Optional: 1},
+		filepath.Join(base, "cdx-weak-checksums.json"):   {Score: 5.0, Grade: "D", Required: 4, Optional: 2},
+		filepath.Join(base, "cdx-no-dependencies.json"):  {Score: 7.5, Grade: "C", Required: 6, Optional: 2},
+		filepath.Join(base, "cdx-invalid-licenses.json"): {Score: 5.0, Grade: "D", Required: 4, Optional: 1},
+		filepath.Join(base, "cdx-no-authors.json"):       {Score: 5.0, Grade: "D", Required: 4, Optional: 1},
+		filepath.Join(base, "cdx-no-timestamp.json"):     {Score: 3.8, Grade: "F", Required: 3, Optional: 1},
+		filepath.Join(base, "cdx-old-version.json"):      {Score: 5.0, Grade: "D", Required: 4, Optional: 1},
+	}
+
+	// Sort test cases for organized output
+	var paths []string
+	for path := range testCases {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	allPassed := true
+	failCount := 0
+
+	for _, path := range paths {
+		want := testCases[path]
+		filename := filepath.Base(path)
+
+		cfg := config.Config{
+			Profile: []string{string(registry.ProfileNTIA)},
+		}
+		pathList := []string{path}
+
+		ctx := context.Background()
+
+		results, err := score.ScoreSBOM(ctx, cfg, pathList)
+		require.NoError(t, err)
+
+		for _, r := range results {
+			require.NotNil(t, r.Profiles, "Profile results should not be nil")
+			require.Len(t, r.Profiles.ProfResult, 1, "Should have exactly one profile result")
+			
+			profResult := r.Profiles.ProfResult[0]
+			gotRaw := profResult.InterlynkScore
+			gotRounded := math.Round(gotRaw*10) / 10
+
+			// Count required and optional fields
+			requiredCompliant := 0
+			optionalPresent := 0
+			
+			for _, item := range profResult.Items {
+				if item.Required {
+					if item.Score >= 10.0 {
+						requiredCompliant++
+					}
+				} else {
+					if item.Score >= 10.0 {
+						optionalPresent++
+					}
+				}
+			}
+
+			// Check if test passes
+			scoreMatch := math.Abs(want.Score-gotRounded) < 1e-9
+			gradeMatch := want.Grade == profResult.Grade
+			requiredMatch := want.Required == requiredCompliant
+			optionalMatch := want.Optional == optionalPresent
+			passed := scoreMatch && gradeMatch && requiredMatch && optionalMatch
+
+			if !passed {
+				allPassed = false
+				failCount++
+				// Only print failures
+				t.Errorf("NTIA test failed for %s: Score: got %.1f want %.1f, Grade: got %s want %s",
+					filename, gotRounded, want.Score, profResult.Grade, want.Grade)
+			}
+
+			// Verify assertions
+			require.InDelta(t, want.Score, gotRounded, 1e-9,
+				"NTIA score (rounded to 1 decimal) mismatch for %s", filename)
+			require.Equal(t, want.Grade, profResult.Grade,
+				"Grade mismatch for %s", filename)
+			require.Equal(t, want.Required, requiredCompliant,
+				"Required fields compliance count mismatch for %s", filename)
+			require.Equal(t, want.Optional, optionalPresent,
+				"Optional fields present count mismatch for %s", filename)
+		}
+	}
+
+	// Only print summary
+	if allPassed {
+		t.Logf("NTIA Profile: ✓ All %d test cases PASSED", len(testCases))
+	} else {
+		t.Errorf("NTIA Profile: ✗ %d/%d test cases FAILED", failCount, len(testCases))
+	}
+}
+
+func Test_NTIAProfileDetailedFieldAnalysis(t *testing.T) {
+	// Test a single file with detailed field analysis
+	base := filepath.Join("..", "..", "..", "testdata", "fixtures")
+	testFile := filepath.Join(base, "cdx-perfect-score.json")
+	
+	cfg := config.Config{
+		Profile: []string{string(registry.ProfileNTIA)},
+	}
+	paths := []string{testFile}
+	
+	ctx := context.Background()
+	results, err := score.ScoreSBOM(ctx, cfg, paths)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	
+	r := results[0]
+	require.NotNil(t, r.Profiles)
+	require.Len(t, r.Profiles.ProfResult, 1)
+	
+	profResult := r.Profiles.ProfResult[0]
+	
+	// Count summary
+	requiredCount, requiredCompliant := 0, 0
+	optionalCount, optionalPresent := 0, 0
+	
+	for _, item := range profResult.Items {
+		if item.Required {
+			requiredCount++
+			if item.Score >= 10.0 {
+				requiredCompliant++
+			}
+		} else {
+			optionalCount++
+			if item.Score >= 10.0 {
+				optionalPresent++
+			}
+		}
+	}
+	
+	// Verify counts
+	require.Equal(t, 8, requiredCount, "Should have 8 required fields")
+	require.Equal(t, 4, optionalCount, "Should have 4 optional fields")
+	require.Equal(t, 8, requiredCompliant, "CDX perfect score should have all required fields")
+	require.Equal(t, 3, optionalPresent, "CDX perfect score should have 3 optional fields")
+	
+	t.Logf("NTIA Field Analysis: Score: %.1f/10.0, Grade: %s, Required: %d/%d, Optional: %d/%d",
+		profResult.InterlynkScore, profResult.Grade, requiredCompliant, requiredCount, optionalPresent, optionalCount)
+}
+
+func Test_NTIAProfile_CLIModes(t *testing.T) {
+	// Test basic and JSON output modes with NTIA profile
+	base := filepath.Join("..", "..", "..", "testdata", "fixtures")
+	
+	testCases := []struct {
+		name     string
+		file     string
+		expected expectedNTIAScore
+	}{
+		{
+			name:     "CDX Perfect Score",
+			file:     "cdx-perfect-score.json",
+			expected: expectedNTIAScore{Score: 10.0, Grade: "A", Required: 8, Optional: 3},
+		},
+		{
+			name:     "CDX Minimal",
+			file:     "cdx-minimal.json",
+			expected: expectedNTIAScore{Score: 2.5, Grade: "F", Required: 2, Optional: 0},
+		},
+		{
+			name:     "SPDX Perfect Score",
+			file:     "spdx-perfect-score.json",
+			expected: expectedNTIAScore{Score: 8.8, Grade: "B", Required: 7, Optional: 3},
+		},
+		{
+			name:     "SPDX Minimal",
+			file:     "spdx-minimal.json",
+			expected: expectedNTIAScore{Score: 3.8, Grade: "F", Required: 3, Optional: 1},
+		},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testFile := filepath.Join(base, tc.file)
+			
+			cfg := config.Config{
+				Profile: []string{string(registry.ProfileNTIA)},
+			}
+			paths := []string{testFile}
+			
+			ctx := context.Background()
+			results, err := score.ScoreSBOM(ctx, cfg, paths)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			
+			r := results[0]
+			require.NotNil(t, r.Profiles)
+			require.Len(t, r.Profiles.ProfResult, 1)
+			
+			profResult := r.Profiles.ProfResult[0]
+			gotRounded := math.Round(profResult.InterlynkScore*10) / 10
+			
+			require.InDelta(t, tc.expected.Score, gotRounded, 1e-9,
+				"Score mismatch for %s", tc.file)
+			require.Equal(t, tc.expected.Grade, profResult.Grade,
+				"Grade mismatch for %s", tc.file)
+		})
+	}
+}

--- a/pkg/scorer/v2/profiles/ntia.go
+++ b/pkg/scorer/v2/profiles/ntia.go
@@ -15,6 +15,8 @@
 package profiles
 
 import (
+	"fmt"
+
 	"github.com/interlynk-io/sbomqs/v2/pkg/sbom"
 	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/catalog"
 )
@@ -57,4 +59,129 @@ func CompWithSupplier(doc sbom.Document) catalog.ProfFeatScore {
 // Component Other Identifiers
 func CompWithUniqID(doc sbom.Document) catalog.ProfFeatScore {
 	return CompUniqID(doc)
+}
+
+// NTIA Optional Fields - These don't impact overall scoring but show field coverage
+
+// Component Hash (SHOULD)
+func NTIACompHash(doc sbom.Document) catalog.ProfFeatScore {
+	comps := doc.Components()
+	if len(comps) == 0 {
+		return catalog.ProfFeatScore{
+			Score: 0.0,
+			Desc:  "no components",
+		}
+	}
+	
+	have := 0
+	for _, c := range comps {
+		checksums := c.GetChecksums()
+		if len(checksums) > 0 {
+			have++
+		}
+	}
+	
+	total := len(comps)
+	score := (float64(have) / float64(total)) * 10.0
+	
+	var desc string
+	if have == total {
+		desc = "complete"
+	} else if have == 0 {
+		desc = fmt.Sprintf("add to %d components", total)
+	} else {
+		desc = fmt.Sprintf("add to %d components", total-have)
+	}
+	
+	return catalog.ProfFeatScore{
+		Score: score,
+		Desc:  desc,
+	}
+}
+
+// SBOM Lifecycle (SHOULD)
+func NTIASBOMLifecycle(doc sbom.Document) catalog.ProfFeatScore {
+	lifecycles := doc.Lifecycles()
+	if len(lifecycles) > 0 {
+		return catalog.ProfFeatScore{
+			Score: 10.0,
+			Desc:  "complete",
+		}
+	}
+	return catalog.ProfFeatScore{
+		Score: 0.0,
+		Desc:  "add lifecycle phase",
+	}
+}
+
+// Component Relationships (SHOULD)
+func NTIACompRelationships(doc sbom.Document) catalog.ProfFeatScore {
+	comps := doc.Components()
+	if len(comps) == 0 {
+		return catalog.ProfFeatScore{
+			Score: 0.0,
+			Desc:  "no components",
+		}
+	}
+	
+	have := 0
+	for _, comp := range comps {
+		// Check for pedigree info in CycloneDX or additional relationships in SPDX
+		if comp.HasRelationShips() {
+			have++
+		}
+	}
+	
+	total := len(comps)
+	score := (float64(have) / float64(total)) * 10.0
+	
+	var desc string
+	if have == total {
+		desc = "complete"
+	} else if have == 0 {
+		desc = fmt.Sprintf("add to %d components", total)
+	} else {
+		desc = fmt.Sprintf("add to %d components", total-have)
+	}
+	
+	return catalog.ProfFeatScore{
+		Score: score,
+		Desc:  desc,
+	}
+}
+
+// Component License (SHOULD)
+func NTIACompLicense(doc sbom.Document) catalog.ProfFeatScore {
+	comps := doc.Components()
+	if len(comps) == 0 {
+		return catalog.ProfFeatScore{
+			Score: 0.0,
+			Desc:  "no components",
+		}
+	}
+	
+	have := 0
+	for _, c := range comps {
+		licenses := c.GetLicenses()
+		if len(licenses) > 0 {
+			have++
+		}
+	}
+	
+	total := len(comps)
+	score := (float64(have) / float64(total)) * 10.0
+	
+	var desc string
+	if have == total {
+		desc = "complete"
+	} else if have == 0 {
+		desc = fmt.Sprintf("add to %d components", total)
+	} else {
+		desc = fmt.Sprintf("add to %d components", total-have)
+	}
+	
+	return catalog.ProfFeatScore{
+		Score: score,
+		Desc:  desc,
+	}
 }

--- a/pkg/scorer/v2/profiles/ntia_test.go
+++ b/pkg/scorer/v2/profiles/ntia_test.go
@@ -1,0 +1,182 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiles
+
+import (
+	"testing"
+
+	"github.com/interlynk-io/sbomqs/v2/pkg/sbom"
+)
+
+func TestCompWithSupplier(t *testing.T) {
+	testCases := []struct {
+		name          string
+		doc           sbom.Document
+		expectedScore float64
+		expectedDesc  string
+	}{
+		{
+			name:          "All components have suppliers",
+			doc:           createDocWithAllSuppliers(),
+			expectedScore: 10.0,
+			expectedDesc:  "complete",
+		},
+		{
+			name:          "Half components have suppliers",
+			doc:           createDocWithHalfSuppliers(),
+			expectedScore: 5.0,
+			expectedDesc:  "add to 1 component",
+		},
+		{
+			name:          "No components have suppliers",
+			doc:           createDocWithNoSuppliers(),
+			expectedScore: 0.0,
+			expectedDesc:  "add to 2 components",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CompWithSupplier(tc.doc)
+			if result.Score != tc.expectedScore {
+				t.Errorf("Expected score %f, got %f", tc.expectedScore, result.Score)
+			}
+			if result.Desc != tc.expectedDesc {
+				t.Errorf("Expected desc '%s', got '%s'", tc.expectedDesc, result.Desc)
+			}
+		})
+	}
+}
+
+func TestNTIAOptionalFields(t *testing.T) {
+	doc := createDocWithOptionalFields()
+
+	t.Run("Component Hash (optional)", func(t *testing.T) {
+		result := NTIACompHash(doc)
+		// Optional fields now return scores for display but shouldn't impact overall score
+		if result.Score < 0.0 || result.Score > 10.0 {
+			t.Errorf("Optional field score should be between 0-10, got %f", result.Score)
+		}
+		// Check that description is appropriate
+		if result.Desc == "" {
+			t.Errorf("Optional field desc should not be empty")
+		}
+	})
+
+	t.Run("SBOM Lifecycle (optional)", func(t *testing.T) {
+		result := NTIASBOMLifecycle(doc)
+		if result.Score < 0.0 || result.Score > 10.0 {
+			t.Errorf("Optional field score should be between 0-10, got %f", result.Score)
+		}
+		if result.Desc == "" {
+			t.Errorf("Optional field desc should not be empty")
+		}
+	})
+
+	t.Run("Component Relationships (optional)", func(t *testing.T) {
+		result := NTIACompRelationships(doc)
+		if result.Score < 0.0 || result.Score > 10.0 {
+			t.Errorf("Optional field score should be between 0-10, got %f", result.Score)
+		}
+		if result.Desc == "" {
+			t.Errorf("Optional field desc should not be empty")
+		}
+	})
+
+	t.Run("Component License (optional)", func(t *testing.T) {
+		result := NTIACompLicense(doc)
+		if result.Score < 0.0 || result.Score > 10.0 {
+			t.Errorf("Optional field score should be between 0-10, got %f", result.Score)
+		}
+		if result.Desc == "" {
+			t.Errorf("Optional field desc should not be empty")
+		}
+	})
+}
+
+// Helper functions to create test documents
+func createDocWithAllSuppliers() sbom.Document {
+	comp1 := sbom.Component{
+		Name:    "comp1",
+		Version: "1.0",
+		Supplier: sbom.Supplier{
+			Name: "Supplier1",
+		},
+	}
+	comp2 := sbom.Component{
+		Name:    "comp2", 
+		Version: "2.0",
+		Supplier: sbom.Supplier{
+			Email: "supplier2@example.com",
+		},
+	}
+	
+	return sbom.SpdxDoc{
+		Comps: []sbom.GetComponent{comp1, comp2},
+	}
+}
+
+func createDocWithHalfSuppliers() sbom.Document {
+	comp1 := sbom.Component{
+		Name:    "comp1",
+		Version: "1.0",
+		Supplier: sbom.Supplier{
+			Name: "Supplier1",
+		},
+	}
+	comp2 := sbom.Component{
+		Name:    "comp2",
+		Version: "2.0",
+		// No supplier
+	}
+	
+	return sbom.SpdxDoc{
+		Comps: []sbom.GetComponent{comp1, comp2},
+	}
+}
+
+func createDocWithNoSuppliers() sbom.Document {
+	comp1 := sbom.Component{
+		Name:    "comp1",
+		Version: "1.0",
+	}
+	comp2 := sbom.Component{
+		Name:    "comp2",
+		Version: "2.0",
+	}
+	
+	return sbom.SpdxDoc{
+		Comps: []sbom.GetComponent{comp1, comp2},
+	}
+}
+
+func createDocWithOptionalFields() sbom.Document {
+	chk1 := sbom.Checksum{
+		Alg:     "SHA-256",
+		Content: "abc123",
+	}
+	
+	comp1 := sbom.Component{
+		Name:             "comp1",
+		Version:          "1.0",
+		Checksums:        []sbom.GetChecksum{chk1},
+		HasRelationships: true, // Has relationships
+	}
+	
+	return sbom.SpdxDoc{
+		Comps:     []sbom.GetComponent{comp1},
+		Lifecycle: "build", // Has lifecycle
+	}
+}

--- a/pkg/scorer/v2/profiles/profile.go
+++ b/pkg/scorer/v2/profiles/profile.go
@@ -86,7 +86,8 @@ func evaluateEachProfile(ctx context.Context, doc sbom.Document, profile catalog
 		// proResult.Score += pFeatResult.Score
 		proResult.Items = append(proResult.Items, pFeatResult)
 
-		if !pFeatScore.Ignore {
+		// Only count required fields for scoring
+		if !pFeatScore.Ignore && spec.Required {
 			sumScore += pFeatScore.Score
 			countNonNA++
 		}

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -663,13 +663,20 @@ var profileNTIASpec = catalog.ProfSpec{
 	Name:        "NTIA Minimum Elements (2021)",
 	Description: "NTIA Minimum Elements Profile",
 	Features: []catalog.ProfFeatSpec{
+		// Required (SHALL) fields
 		{Key: "sbom_machine_format", Name: "Automation Support", Required: true, Description: "Valid spec (SPDX/CycloneDX) and format (JSON/XML)", Evaluate: profiles.SBOMAutomationSpec},
+		{Key: "comp_supplier", Name: "Supplier Name", Required: true, Description: "Component supplier information", Evaluate: profiles.CompWithSupplier},
 		{Key: "comp_name", Name: "Component Name", Required: true, Description: "All components must have names", Evaluate: profiles.CompName},
 		{Key: "comp_version", Name: "Component Version", Required: true, Description: "Version strings for all components", Evaluate: profiles.CompVersion},
 		{Key: "comp_uniq_id", Name: "Component Other Identifiers", Required: true, Description: "PURL, CPE, or other unique IDs", Evaluate: profiles.CompWithUniqID},
 		{Key: "sbom_dependencies", Name: "Dependency Relationships", Required: true, Description: "Component dependency mapping", Evaluate: profiles.SBOMDepedencies},
 		{Key: "sbom_creator", Name: "SBOM Author", Required: true, Description: "Tool or person who created SBOM", Evaluate: profiles.SBOMAuthors},
 		{Key: "sbom_timestamp", Name: "SBOM Timestamp", Required: true, Description: "ISO 8601 creation timestamp", Evaluate: profiles.SBOMCreationTimestamp},
+		// Optional (SHOULD) fields - don't impact score
+		{Key: "comp_hash", Name: "Component Hash", Required: false, Description: "Component checksums (optional)", Evaluate: profiles.NTIACompHash},
+		{Key: "sbom_lifecycle", Name: "Lifecycle Phase", Required: false, Description: "SBOM lifecycle phase (optional)", Evaluate: profiles.NTIASBOMLifecycle},
+		{Key: "comp_relationships", Name: "Other Component Relationships", Required: false, Description: "Additional relationships (optional)", Evaluate: profiles.NTIACompRelationships},
+		{Key: "comp_license", Name: "License Information", Required: false, Description: "Component licenses (optional)", Evaluate: profiles.NTIACompLicense},
 	},
 }
 


### PR DESCRIPTION
 What Changed

  - Added missing required field: comp_supplier (Supplier Name) now properly evaluated as a required field
  - Added 4 optional fields: comp_hash, sbom_lifecycle, comp_relationships, comp_license - these display scores but don't impact the overall NTIA score as per specification
  - Fixed scoring logic: Only required (SHALL) fields count toward the overall score; optional (SHOULD) fields are informational only
  - Fixed output modes: Basic (-b) and JSON (-j) modes now work correctly with profile-only scoring
  - Added comprehensive tests: Integration tests for all 20 test files with accurate expected scores