### PR TITLE
[bug] return error on non-supported field

### DIFF
--- a/cmd/features.go
+++ b/cmd/features.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+var featuresCmd = &cobra.Command{
+	Use:   "features",
+	Short: "List supported sbomqs features",
+	Long:  "Displays all supported features grouped by category.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+
+		if jsonOutput {
+			return printFeaturesJSON()
+		}
+
+		printFeaturesHuman()
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(featuresCmd)
+
+	featuresCmd.Flags().BoolP("json", "j", false, "Output in JSON format")
+}
+
+func printFeaturesHuman() {
+	grouped := make(map[string][]Feature)
+
+	for _, f := range FeatureRegistry {
+		grouped[f.Category] = append(grouped[f.Category], f)
+	}
+
+	// Sort categories
+	var categories []string
+	for cat := range grouped {
+		categories = append(categories, cat)
+	}
+	sort.Strings(categories)
+
+	total := len(FeatureRegistry)
+	fmt.Printf("Supported Features (%d total):\n\n", total)
+
+	for _, cat := range categories {
+		features := grouped[cat]
+
+		// Sort features inside category
+		sort.Slice(features, func(i, j int) bool {
+			return features[i].Name < features[j].Name
+		})
+
+		fmt.Printf("%s:\n", cat)
+		for _, f := range features {
+			fmt.Printf("  - %-30s %s\n", f.Name, f.Description)
+		}
+		fmt.Println()
+	}
+}
+
+func printFeaturesJSON() error {
+	grouped := make(map[string][]Feature)
+
+	for _, f := range FeatureRegistry {
+		grouped[f.Category] = append(grouped[f.Category], f)
+	}
+
+	// Optional: sort features per category for stable output
+	for _, features := range grouped {
+		sort.Slice(features, func(i, j int) bool {
+			return features[i].Name < features[j].Name
+		})
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(map[string]interface{}{
+		"total":      len(FeatureRegistry),
+		"categories": grouped,
+	})
+}


### PR DESCRIPTION
closes #623 

This PR adds the following changes:
- return an error for non-supported fields.
- and add separate `features` command to show all supported features.

Test non-supported feature
```bash
sbomqs list --json --feature feature_that_doesnt_exist samples/photon.spdx.json
Error: feature "feature_that_doesnt_exist" is not supported.

Run "sbomqs features" to see supported features.
exit status 1
```

See, list of all supported features:
```bash
sbomqs features            
Supported Features (74 total):

Component:
  - comp_cpe                       Validate component CPE
  - comp_dependencies              Validate component dependencies
  - comp_depth                     Validate component dependency depth
  - comp_hash                      Validate component hash presence
  - comp_hash_sha256               Validate component SHA256 checksum
  - comp_name                      Validate component name
  - comp_purl                      Validate component PURL
  - comp_purpose                   Validate component purpose field
  - comp_source_hash               Validate source code hash
  - comp_supplier                  Validate component supplier
  - comp_version                   Validate component version
  - comp_with_checksums            Ensure component has checksums
  - comp_with_checksums_sha256     Ensure component has SHA256 checksum entry
  - comp_with_cpe                  Ensure component has CPE
  - comp_with_dependencies         Ensure component dependency section exists
  - comp_with_executable_uri       Validate executable URI
  - comp_with_local_id             Validate component local identifier
  - comp_with_name                 Ensure component has a name
  - comp_with_primary_purpose      Validate primary purpose designation
  - comp_with_purl                 Ensure component has PURL
  - comp_with_purpose              Ensure component purpose exists
  - comp_with_sha256               Ensure component has SHA256 checksum
  - comp_with_source_code          Ensure component references source code
  - comp_with_source_code_hash     Ensure source code hash exists
  - comp_with_source_code_uri      Validate source code URI
  - comp_with_strong_checksums     Validate component uses strong checksums
  - comp_with_supplier             Ensure component supplier exists
  - comp_with_uniq_ids             Ensure component has unique identifiers
  - comp_with_version              Ensure component has version
  - comp_with_weak_checksums       Detect weak checksum algorithms

License:
  - comp_associated_license        Validate associated license
  - comp_license                   Validate component license presence
  - comp_no_deprecated_licenses    Ensure no deprecated licenses are used
  - comp_no_restrictive_licenses   Ensure no restrictive licenses are used
  - comp_valid_licenses            Validate license identifiers
  - comp_with_associated_license   Ensure associated license exists
  - comp_with_concluded_license    Validate concluded license
  - comp_with_declared_license     Validate declared license
  - comp_with_deprecated_licenses  Detect deprecated licenses
  - comp_with_licenses             Ensure component license section exists
  - comp_with_restrictive_licenses Detect restrictive licenses
  - comp_with_valid_licenses       Ensure licenses are valid SPDX identifiers

SBOM:
  - sbom_authors                   Validate SBOM authors field
  - sbom_bomlinks                  Validate SBOM BOM links section
  - sbom_build                     Validate SBOM build metadata
  - sbom_build_process             Validate SBOM build process information
  - sbom_creation_timestamp        Validate SBOM creation timestamp
  - sbom_creator                   Validate SBOM creator information
  - sbom_dependencies              Validate SBOM dependency graph
  - sbom_depth                     Validate SBOM dependency depth
  - sbom_file_format               Validate SBOM file format
  - sbom_machine_format            Validate machine-readable SBOM format
  - sbom_name                      Validate SBOM name field
  - sbom_organization              Validate SBOM organization metadata
  - sbom_parsable                  Ensure SBOM can be parsed successfully
  - sbom_primary_component         Validate primary component details
  - sbom_schema_valid              Validate SBOM against schema
  - sbom_sharable                  Validate SBOM sharability compliance
  - sbom_spdxid                    Validate SPDX ID presence
  - sbom_spec                      Ensure SBOM specification is declared
  - sbom_spec_declared             Validate SBOM specification declaration
  - sbom_spec_file_format          Validate SBOM specification file format
  - sbom_spec_version              Validate SBOM specification version
  - sbom_timestamp                 Validate SBOM timestamp field
  - sbom_tool                      Validate SBOM tool metadata
  - sbom_uri                       Validate SBOM URI field
  - sbom_with_bomlinks             Validate presence of BOM links
  - sbom_with_primary_component    Validate SBOM has a primary component
  - sbom_with_uri                  Validate SBOM contains URI reference
  - spec_with_version_compliant    Validate SBOM spec version compliance

Security:
  - comp_with_any_vuln_lookup_id   Ensure component has vulnerability lookup ID
  - comp_with_multi_vuln_lookup_id Ensure component has multiple vulnerability lookup IDs
  - sbom_vulnerabilities           Validate SBOM vulnerability section
  - sbom_with_vuln                 Validate SBOM contains vulnerability entries

```