### PR TITLE
enable ci workflow on call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main, master]
   workflow_dispatch:
+  workflow_call:
 
 env:
   GO_VERSION: "1.21"


### PR DESCRIPTION
This PR fix the following stuffs:
- this is related to issue: https://github.com/interlynk-io/sbomqs/actions/runs/19883232162/workflow
- it enable the ci workflow via `workflow_call:`