### PR TITLE
fix orFeatures handling. Implement on score calculation side.

### DIFF
--- a/pkg/reporter/v2/detailed.go
+++ b/pkg/reporter/v2/detailed.go
@@ -59,7 +59,7 @@ func (r *Reporter) detailedReport() {
 				catNameWithWeight := formatCategoryWithWeight(cat.Name, cat.Weight, totalCatWeight, isCompInfo)
 				for _, feat := range cat.Features {
 					scoreStr := formatScore(feat)
-					featNameWithWeight := formatFeatureWithWeight(feat.Key, cat.Weight, feat.Weight, totalCatWeight, isCompInfo)
+					featNameWithWeight := formatFeatureWithWeight(feat.Key, feat.OrGroup, cat.Weight, feat.Weight, totalCatWeight, isCompInfo)
 					l := []string{catNameWithWeight, featNameWithWeight, scoreStr, feat.Desc}
 					outDoc = append(outDoc, l)
 				}
@@ -80,7 +80,7 @@ func (r *Reporter) detailedReport() {
 				catNameWithWeight := formatCategoryWithWeight(cat.Name, cat.Weight, totalCatWeight, isCompInfo)
 				for _, feat := range cat.Features {
 					scoreStr := formatScore(feat)
-					featNameWithWeight := formatFeatureWithWeight(feat.Key, cat.Weight, feat.Weight, totalCatWeight, isCompInfo)
+					featNameWithWeight := formatFeatureWithWeight(feat.Key, feat.OrGroup, cat.Weight, feat.Weight, totalCatWeight, isCompInfo)
 					l := []string{catNameWithWeight, featNameWithWeight, scoreStr, feat.Desc}
 					outDoc = append(outDoc, l)
 				}
@@ -210,12 +210,6 @@ func calculateTotalCategoryWeight(catResults []api.CategoryResult) float64 {
 	return total
 }
 
-// orFeatures defines features that are OR conditions (either one satisfies the requirement)
-var orFeatures = map[string]bool{
-	"comp_with_purl": true,
-	"comp_with_cpe":  true,
-}
-
 // formatCategoryWithWeight formats category name with its weight percentage
 func formatCategoryWithWeight(catName string, catWeight, totalCatWeight float64, isCompInfo bool) string {
 	if isCompInfo || totalCatWeight == 0 {
@@ -225,14 +219,16 @@ func formatCategoryWithWeight(catName string, catWeight, totalCatWeight float64,
 	return fmt.Sprintf("%s (%.1f%%)", catName, effectiveWeight)
 }
 
-// formatFeatureWithWeight formats feature key with its effective weight percentage
-func formatFeatureWithWeight(featKey string, catWeight, featWeight, totalCatWeight float64, isCompInfo bool) string {
+// formatFeatureWithWeight formats feature key with its effective weight percentage.
+// orGroup is non-empty when the feature belongs to an OR group (either one satisfies
+// the requirement); in that case the full category weight is shown with an OR label.
+func formatFeatureWithWeight(featKey, orGroup string, catWeight, featWeight, totalCatWeight float64, isCompInfo bool) string {
 	if isCompInfo || totalCatWeight == 0 {
 		return featKey
 	}
 
-	// For OR features, show the full category weight since either one satisfies the requirement
-	if orFeatures[featKey] {
+	// For OR features, show the full category weight since either one satisfies the requirement.
+	if orGroup != "" {
 		effectiveWeight := (catWeight / totalCatWeight) * 100
 		return fmt.Sprintf("%s (%.1f%% OR)", featKey, effectiveWeight)
 	}

--- a/pkg/reporter/v2/reporter.go
+++ b/pkg/reporter/v2/reporter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/api"
 )
 
-const EngineVersion = "6"
+const EngineVersion = "7"
 
 type ReportOutput string
 

--- a/pkg/scorer/v2/api/result.go
+++ b/pkg/scorer/v2/api/result.go
@@ -94,6 +94,9 @@ type FeatureResult struct {
 	Score   float64
 	Desc    string
 	Ignored bool
+	// OrGroup matches catalog.ComprFeatSpec.OrGroup: features sharing the same
+	// non-empty group are OR-peers and scored via max() rather than averaged.
+	OrGroup string
 }
 
 // ProfileResult represents the evaluation outcome for a single compliance profile.
@@ -161,10 +164,11 @@ func NewProfFeatResult(pFeat catalog.ProfFeatSpec) ProfileFeatureResult {
 // metadata and weight information.
 func NewComprFeatResult(comprFeat catalog.ComprFeatSpec) FeatureResult {
 	return FeatureResult{
-		Name:   comprFeat.Name,
-		Key:    string(comprFeat.Key),
-		Score:  0.0,
-		Weight: comprFeat.Weight,
+		Name:    comprFeat.Name,
+		Key:     string(comprFeat.Key),
+		Score:   0.0,
+		Weight:  comprFeat.Weight,
+		OrGroup: comprFeat.OrGroup,
 	}
 }
 

--- a/pkg/scorer/v2/catalog/features.go
+++ b/pkg/scorer/v2/catalog/features.go
@@ -42,6 +42,10 @@ type ComprFeatSpec struct {
 	Key         string
 	Weight      float64
 	Evaluate    ComprFeatEval
+	// OrGroup groups mutually-substitutable features (e.g. purl vs cpe).
+	// When non-empty, ComputeCategoryScore uses max(score) across all members
+	// of the group instead of averaging them individually.
+	OrGroup string
 }
 
 // ComprFeatEval is the evaluation function type for a comprehensive feature.

--- a/pkg/scorer/v2/extractors/vulnerability.go
+++ b/pkg/scorer/v2/extractors/vulnerability.go
@@ -55,3 +55,20 @@ func CompWithCPE(_ context.Context, input catalog.EvalInput) catalog.ComprFeatSc
 
 	return formulae.ScoreCompFull(have, len(comps), "CPEs", false)
 }
+
+// CompWithPURLOrCPE: percentage of components that have at least one PURL or CPE (or both).
+// This implements union-based scoring for vulnerability identifiers.
+// A component is counted as "have" if it has either PURL or CPE (or both).
+func CompWithPURLOrCPE(_ context.Context, input catalog.EvalInput) catalog.ComprFeatScore {
+	doc := input.Doc
+	comps := doc.Components()
+	if len(comps) == 0 {
+		return formulae.ScoreCompNA()
+	}
+
+	have := lo.CountBy(comps, func(c sbom.GetComponent) bool {
+		return commonV2.CompHasAnyPURLs(c) || commonV2.CompHasAnyCPEs(c)
+	})
+
+	return formulae.ScoreCompFull(have, len(comps), "PURLs or CPEs", false)
+}

--- a/pkg/scorer/v2/extractors/vulnerability_test.go
+++ b/pkg/scorer/v2/extractors/vulnerability_test.go
@@ -547,3 +547,381 @@ func TestCompWithPURL(t *testing.T) {
 		assert.False(t, got.Ignore)
 	})
 }
+
+// Test data for CompWithPURLOrCPE: All components have both PURL and CPE
+var cdxCompBothPURLAndCPE = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-a",
+      "version": "1.0",
+      "purl": "pkg:maven/a@1.0",
+      "cpe": "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"
+    }
+  ]
+}
+`)
+
+// Test data: All components have only PURL
+var cdxCompOnlyPURL = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-a",
+      "version": "1.0",
+      "purl": "pkg:maven/a@1.0"
+    }
+  ]
+}
+`)
+
+// Test data: All components have only CPE
+var cdxCompOnlyCPE = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-a",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"
+    }
+  ]
+}
+`)
+
+// Test data: Alternate PURL and CPE (5 with PURL, 5 with CPE, no overlap)
+var cdxCompAlternatePURLAndCPE = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-a",
+      "version": "1.0",
+      "purl": "pkg:maven/a@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-b",
+      "version": "1.0",
+      "purl": "pkg:maven/b@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-c",
+      "version": "1.0",
+      "purl": "pkg:maven/c@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-d",
+      "version": "1.0",
+      "purl": "pkg:maven/d@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-e",
+      "version": "1.0",
+      "purl": "pkg:maven/e@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-f",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:f:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-g",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:g:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-h",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:h:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-i",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:i:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-j",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:j:1.0:*:*:*:*:*:*:*"
+    }
+  ]
+}
+`)
+
+// Test data: No components have either PURL or CPE
+var cdxCompNoPURLOrCPE = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-a",
+      "version": "1.0"
+    }
+  ]
+}
+`)
+
+// Test data: 7 components with PURL or CPE, 3 without (7 out of 10 = 7.0)
+var cdxCompSeven = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-1",
+      "version": "1.0",
+      "purl": "pkg:maven/lib1@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-2",
+      "version": "1.0",
+      "purl": "pkg:maven/lib2@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-3",
+      "version": "1.0",
+      "purl": "pkg:maven/lib3@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-4",
+      "version": "1.0",
+      "purl": "pkg:maven/lib4@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-5",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:lib5:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-6",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:lib6:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-7",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:lib7:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-8",
+      "version": "1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-9",
+      "version": "1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-10",
+      "version": "1.0"
+    }
+  ]
+}
+`)
+
+// Test data: Mixed coverage - 4 with both + 3 PURL only + 3 CPE only = 10 total coverage (10 out of 10 = 10.0)
+var cdxCompMixedCoverage = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-1",
+      "version": "1.0",
+      "purl": "pkg:maven/lib1@1.0",
+      "cpe": "cpe:2.3:a:vendor:lib1:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-2",
+      "version": "1.0",
+      "purl": "pkg:maven/lib2@1.0",
+      "cpe": "cpe:2.3:a:vendor:lib2:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-3",
+      "version": "1.0",
+      "purl": "pkg:maven/lib3@1.0",
+      "cpe": "cpe:2.3:a:vendor:lib3:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-4",
+      "version": "1.0",
+      "purl": "pkg:maven/lib4@1.0",
+      "cpe": "cpe:2.3:a:vendor:lib4:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-5",
+      "version": "1.0",
+      "purl": "pkg:maven/lib5@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-6",
+      "version": "1.0",
+      "purl": "pkg:maven/lib6@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-7",
+      "version": "1.0",
+      "purl": "pkg:maven/lib7@1.0"
+    },
+    {
+      "type": "library",
+      "name": "lib-8",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:lib8:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-9",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:lib9:1.0:*:*:*:*:*:*:*"
+    },
+    {
+      "type": "library",
+      "name": "lib-10",
+      "version": "1.0",
+      "cpe": "cpe:2.3:a:vendor:lib10:1.0:*:*:*:*:*:*:*"
+    }
+  ]
+}
+`)
+
+// TestCompWithPURLOrCPE tests the union-based scoring for components with PURL or CPE
+func TestCompWithPURLOrCPE(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Case1-BothPURLAndCPE", func(t *testing.T) {
+		// All components have both PURL and CPE → 10.0
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxCompBothPURLAndCPE, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := CompWithPURLOrCPE(ctx, catalog.EvalInput{Doc: doc})
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, "complete", got.Desc)
+		assert.False(t, got.Ignore)
+	})
+
+	t.Run("Case2-OnlyPURL", func(t *testing.T) {
+		// All components have only PURL → 10.0
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxCompOnlyPURL, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := CompWithPURLOrCPE(ctx, catalog.EvalInput{Doc: doc})
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, "complete", got.Desc)
+		assert.False(t, got.Ignore)
+	})
+
+	t.Run("Case3-OnlyCPE", func(t *testing.T) {
+		// All components have only CPE → 10.0
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxCompOnlyCPE, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := CompWithPURLOrCPE(ctx, catalog.EvalInput{Doc: doc})
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, "complete", got.Desc)
+		assert.False(t, got.Ignore)
+	})
+
+	t.Run("Case4-AlternatePURLAndCPE", func(t *testing.T) {
+		// Alternate PURL and CPE (5 with PURL, 5 with CPE, no overlap) → 10.0
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxCompAlternatePURLAndCPE, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := CompWithPURLOrCPE(ctx, catalog.EvalInput{Doc: doc})
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, "complete", got.Desc)
+		assert.False(t, got.Ignore)
+	})
+
+	t.Run("Case5-NoPURLOrCPE", func(t *testing.T) {
+		// No components have either → 0.0
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxCompNoPURLOrCPE, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := CompWithPURLOrCPE(ctx, catalog.EvalInput{Doc: doc})
+
+		assert.InDelta(t, 0.0, got.Score, 1e-9)
+		assert.Equal(t, "add to 1 component", got.Desc)
+		assert.False(t, got.Ignore)
+	})
+
+	t.Run("Case6-Seven", func(t *testing.T) {
+		// 7 components with PURL or CPE, 3 without → 7.0
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxCompSeven, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := CompWithPURLOrCPE(ctx, catalog.EvalInput{Doc: doc})
+
+		assert.InDelta(t, 7.0, got.Score, 1e-9)
+		assert.Equal(t, "add to 3 components", got.Desc)
+		assert.False(t, got.Ignore)
+	})
+
+	t.Run("Case7-MixedCoverage", func(t *testing.T) {
+		// Mixed coverage - 4 both + 3 PURL only + 3 CPE only = 10 total (10 out of 10 = 10.0)
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxCompMixedCoverage, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := CompWithPURLOrCPE(ctx, catalog.EvalInput{Doc: doc})
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, "complete", got.Desc)
+		assert.False(t, got.Ignore)
+	})
+}

--- a/pkg/scorer/v2/formulae/farmulas.go
+++ b/pkg/scorer/v2/formulae/farmulas.go
@@ -194,21 +194,53 @@ func ToGrade(score float64) string {
 		 ComputeCategoryScore calculates the category-level score using a weighted
 		 average of all non-ignored feature scores.
 
-		 category_score = Σ(score_i * (weight_i / totalFeatureWeight))
-	                    = (Σ(score_i * weight_i)) / totalFeatureWeight
+		 For ordinary features:
+		   category_score = Σ(score_i * (weight_i / totalFeatureWeight))
+
+		 For OR-group features (features sharing a non-empty OrGroup):
+		   Each group contributes as a single virtual feature whose score is
+		   max(score_i for i in group) and whose weight is Σ(weight_i for i in group).
+		   This reflects that any one identifier (PURL or CPE) fully satisfies the
+		   requirement - having only a PURL should not be penalised for lacking a CPE.
 
 		 Behavior:
-		  1. totalFeatureWeight = Sums the weights of all features where Ignored == false.
+		  1. Ignored features are excluded from both weight sums and score computation.
 		  2. If no valid weights remain, returns 0.
-		  3. Renormalizes each feature’s weight (weight_i / totalFeatureWeight).
+		  3. Renormalizes each feature/group weight by totalFeatureWeight.
 		  4. Computes the weighted average: Σ(score_i * normalizedWeight_i).
 */
 func ComputeCategoryScore(features []api.FeatureResult) float64 {
+	type orGroupInfo struct {
+		maxScore    float64
+		totalWeight float64
+	}
+	orGroups := map[string]*orGroupInfo{}
+
 	var totalFeatureWeight float64
+
+	// First pass: collect OR-group info and accumulate non-OR weights.
 	for _, feature := range features {
-		if !feature.Ignored {
+		if feature.Ignored {
+			continue
+		}
+		if feature.OrGroup != "" {
+			g, ok := orGroups[feature.OrGroup]
+			if !ok {
+				g = &orGroupInfo{}
+				orGroups[feature.OrGroup] = g
+			}
+			g.totalWeight += feature.Weight
+			if feature.Score > g.maxScore {
+				g.maxScore = feature.Score
+			}
+		} else {
 			totalFeatureWeight += feature.Weight
 		}
+	}
+
+	// Add each OR-group's combined weight once.
+	for _, g := range orGroups {
+		totalFeatureWeight += g.totalWeight
 	}
 
 	if totalFeatureWeight <= 0 {
@@ -217,16 +249,19 @@ func ComputeCategoryScore(features []api.FeatureResult) float64 {
 
 	var weightedScore float64
 
+	// Ordinary features.
 	for _, feature := range features {
-		if feature.Ignored {
+		if feature.Ignored || feature.OrGroup != "" {
 			continue
 		}
+		normalizedWeight_i := feature.Weight / totalFeatureWeight
+		weightedScore += feature.Score * normalizedWeight_i
+	}
 
-		score_i := feature.Score
-		weight_i := feature.Weight
-
-		normalizedWeight_i := weight_i / totalFeatureWeight
-		weightedScore += score_i * normalizedWeight_i
+	// OR groups: each group contributes once with max(score).
+	for _, g := range orGroups {
+		normalizedWeight := g.totalWeight / totalFeatureWeight
+		weightedScore += g.maxScore * normalizedWeight
 	}
 
 	return weightedScore

--- a/pkg/scorer/v2/formulae/formulas_test.go
+++ b/pkg/scorer/v2/formulae/formulas_test.go
@@ -237,6 +237,33 @@ func TestComputeCategoryScore(t *testing.T) {
 			},
 			expected: 1.0, // (1.0*3) / 3
 		},
+		{
+			name: "OR group: purl present, cpe absent -> max(10,0) = 10",
+			frs: []api.FeatureResult{
+				{Key: "comp_with_purl", Weight: 0.50, Score: 10.0, Ignored: false, OrGroup: "vuln_id"},
+				{Key: "comp_with_cpe", Weight: 0.50, Score: 0.0, Ignored: false, OrGroup: "vuln_id"},
+			},
+			// OR group: max(10,0)=10, combined weight=1.0, totalWeight=1.0 -> 10.0
+			expected: 10.0,
+		},
+		{
+			name: "OR group: both present -> max(10,10) = 10",
+			frs: []api.FeatureResult{
+				{Key: "comp_with_purl", Weight: 0.50, Score: 10.0, Ignored: false, OrGroup: "vuln_id"},
+				{Key: "comp_with_cpe", Weight: 0.50, Score: 10.0, Ignored: false, OrGroup: "vuln_id"},
+			},
+			expected: 10.0,
+		},
+		{
+			name: "OR group with other features: OR=10 (w=1.0), other=5 (w=0.5) -> (10*1.0+5*0.5)/1.5",
+			frs: []api.FeatureResult{
+				{Key: "comp_with_purl", Weight: 0.50, Score: 10.0, Ignored: false, OrGroup: "vuln_id"},
+				{Key: "comp_with_cpe", Weight: 0.50, Score: 0.0, Ignored: false, OrGroup: "vuln_id"},
+				{Key: "other_feat", Weight: 0.50, Score: 5.0, Ignored: false},
+			},
+			// totalWeight=1.5; OR group=(10*1.0)/1.5; other=(5*0.5)/1.5
+			expected: (10.0*1.0 + 5.0*0.5) / 1.5,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -700,8 +700,8 @@ var CatVulnerabilityAndTraceSpec = catalog.ComprCatSpec{
 	Description: "Ability to map components to vulnerability databases",
 	Weight:      10,
 	Features: []catalog.ComprFeatSpec{
-		{Key: "comp_with_purl", Name: "Component With PURL", Weight: 0.50, Ignore: false, Evaluate: extractors.CompWithPURL},
-		{Key: "comp_with_cpe", Name: "Component With CPE", Weight: 0.50, Ignore: false, Evaluate: extractors.CompWithCPE},
+		{Key: "comp_with_purl", Name: "Component With PURL", Weight: 0.50, Ignore: false, Evaluate: extractors.CompWithPURL, OrGroup: "vuln_id"},
+		{Key: "comp_with_cpe", Name: "Component With CPE", Weight: 0.50, Ignore: false, Evaluate: extractors.CompWithCPE, OrGroup: "vuln_id"},
 	},
 }
 

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -263,8 +263,9 @@ var CompKeyToEvaluatingFunction = map[string]catalog.ComprFeatEval{
 	"comp_with_declared_licenses":  extractors.CompWithDeclaredLicenses,
 	"sbom_data_license":            extractors.SBOMDataLicense,
 
-	"comp_with_purl": extractors.CompWithPURL,
-	"comp_with_cpe":  extractors.CompWithCPE,
+	"comp_with_purl":           extractors.CompWithPURL,
+	"comp_with_cpe":            extractors.CompWithCPE,
+	"comp_with_purl_or_cpe":    extractors.CompWithPURLOrCPE,
 
 	"sbom_spec_declared": extractors.SBOMWithSpec,
 	"sbom_spec_version":  extractors.SBOMSpecVersion,
@@ -700,8 +701,9 @@ var CatVulnerabilityAndTraceSpec = catalog.ComprCatSpec{
 	Description: "Ability to map components to vulnerability databases",
 	Weight:      10,
 	Features: []catalog.ComprFeatSpec{
-		{Key: "comp_with_purl", Name: "Component With PURL", Weight: 0.50, Ignore: false, Evaluate: extractors.CompWithPURL, OrGroup: "vuln_id"},
-		{Key: "comp_with_cpe", Name: "Component With CPE", Weight: 0.50, Ignore: false, Evaluate: extractors.CompWithCPE, OrGroup: "vuln_id"},
+		{Key: "comp_with_purl", Name: "Component With PURL", Weight: 0.33, Ignore: false, Evaluate: extractors.CompWithPURL, OrGroup: "vuln_id"},
+		{Key: "comp_with_cpe", Name: "Component With CPE", Weight: 0.33, Ignore: false, Evaluate: extractors.CompWithCPE, OrGroup: "vuln_id"},
+		{Key: "comp_with_purl_or_cpe", Name: "Component With PURL or CPE (Union)", Weight: 0.34, Ignore: false, Evaluate: extractors.CompWithPURLOrCPE, OrGroup: "vuln_id"},
 	},
 }
 


### PR DESCRIPTION
The `sbomq score` feature shows two categories that are "OR":

```
+------------------------+--------------------------------+-----------+-------------------------------------+
| Vulnerability (12.2%)  | comp_with_purl (12.2% OR)      | 10.0/10.0 | complete                            |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_cpe (12.2% OR)       | 0.0/10.0  | add to 1 component                  |
+------------------------+--------------------------------+-----------+-------------------------------------+
```

However, this was not reflected in category breakdown in overall results:

```
Category Breakdown:
+-------------------+--------+-----------+-------+
|     CATEGORY      | WEIGHT |   SCORE   | GRADE |
[...]
+-------------------+--------+-----------+-------+
| Vulnerability     | 12.2%  | 5.0/10.0  | D     |
+-------------------+--------+-----------+-------+
```

Calculate score for OR-features as weighted, not only on results display.

Add tests for orFeatures.