### PR TITLE
Fix hang on complex SPDX license expressions

### DIFF
--- a/pkg/licenses/license.go
+++ b/pkg/licenses/license.go
@@ -178,7 +178,13 @@ func LookupExpression(expression string, customLicenses []License) []License {
 	} else {
 		// Normal path: semantic parsing
 		// spdxexp replaces "+" operator
-		extLicenses, err = spdxexp.ExtractLicenses(expression)
+		//
+		// Complex license expressions with many AND/OR operators can cause
+		// the SPDX expression parser to hang due to exponential parsing
+		// complexity (e.g., kernel-headers license strings).
+		// Split top-level AND clauses and parse each independently to
+		// avoid the pathological behavior.
+		extLicenses, err = extractLicensesSafe(expression)
 		if err != nil {
 			return []License{CreateCustomLicense(expression, expression)}
 		}
@@ -213,6 +219,71 @@ func LookupExpression(expression string, customLicenses []License) []License {
 	}
 
 	return licenses
+}
+
+// maxDirectExtractOperators is the threshold above which we split the
+// expression at top-level AND boundaries before feeding sub-expressions
+// to spdxexp.ExtractLicenses. The go-spdx parser exhibits exponential
+// behaviour on large compound expressions.
+const maxDirectExtractOperators = 20
+
+// extractLicensesSafe wraps spdxexp.ExtractLicenses with a guard against
+// pathologically complex expressions. When the expression contains more
+// than maxDirectExtractOperators boolean operators, it is split at top-level
+// AND boundaries and each clause is parsed individually.
+func extractLicensesSafe(expression string) ([]string, error) {
+	if strings.Count(expression, " AND ")+strings.Count(expression, " OR ") <= maxDirectExtractOperators {
+		return spdxexp.ExtractLicenses(expression)
+	}
+
+	// Split at top-level AND boundaries (outside parentheses).
+	clauses := splitTopLevelAND(expression)
+
+	seen := map[string]bool{}
+	var all []string
+	for _, clause := range clauses {
+		lics, err := spdxexp.ExtractLicenses(strings.TrimSpace(clause))
+		if err != nil {
+			// Treat unparseable clauses as custom licenses.
+			clause = strings.TrimSpace(clause)
+			if !seen[clause] {
+				all = append(all, clause)
+				seen[clause] = true
+			}
+			continue
+		}
+		for _, l := range lics {
+			if !seen[l] {
+				all = append(all, l)
+				seen[l] = true
+			}
+		}
+	}
+	return all, nil
+}
+
+// splitTopLevelAND splits an SPDX expression at top-level " AND " tokens,
+// i.e. those not inside parentheses.
+func splitTopLevelAND(expr string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(expr); i++ {
+		switch expr[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ' ':
+			if depth == 0 && i+5 <= len(expr) && expr[i:i+5] == " AND " {
+				parts = append(parts, expr[start:i])
+				start = i + 5
+				i += 4 // skip past " AND "
+			}
+		}
+	}
+	parts = append(parts, expr[start:])
+	return parts
 }
 
 func CreateCustomLicense(id, name string) License {

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -72,8 +72,9 @@ type spdxbasic struct {
 }
 
 type cdxbasic struct {
-	XMLNS     string `json:"-" xml:"xmlns,attr"`
-	BOMFormat string `json:"bomFormat" xml:"-"`
+	XMLNS       string `json:"-" xml:"xmlns,attr"`
+	BOMFormat   string `json:"bomFormat" xml:"-"`
+	SpecVersion string `json:"specVersion" xml:"version,attr"`
 }
 
 // SupportedSBOMSpecs returns a list of all supported SBOM specification formats
@@ -145,7 +146,7 @@ func detectSbomFormat(f io.ReadSeeker) (SpecFormat, FileFormat, FormatVersion, e
 	var cdx cdxbasic
 	if err := json.NewDecoder(f).Decode(&cdx); err == nil {
 		if cdx.BOMFormat == "CycloneDX" {
-			return SBOMSpecCDX, FileFormatJSON, "", nil
+			return SBOMSpecCDX, FileFormatJSON, FormatVersion(cdx.SpecVersion), nil
 		}
 	}
 
@@ -156,7 +157,7 @@ func detectSbomFormat(f io.ReadSeeker) (SpecFormat, FileFormat, FormatVersion, e
 
 	if err := xml.NewDecoder(f).Decode(&cdx); err == nil {
 		if strings.HasPrefix(cdx.XMLNS, "http://cyclonedx.org") {
-			return SBOMSpecCDX, FileFormatXML, "", nil
+			return SBOMSpecCDX, FileFormatXML, FormatVersion(cdx.SpecVersion), nil
 		}
 	}
 	_, err = f.Seek(0, io.SeekStart)

--- a/pkg/validation/schema.go
+++ b/pkg/validation/schema.go
@@ -65,6 +65,11 @@ func loadSchema(schemaURL string) (*jsonschema.Schema, error) {
 		return nil, fmt.Errorf("unknown schema")
 	}
 
+	// Only compile schemas that are in the registry to avoid HTTP fetches
+	if _, ok := schemaRegistry[schemaURL]; !ok {
+		return nil, fmt.Errorf("unsupported schema: %s", schemaURL)
+	}
+
 	c := jsonschema.NewCompiler()
 
 	if err := preloadSchemas(c); err != nil {


### PR DESCRIPTION
## Summary

- **Root cause**: `spdxexp.ExtractLicenses()` from `github.com/github/go-spdx/v2` exhibits exponential parsing complexity on compound SPDX expressions with many AND/OR operators, causing `sbomqs score` to hang indefinitely
- **Fix**: Added `extractLicensesSafe()` that splits complex expressions (>20 boolean operators) at top-level AND boundaries before parsing each sub-expression independently
- **Also fixed**: CycloneDX spec version detection was returning empty string, and schema validation could attempt HTTP fetches for unknown schema URLs

## Failing component

The hang was triggered by the `kernel-headers` RPM package in a Trivy-generated CycloneDX SBOM:

- **Component**: `kernel-headers`
- **Version**: `5.14.0-611.42.1.el9_7`
- **PURL**: `pkg:rpm/redhat/kernel-headers@5.14.0-611.42.1.el9_7?arch=x86_64&distro=redhat-9.7`
- **License expression** (~50 boolean operators):

```
(GPL-2.0-only WITH Linux-syscall-note OR BSD-2-Clause) AND (GPL-2.0-only WITH Linux-syscall-note OR BSD-3-Clause) AND (GPL-2.0-only WITH Linux-syscall-note OR CDDL-1.0) AND (GPL-2.0-only WITH Linux-syscall-note OR Linux-OpenIB) AND (GPL-2.0-only WITH Linux-syscall-note OR MIT) AND (GPL-2.0-or-later WITH Linux-syscall-note OR BSD-3-Clause) AND (GPL-2.0-or-later WITH Linux-syscall-note OR MIT) AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND BSD-3-Clause-Clear AND GFDL-1.1-no-invariants-or-later AND GPL-1.0-or-later AND (GPL-1.0-or-later OR BSD-3-Clause) AND GPL-1.0-or-later WITH Linux-syscall-note AND GPL-2.0-only AND (GPL-2.0-only OR Apache-2.0) AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0-only OR BSD-3-Clause) AND (GPL-2.0-only OR CDDL-1.0) AND (GPL-2.0-only OR GFDL-1.1-no-invariants-or-later) AND (GPL-2.0-only OR GFDL-1.2-no-invariants-only) AND GPL-2.0-only WITH Linux-syscall-note AND GPL-2.0-or-later AND (GPL-2.0-or-later OR BSD-2-Clause) AND (GPL-2.0-or-later OR BSD-3-Clause) AND (GPL-2.0-or-later OR CC-BY-4.0) AND GPL-2.0-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later WITH Linux-syscall-note AND ISC AND LGPL-2.0-or-later AND (LGPL-2.0-or-later OR BSD-2-Clause) AND LGPL-2.0-or-later WITH Linux-syscall-note AND LGPL-2.1-only AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1-only WITH Linux-syscall-note AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH Linux-syscall-note AND (Linux-OpenIB OR GPL-2.0-only) AND (Linux-OpenIB OR GPL-2.0-only OR BSD-2-Clause) AND Linux-man-pages-copyleft AND MIT AND (MIT OR GPL-2.0-only) AND (MIT OR GPL-2.0-or-later) AND (MIT OR LGPL-2.1-only) AND (MPL-1.1 OR GPL-2.0-only) AND (X11 OR GPL-2.0-only) AND (X11 OR GPL-2.0-or-later) AND Zlib AND (copyleft-next-0.3.1 OR GPL-2.0-or-later)
```

## Test plan

- [x] `./build/sbomqs score -d trivy_image_bom.cdx.json` completes in <1s (was hanging forever)
- [x] `go test ./pkg/licenses/...` passes
- [x] `go test ./pkg/validation/...` passes
- [x] `go test ./pkg/sbom/...` passes

