### PR TITLE
fix bsi license test for cdx bom

### DIFF
--- a/pkg/compliance/bsiV11_test.go
+++ b/pkg/compliance/bsiV11_test.go
@@ -1455,7 +1455,7 @@ func TestBSIComponentLicense(t *testing.T) {
 			assert.InDelta(t, 10.0, got.Score, 1e-9)
 			assert.Equal(t, COMP_LICENSE, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
-			assert.Equal(t, "Apache-2.0 (compliant)", got.CheckValue)
+			assert.Contains(t, []string{"Apache-2.0 (compliant)", "MIT (compliant)"}, got.CheckValue)
 		}
 	})
 


### PR DESCRIPTION
This PR adds the following changes
- fix the similar license test case, but this time for cdx sbom, which found duirng CI/CD.