### PR TITLE
cosign v4 requires bundle option

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,6 +44,7 @@ signs:
       - sign-blob
       - --output-certificate=${certificate}
       - --output-signature=${signature}
+      - --bundle=${artifact}.bundle
       - ${artifact}
       - --yes
     artifacts: all


### PR DESCRIPTION

**Issue**
Error in the workflow:
```
 error=
    │ sign: cosign failed: exit status 1: Error: must provide --bundle with --signing-config or --use-signing-config
    │ error during command execution: must provide --bundle with --signing-config or --use-signing-config
```
**Fixes**: 
This PR adds the following changes:
- The cosign requires bundle option.