### PR TITLE
include target/source ref present in spdx files section

### DIFF
--- a/pkg/compliance/bsiV11.go
+++ b/pkg/compliance/bsiV11.go
@@ -349,10 +349,14 @@ func bsiV11ComponentDependencies(doc sbom.Document, component sbom.GetComponent)
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
 	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
+	}
 
 	var declared []string
 	for _, r := range doc.GetOutgoingRelations(compID) {
-		if strings.EqualFold(r.GetType(), "DEPENDS_ON") {
+		if strings.EqualFold(r.GetType(), "DEPENDS_ON") || strings.EqualFold(r.GetType(), "CONTAINS") {
 			declared = append(declared, r.GetTo())
 		}
 	}
@@ -398,10 +402,14 @@ func bsiV11SBOMDepth(doc sbom.Document) *db.Record {
 		return db.NewRecordStmt(SBOM_DEPTH, "doc", "no relationships declared", 0.0, "")
 	}
 
-	// Build component map (include primary)
+	// Build component map (include primary and files)
 	componentMap := make(map[string]sbom.GetComponent)
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
+	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
 	}
 	componentMap[primary.GetID()] = primary.Component()
 
@@ -423,7 +431,7 @@ func bsiV11SBOMDepth(doc sbom.Document) *db.Record {
 		return db.NewRecordStmt(SBOM_DEPTH, "doc", "primary component does not declare its dependencies", 0.0, "")
 	}
 
-	// Recursive DFS from primary following DEPENDS_ON (v1.1 does not include CONTAINS)
+	// Recursive DFS from primary following DEPENDS_ON or CONTAINS (BSI v1.1 §5.2.2)
 	visited := make(map[string]bool)
 	var dfs func(id string)
 	dfs = func(id string) {
@@ -432,7 +440,7 @@ func bsiV11SBOMDepth(doc sbom.Document) *db.Record {
 		}
 		visited[id] = true
 		for _, rel := range doc.GetOutgoingRelations(id) {
-			if strings.EqualFold(rel.GetType(), "DEPENDS_ON") {
+			if strings.EqualFold(rel.GetType(), "DEPENDS_ON") || strings.EqualFold(rel.GetType(), "CONTAINS") {
 				dfs(rel.GetTo())
 			}
 		}

--- a/pkg/compliance/bsiV20.go
+++ b/pkg/compliance/bsiV20.go
@@ -414,6 +414,10 @@ func bsiV20ComponentDependencies(doc sbom.Document, component sbom.GetComponent)
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
 	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
+	}
 
 	var declared []string
 	for _, r := range doc.GetOutgoingRelations(compID) {
@@ -464,6 +468,10 @@ func bsiV20SBOMDepth(doc sbom.Document) *db.Record {
 	componentMap := make(map[string]sbom.GetComponent)
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
+	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
 	}
 	componentMap[primary.GetID()] = primary.Component()
 

--- a/pkg/compliance/bsiV21.go
+++ b/pkg/compliance/bsiV21.go
@@ -173,6 +173,10 @@ func bsiV21SBOMDepth(doc sbom.Document) *db.Record {
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
 	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
+	}
 	componentMap[primary.GetID()] = primary.Component()
 
 	for _, r := range rels {
@@ -502,6 +506,10 @@ func bsiV21ComponentDependencies(doc sbom.Document, component sbom.GetComponent)
 	componentMap := make(map[string]sbom.GetComponent)
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
+	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
 	}
 
 	var declared []string

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -127,6 +127,11 @@ func (c CdxDoc) Components() []GetComponent {
 	return c.Comps
 }
 
+// Files returns all files defined in the SBOM (SPDX-specific, empty for CycloneDX)
+func (c CdxDoc) Files() []GetComponent {
+	return nil
+}
+
 func (c CdxDoc) Authors() []GetAuthor {
 	return c.CdxAuthors
 }

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -29,6 +29,9 @@ type Document interface {
 	// Components returns all components defined in the SBOM
 	Components() []GetComponent
 
+	// Files returns all files defined in the SBOM (SPDX-specific)
+	Files() []GetComponent
+
 	// Authors returns the authors of the SBOM
 	Authors() []GetAuthor
 

--- a/pkg/sbom/sbomfakes/fake_document.go
+++ b/pkg/sbom/sbomfakes/fake_document.go
@@ -38,6 +38,16 @@ type FakeDocument struct {
 	compositionReturnsOnCall map[int]struct {
 		result1 []sbom.GetComposition
 	}
+	FilesStub        func() []sbom.GetComponent
+	filesMutex       sync.RWMutex
+	filesArgsForCall []struct {
+	}
+	filesReturns struct {
+		result1 []sbom.GetComponent
+	}
+	filesReturnsOnCall map[int]struct {
+		result1 []sbom.GetComponent
+	}
 	GetDirectDependenciesStub        func(string, ...string) []sbom.GetComponent
 	getDirectDependenciesMutex       sync.RWMutex
 	getDirectDependenciesArgsForCall []struct {
@@ -331,6 +341,59 @@ func (fake *FakeDocument) CompositionReturnsOnCall(i int, result1 []sbom.GetComp
 	}
 	fake.compositionReturnsOnCall[i] = struct {
 		result1 []sbom.GetComposition
+	}{result1}
+}
+
+func (fake *FakeDocument) Files() []sbom.GetComponent {
+	fake.filesMutex.Lock()
+	ret, specificReturn := fake.filesReturnsOnCall[len(fake.filesArgsForCall)]
+	fake.filesArgsForCall = append(fake.filesArgsForCall, struct {
+	}{})
+	stub := fake.FilesStub
+	fakeReturns := fake.filesReturns
+	fake.recordInvocation("Files", []interface{}{})
+	fake.filesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeDocument) FilesCallCount() int {
+	fake.filesMutex.RLock()
+	defer fake.filesMutex.RUnlock()
+	return len(fake.filesArgsForCall)
+}
+
+func (fake *FakeDocument) FilesCalls(stub func() []sbom.GetComponent) {
+	fake.filesMutex.Lock()
+	defer fake.filesMutex.Unlock()
+	fake.FilesStub = stub
+}
+
+func (fake *FakeDocument) FilesReturns(result1 []sbom.GetComponent) {
+	fake.filesMutex.Lock()
+	defer fake.filesMutex.Unlock()
+	fake.FilesStub = nil
+	fake.filesReturns = struct {
+		result1 []sbom.GetComponent
+	}{result1}
+}
+
+func (fake *FakeDocument) FilesReturnsOnCall(i int, result1 []sbom.GetComponent) {
+	fake.filesMutex.Lock()
+	defer fake.filesMutex.Unlock()
+	fake.FilesStub = nil
+	if fake.filesReturnsOnCall == nil {
+		fake.filesReturnsOnCall = make(map[int]struct {
+			result1 []sbom.GetComponent
+		})
+	}
+	fake.filesReturnsOnCall[i] = struct {
+		result1 []sbom.GetComponent
 	}{result1}
 }
 

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -60,6 +60,7 @@ type SpdxDoc struct {
 	compositions     []GetComposition
 	Vuln             []GetVulnerabilities
 	rawContent       []byte // Store raw content for manual parsing
+	File             []GetComponent
 }
 
 func newSPDXDoc(ctx context.Context, f io.ReadSeeker, format FileFormat, version FormatVersion, _ Signature) (Document, error) {
@@ -122,6 +123,10 @@ func (s SpdxDoc) Spec() Spec {
 
 func (s SpdxDoc) Components() []GetComponent {
 	return s.Comps
+}
+
+func (s SpdxDoc) Files() []GetComponent {
+	return s.File
 }
 
 func (s SpdxDoc) Authors() []GetAuthor {
@@ -235,6 +240,7 @@ func (s *SpdxDoc) parse() {
 	s.parsePrimaryComponent()
 	s.parseRelationships()
 	s.parseComps()
+	s.parseFiles()
 }
 
 func (s *SpdxDoc) parseDoc() {
@@ -388,6 +394,96 @@ func (s *SpdxDoc) parseComps() {
 		nc.PackageFilename = sc.PackageFileName
 
 		s.Comps = append(s.Comps, nc)
+	}
+
+}
+
+// Files returns all files defined in the SBOM (SPDX-specific)
+func (s *SpdxDoc) parseFiles() {
+	s.File = []GetComponent{}
+
+	for _, sf := range s.doc.Files {
+		nc := NewComponent()
+
+		// Basic file information
+		nc.Name = sf.FileName
+		nc.Spdxid = string(sf.FileSPDXIdentifier)
+		nc.ID = string(sf.FileSPDXIdentifier)
+		nc.PackageFilename = sf.FileName
+
+		// File checksums (mandatory SHA1 + optional others)
+		if len(sf.Checksums) > 0 {
+			chks := make([]GetChecksum, 0, len(sf.Checksums))
+			for _, c := range sf.Checksums {
+				ck := Checksum{}
+				ck.Alg = string(c.Algorithm)
+				ck.Content = c.Value
+				chks = append(chks, ck)
+			}
+			nc.Checksums = chks
+		}
+
+		// File copyright text (mandatory field in SPDX)
+		nc.CopyRight = sf.FileCopyrightText
+
+		// File licenses
+		if sf.LicenseConcluded != "" {
+			nc.Licenses = licenses.LookupExpression(sf.LicenseConcluded, nil)
+			nc.ConcludedLicense = nc.Licenses
+		}
+
+		// Declared licenses from LicenseInfoInFiles
+		if len(sf.LicenseInfoInFiles) > 0 {
+			declaredLics := []licenses.License{}
+			for _, licExpr := range sf.LicenseInfoInFiles {
+				declaredLics = append(declaredLics, licenses.LookupExpression(licExpr, nil)...)
+			}
+			nc.DeclaredLicense = declaredLics
+		}
+
+		// File types (e.g., BINARY, SOURCE, etc.)
+		if len(sf.FileTypes) > 0 {
+			nc.Purpose = string(sf.FileTypes[0])
+		}
+
+		// File contributors as authors
+		if len(sf.FileContributors) > 0 {
+			authors := []GetAuthor{}
+			for _, contributor := range sf.FileContributors {
+				a := Author{}
+				entity := parseEntity(contributor)
+				if entity != nil {
+					a.Name = entity.name
+					a.Email = entity.email
+				} else {
+					a.Name = contributor
+				}
+				authors = append(authors, a)
+			}
+			nc.Athrs = authors
+		}
+
+		// Store additional file metadata as properties
+		props := []ComponentProperty{}
+		if sf.LicenseComments != "" {
+			props = append(props, ComponentProperty{Name: "licenseComments", Value: sf.LicenseComments})
+		}
+		if sf.FileComment != "" {
+			props = append(props, ComponentProperty{Name: "fileComment", Value: sf.FileComment})
+		}
+		if sf.FileNotice != "" {
+			props = append(props, ComponentProperty{Name: "fileNotice", Value: sf.FileNotice})
+		}
+		if len(sf.FileAttributionTexts) > 0 {
+			for i, attr := range sf.FileAttributionTexts {
+				props = append(props, ComponentProperty{Name: fmt.Sprintf("attributionText_%d", i), Value: attr})
+			}
+		}
+		if len(props) > 0 {
+			nc.Props = props
+		}
+
+		s.File = append(s.File, nc)
 	}
 
 }

--- a/pkg/scorer/v2/profiles/bsiv11.go
+++ b/pkg/scorer/v2/profiles/bsiv11.go
@@ -669,6 +669,10 @@ func BSIV11CompDependencies(doc sbom.Document) catalog.ProfFeatScore {
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
 	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
+	}
 	componentMap[primary.GetID()] = primary.Component()
 
 	// 1. Validate all relationships reference valid components
@@ -724,7 +728,7 @@ func BSIV11CompDependencies(doc sbom.Document) catalog.ProfFeatScore {
 		visited[id] = true
 
 		for _, rel := range doc.GetOutgoingRelations(id) {
-			if rel.GetType() == "DEPENDS_ON" {
+			if rel.GetType() == "DEPENDS_ON" || rel.GetType() == "CONTAINS" {
 				dfs(rel.GetTo())
 			}
 		}

--- a/pkg/scorer/v2/profiles/bsiv20.go
+++ b/pkg/scorer/v2/profiles/bsiv20.go
@@ -237,6 +237,10 @@ func BSIV20CompDependencies(doc sbom.Document) catalog.ProfFeatScore {
 	for _, c := range doc.Components() {
 		componentMap[c.GetID()] = c
 	}
+	// Also include files (for SPDX) as they can be dependency targets
+	for _, f := range doc.Files() {
+		componentMap[f.GetID()] = f
+	}
 	componentMap[primary.GetID()] = primary.Component()
 
 	// 1. Validate all relationships reference valid components


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomqs/issues/655

This PR adds the following changes:
- Includes files reference ID into map, just before checking dependency ref existance
- Created a separate function to parse files.
- Added function `Files` in doc interface
- And updated compliances as well as profiles.

```bash
$ go run main.go compliance -s test-sbom.spdx.json
BSI TR-03183-2 v2.0.0 Compliance Report 
Compliance score by Interlynk Score:6.5 RequiredScore:6.2 AdditionalScore:7.5 for test-sbom.spdx.json
* indicates optional fields
+-------------+---------+--------------------------------+--------------------------------------------------------------+-------+
|  ELEMENTID  | SECTION |           DATAFIELD            |                        ELEMENT RESULT                        | SCORE |
+-------------+---------+--------------------------------+--------------------------------------------------------------+-------+
| SBOM        |     3.1 | vuln                           | no-vulnerability                                             |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             |       4 | specification version          |                                                          2.3 |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.1   | creator of SBOM                | info-de@test.com (author)                                    |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.1   | timestamp                      | 2026-04-10T07:53:32Z                                         |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.1   | dependency graph completeness  | dependencies are recursively                                 |  10.0 |
|             |         |                                | declared and structurally                                    |       |
|             |         |                                | complete                                                     |       |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.3.1*  | SBOM-URI                       | https://test.com/spdx/rootfs-179d43eb-3647-47ea-8b65-8dfb8ba |  10.0 |
|             |         |                                | 274b5                                                        |       |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | components                     | present                                                      |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.4*    | signature                      |                                                              |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.4*    | BOM links                      |                                                              |   0.0 |
+-------------+---------+--------------------------------+--------------------------------------------------------------+-------+
| rsync-3.3.0 | 5.2.2   | component creator              |                                                              |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | component name                 | net-misc/rsync                                               |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | component version              | 3.3.0                                                        |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | filename                       |                                                              |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | dependencies on other          | (all dependencies resolved)                                  |  10.0 |
|             |         | components                     | usr/bin/rsync                                                |       |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | associated license             | compliant                                                    |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | hash value of deployable       |                                                              |   0.0 |
|             |         | component                      |                                                              |       |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | executable property            |                                                              |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | archive property               |                                                              |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.2.2   | structured property            |                                                              |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.3.2*  | source code URI                |                                                              |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.3.2*  | URI of deployable form         | NOASSERTION                                                  |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.3.2*  | other unique identifiers       | purl:                                                        |  10.0 |
|             |         |                                | pkg:ebuild/net-misc/rsync@3.3.0-r1?repository=gentoo         |       |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.3.2*  | concluded license              | compliant                                                    |  10.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.4.1*  | declared license               | not-compliant                                                |   0.0 |
+             +---------+--------------------------------+--------------------------------------------------------------+-------+
|             | 5.3.2*  | hash value of source code      |                                                              |   0.0 |
+-------------+---------+--------------------------------+--------------------------------------------------------------+-------+


```