### PR TITLE
Fix/add flag comp analysis

### DIFF
--- a/cmd/score.go
+++ b/cmd/score.go
@@ -68,8 +68,9 @@ type userCmd struct {
 	legacy bool
 
 	// Interlynk Component Quality API
-	interlynkURL    string
-	interlynkAPIKey string
+	interlynkURL            string
+	interlynkAPIKey         string
+	enableComponentAnalysis bool
 }
 
 // scoreCmd represents the score command for generating comprehensive quality scores for SBOM documents.
@@ -103,6 +104,16 @@ var scoreCmd = &cobra.Command{
 
   # Recursively score all SBOMs under a directory
   sbomqs score --recursive testdata
+
+  # Enable component quality analysis with API key via flag
+  sbomqs score --enable-component-analysis --api-key "your-api-key" samples/sbomqs-spdx-syft.json
+
+  # Enable component quality analysis with API key via environment variable
+  export INTERLYNK_SECURITY_TOKEN="your-api-key"
+  sbomqs score --enable-component-analysis samples/sbomqs-spdx-syft.json
+
+  # Enable component quality analysis with custom API URL
+  sbomqs score --enable-component-analysis --api-url "https://api.interlynk.io" --api-key "your-api-key" samples/sbomqs-spdx-syft.json
 `,
 
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -290,28 +301,49 @@ func toUserCmd(cmd *cobra.Command, args []string) *userCmd {
 	uCmd.recursive, _ = cmd.Flags().GetBool("recursive")
 
 	// Interlynk Component Quality API
-	uCmd.interlynkURL, _ = cmd.Flags().GetString("url")
-	uCmd.interlynkAPIKey, _ = cmd.Flags().GetString("api-key")
+	uCmd.enableComponentAnalysis, _ = cmd.Flags().GetBool("enable-component-analysis")
+
+	// API URL: --api-url flag > INTERLYNK_API_URL env var > default
+	apiURLFlag, _ := cmd.Flags().GetString("api-url")
+	if apiURLFlag != "" {
+		uCmd.interlynkURL = apiURLFlag
+	} else if urlFlag, _ := cmd.Flags().GetString("url"); urlFlag != "" {
+		// Backward compatibility: --url alias
+		uCmd.interlynkURL = urlFlag
+	} else if envURL := os.Getenv("INTERLYNK_API_URL"); envURL != "" {
+		uCmd.interlynkURL = envURL
+	} else {
+		uCmd.interlynkURL = "https://api.interlynk.io"
+	}
+
+	// API Key: --api-key flag > INTERLYNK_SECURITY_TOKEN env var
+	apiKeyFlag, _ := cmd.Flags().GetString("api-key")
+	if apiKeyFlag != "" {
+		uCmd.interlynkAPIKey = apiKeyFlag
+	} else if envToken := os.Getenv("INTERLYNK_SECURITY_TOKEN"); envToken != "" {
+		uCmd.interlynkAPIKey = envToken
+	}
 
 	return uCmd
 }
 
 func toEngineParams(uCmd *userCmd) *engine.Params {
 	return &engine.Params{
-		Path:            uCmd.path,
-		Categories:      uCmd.categories,
-		Features:        uCmd.features,
-		JSON:            uCmd.json,
-		Basic:           uCmd.basic,
-		Detailed:        uCmd.detailed,
-		Color:           uCmd.color,
-		Recursive:       uCmd.recursive,
-		Debug:           uCmd.debug,
-		ConfigPath:      uCmd.configPath,
-		Legacy:          uCmd.legacy,
-		Profiles:        uCmd.profile,
-		InterlynkURL:    uCmd.interlynkURL,
-		InterlynkAPIKey: uCmd.interlynkAPIKey,
+		Path:                    uCmd.path,
+		Categories:              uCmd.categories,
+		Features:                uCmd.features,
+		JSON:                    uCmd.json,
+		Basic:                   uCmd.basic,
+		Detailed:                uCmd.detailed,
+		Color:                   uCmd.color,
+		Recursive:               uCmd.recursive,
+		Debug:                   uCmd.debug,
+		ConfigPath:              uCmd.configPath,
+		Legacy:                  uCmd.legacy,
+		Profiles:                uCmd.profile,
+		InterlynkURL:            uCmd.interlynkURL,
+		InterlynkAPIKey:         uCmd.interlynkAPIKey,
+		EnableComponentAnalysis: uCmd.enableComponentAnalysis,
 	}
 }
 
@@ -361,6 +393,14 @@ func validateFlags(cmd *userCmd) error {
 			}
 		}
 	}
+
+	// Validate component analysis requirements
+	if cmd.enableComponentAnalysis {
+		if cmd.interlynkAPIKey == "" {
+			return fmt.Errorf("--enable-component-analysis requires an API key; provide it via --api-key flag or INTERLYNK_SECURITY_TOKEN environment variable")
+		}
+	}
+
 	return nil
 }
 
@@ -429,6 +469,14 @@ func init() {
 	scoreCmd.Flags().BoolP("legacy", "e", false, "legacy, prior to sbomqs version 2.0")
 
 	// Interlynk Component Quality API
-	scoreCmd.Flags().StringP("url", "u", "", "Interlynk platform URL for component quality checks (e.g. https://app.interlynk.io)")
-	scoreCmd.Flags().StringP("api-key", "k", "", "Interlynk API key (enables authenticated tier: 5000-component batches, 10 checks)")
+	scoreCmd.Flags().BoolP("enable-component-analysis", "", false, "enable component quality analysis via Interlynk API (requires --api-key or INTERLYNK_SECURITY_TOKEN)")
+	scoreCmd.Flags().StringP("api-url", "u", "", "Interlynk API URL for component quality analysis (default: https://api.interlynk.io, or INTERLYNK_API_URL env var)")
+	scoreCmd.Flags().StringP("url", "", "", "Interlynk API URL (deprecated: use --api-url)")
+	if err := scoreCmd.Flags().MarkHidden("url"); err != nil {
+		log.Fatalf("Failed to mark flag as hidden: %v", err)
+	}
+	if err := scoreCmd.Flags().MarkDeprecated("url", "use --api-url instead"); err != nil {
+		log.Fatalf("Failed to mark flag as deprecated: %v", err)
+	}
+	scoreCmd.Flags().StringP("api-key", "k", "", "Interlynk API key (or INTERLYNK_SECURITY_TOKEN env var)")
 }

--- a/docs/commands/score.md
+++ b/docs/commands/score.md
@@ -52,12 +52,22 @@ sbomqs score [flags] <SBOM file(s)>
 
 - `--debug, -D`: Enable debug logging
 
-### Component Quality API Flags
+### Component Quality Analysis Flags
 
-- `--url <url>`: Interlynk API endpoint for component quality analysis (optional)
-- `--api-key <token>`: API key for authenticated access to the Interlynk API (optional)
+- `--enable-component-analysis`: Enable component quality analysis via Interlynk API (requires `--api-key` or `INTERLYNK_SECURITY_TOKEN` environment variable)
+- `--api-url <url>`: Interlynk API endpoint for component quality analysis (optional, default: `https://api.interlynk.io`)
+- `--api-key <token>`: API key for authenticated access to the Interlynk API (optional, can also use `INTERLYNK_SECURITY_TOKEN` environment variable)
 
-**Note:** The `--url` flag should point to the base URL only (e.g., `https://api.interlynk.io`). The client automatically appends `/api/v1/doctor/check`.
+**Note:** Component quality analysis is opt-in. You must provide `--enable-component-analysis` flag to enable it. The `--api-url` flag should point to the base URL only (e.g., `https://api.interlynk.io`). The client automatically appends `/api/v1/doctor/check`.
+
+**Backward Compatibility:** The `--url` flag is deprecated but still works as an alias for `--api-url`.
+
+#### Configuration Priority
+
+| Setting | Priority Order |
+|---------|---------------|
+| API URL | `--api-url` flag > `--url` flag (deprecated) > `INTERLYNK_API_URL` environment variable > default (`https://api.interlynk.io`) |
+| API Key | `--api-key` flag > `INTERLYNK_SECURITY_TOKEN` environment variable |
 
 #### Unauthenticated vs Authenticated Access
 
@@ -355,6 +365,35 @@ $ sbomqs score --profile bsi samples/app.cdx.json
 $ sbomqs score --profile bsi-v2.0 samples/app.spdx.json
 ```
 
+### Component Quality Analysis Examples
+
+#### Enable with Environment Variable
+
+```bash
+# Set Interlynk Security key via environment variable
+export INTERLYNK_SECURITY_TOKEN="your-api-key"
+
+# Enable component quality analysis
+$ sbomqs score --enable-component-analysis my-app.spdx.json
+```
+
+#### Enable with Command Line Flag
+
+```bash
+# Enable with explicit API key
+$ sbomqs score --enable-component-analysis --api-key "your-api-key" my-app.spdx.json
+
+# Enable with custom API URL
+$ sbomqs score --enable-component-analysis --api-url "https://api.interlynk.io" --api-key "your-api-key" my-app.spdx.json
+```
+
+#### Using Custom API Endpoint
+
+```bash
+# Using a local Interlynk instance
+$ sbomqs score --enable-component-analysis --api-url "http://localhost:3000" --api-key "your-local-key" my-app.spdx.json
+```
+
 ### Version 2.0 vs Legacy Mode
 
 #### Version 2.0 Mode (Default)
@@ -414,7 +453,7 @@ $ sbomqs score --legacy --category ntia my-app.spdx.json
 
 ## Component Quality Analysis
 
-The Component Quality category requires access to the Interlynk API to analyze components for:
+The Component Quality category analyzes components via the Interlynk API for:
 
 - End-of-Life (EOL) and End-of-Support (EOS) status
 - Malicious package detection
@@ -422,20 +461,35 @@ The Component Quality category requires access to the Interlynk API to analyze c
 - Exploit Prediction Scoring System (EPSS)
 - PURL and CPE validity
 
+**Important:** Component quality analysis is opt-in. You must explicitly enable it with the `--enable-component-analysis` flag and provide an API key.
+
 ### API Endpoint Examples
+
+#### Basic Usage with Environment Variable
+
+```bash
+# Set API key via environment variable
+export INTERLYNK_SECURITY_TOKEN="your-api-key"
+
+# Enable component quality analysis
+sbomqs score my-app.spdx.json --enable-component-analysis
+```
+
+#### Using Command Line Flags
+
+```bash
+# Enable with explicit API key
+sbomqs score my-app.spdx.json --enable-component-analysis --api-key "your-api-key"
+
+# Enable with custom API URL
+sbomqs score my-app.spdx.json --enable-component-analysis --api-url "https://api.interlynk.io" --api-key "your-api-key"
+```
 
 #### Local Development
 
 ```bash
 # Using a local Interlynk instance
-sbomqs score my-app.spdx.json --url="http://localhost:3000" --api-key="your-local-api-key"
-```
-
-#### Production (Interlynk Platform)
-
-```bash
-# Using the Interlynk production API
-sbomqs score my-app.spdx.json --url="https://api.interlynk.io" --api-key="$INTERLYNK_SECURITY_TOKEN"
+sbomqs score my-app.spdx.json --enable-component-analysis --api-url="http://localhost:3000" --api-key="your-local-api-key"
 ```
 
 ### Obtaining an API Token
@@ -461,14 +515,14 @@ API_KEY=$(RBENV_VERSION=3.4.9 bundle exec rails runner '
 
 ### Component Quality Scoring Without API
 
-Without the `--url` flag, Component Quality features will show as "N/A" in the output. This is useful when you don't need component-level security analysis.
+Without the `--enable-component-analysis` flag, Component Quality features will show as "N/A" or "Coming Soon" in the output. This is the default behavior when you don't need component-level security analysis.
 
 ```bash
-# Score without component quality analysis
+# Score without component quality analysis (default)
 sbomqs score my-app.spdx.json
 
-# Score with component quality analysis
-sbomqs score my-app.spdx.json --url="https://api.interlynk.io" --api-key="$INTERLYNK_SECURITY_TOKEN"
+# Score with component quality analysis enabled
+sbomqs score my-app.spdx.json --enable-component-analysis --api-key="$INTERLYNK_SECURITY_TOKEN"
 ```
 
 ## CI/CD Integration

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -63,13 +63,13 @@ type Params struct {
 
 	ConfigPath string
 
-	Ntia  bool
+	Ntia   bool
 	Bsi    bool
 	BsiV1  bool
 	BsiV2  bool
 	BsiV21 bool
-	Oct   bool
-	Fsct  bool
+	Oct    bool
+	Fsct   bool
 
 	Color bool
 	Blob  string
@@ -80,8 +80,12 @@ type Params struct {
 
 	// InterlynkURL enables Component Quality API calls when set.
 	InterlynkURL string
+
 	// InterlynkAPIKey activates the authenticated tier (larger batches, more checks).
 	InterlynkAPIKey string
+
+	// EnableComponentAnalysis explicitly opts in to component quality analysis.
+	EnableComponentAnalysis bool
 }
 
 func Run(ctx context.Context, ep *Params) error {
@@ -119,13 +123,14 @@ func scored(ctx context.Context, ep *Params) ([]api.Result, error) {
 	)
 
 	cfg := config.Config{
-		Categories:      ep.Categories,
-		Features:        ep.Features,
-		ConfigFile:      ep.ConfigPath,
-		Profile:         ep.Profiles,
-		Recursive:       ep.Recursive,
-		InterlynkURL:    ep.InterlynkURL,
-		InterlynkAPIKey: ep.InterlynkAPIKey,
+		Categories:              ep.Categories,
+		Features:                ep.Features,
+		ConfigFile:              ep.ConfigPath,
+		Profile:                 ep.Profiles,
+		Recursive:               ep.Recursive,
+		InterlynkURL:            ep.InterlynkURL,
+		InterlynkAPIKey:         ep.InterlynkAPIKey,
+		EnableComponentAnalysis: ep.EnableComponentAnalysis,
 	}
 
 	results, err := score.ScoreSBOM(ctx, cfg, ep.Path)

--- a/pkg/interlynkapi/types.go
+++ b/pkg/interlynkapi/types.go
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // Package interlynkapi provides a client for the Interlynk Component Quality API.
-// When --url is provided to sbomqs score, components are extracted from the SBOM,
-// POSTed to `/api/v1/doctor/check` in batches, and the resulting findings populate
-// the Component Quality category instead of returning N/A.
+// When --enable-component-analysis is provided to sbomqs score, components are extracted
+// from the SBOM, POSTed to `/api/v1/doctor/check` in batches, and the resulting findings
+// populate the Component Quality category instead of returning N/A.
 package interlynkapi
 
 // ComponentPayload is one component in the API request body.

--- a/pkg/scorer/v2/config/config.go
+++ b/pkg/scorer/v2/config/config.go
@@ -58,12 +58,15 @@ type Config struct {
 	Recursive bool
 
 	// InterlynkURL is the base URL of the Interlynk platform for Component Quality checks
-	// (e.g. "https://app.interlynk.io"). When empty (default), no API calls are made and
-	// Component Quality features return N/A.
+	// (e.g. "https://api.interlynk.io"). Can also be set via INTERLYNK_API_URL env var.
 	InterlynkURL string
 
 	// InterlynkAPIKey is the Bearer token for the authenticated API tier.
-	// When empty, the unauthenticated tier is used (50-component batches, 6 basic checks).
-	// When set, the authenticated tier is used (5000-component batches, 10 checks).
+	// Can also be set via INTERLYNK_SECURITY_TOKEN env var.
+	// Required when EnableComponentAnalysis is true.
 	InterlynkAPIKey string
+
+	// EnableComponentAnalysis explicitly opts in to component quality analysis.
+	// When true, the Component Quality category is included and API calls are made.
+	EnableComponentAnalysis bool
 }

--- a/pkg/scorer/v2/extractors/compquality.go
+++ b/pkg/scorer/v2/extractors/compquality.go
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // Component Quality category extractors.
-// When the caller populates input.ComponentQuality (i.e. --url was provided and
-// the API call succeeded), these functions score each feature based on findings
-// returned by /api/v1/doctor/check. Without it they return N/A (informational).
+// When the caller populates input.ComponentQuality (i.e. --enable-component-analysis
+// was provided and the API call succeeded), these functions score each feature based
+// on findings returned by /api/v1/doctor/check. Without it they return N/A (informational).
 package extractors
 
 import (

--- a/pkg/scorer/v2/extractors/compquality_test.go
+++ b/pkg/scorer/v2/extractors/compquality_test.go
@@ -59,7 +59,7 @@ func TestCompWithPurlValid_NoAPIResult(t *testing.T) {
 	doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdxWithPurls, sbom.Signature{})
 	require.NoError(t, err)
 
-	// No ComponentQuality - simulates --url not provided or API call skipped
+	// No ComponentQuality - simulates --enable-component-analysis not provided or API call skipped
 	input := catalog.EvalInput{Doc: doc}
 	got := CompWithPurlValid(ctx, input)
 

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -419,6 +419,7 @@ func InitializeCatalog(ctx context.Context, conf config.Config) (*catalog.Catalo
 	// Default -> use full comprehensive categories
 	log.Info("Catalog initialized with selected categories",
 		zap.Int("categories", len(catal.ComprCategories)),
+		zap.Bool("component_quality_enabled", conf.EnableComponentAnalysis),
 	)
 
 	return catal, nil

--- a/pkg/scorer/v2/score/score.go
+++ b/pkg/scorer/v2/score/score.go
@@ -218,8 +218,7 @@ func SBOMEvaluation(ctx context.Context, catal *catalog.Catalog, cfg config.Conf
 
 	input := catalog.EvalInput{Doc: doc}
 
-	if cfg.InterlynkURL != "" && isCompQualityPresent(catal) {
-
+	if cfg.EnableComponentAnalysis && isCompQualityPresent(catal) {
 		client := interlynkapi.NewClient(cfg.InterlynkURL, cfg.InterlynkAPIKey)
 		log.Debug("Client for component quality API initialized",
 			zap.String("url", cfg.InterlynkURL),


### PR DESCRIPTION
THis PR adds the following changes:
- It adds `--enable-component-analysis` flag for enabling component quality category checks.
- And also support `api-key` and `api-url` via ENV var, `INTERLYNK_SECURITY_TOKEN` and `INTERLYNK_API_URL` respectively.
- Also renamed flag `--url` to ``--api-url` to maintain consistent with `--api-key`.
- update respective docs.

Examples:
```bash
// provide security key via ENV var
$ export INTERLYNK_SECURITY_TOKEN="lynk_live_aHdmzrWkkkkkkkkkkkkkkkkkk"
$ sbomqs score ../sbomasm/samples/cdx/sbomqs-cdx.json --enable-component-analysis


// provide both api key and security key via ENV var
$ export export INTERLYNK_API_URL="https://api.interlynk.io/"
$ sbomqs score ../sbomasm/samples/cdx/sbomqs-cdx.json --key-url="$INTERLYNK_API_URL" --api-key="$INTERLYNK_SECURITY_TOKEN" --enable-component-analysis

// provide both directly via CLI flag
$ sbomqs score ../sbomasm/samples/cdx/sbomqs-cdx.json --key-url="https://api.interlynk.io/" --api-key="lynk_live_aHdmzrWkkkkkkkkkkkkkkkkkk" --enable-component-analysis
```

demo:
```bash
$ go run main.go score ../sbomasm/samples/cdx/sbomqs-cdx.json --api-url="$INTERLYNK_API_URL" --api-key="$INTERLYNK_SECURITY_TOKEN" --enable-component-analysis
SBOM Quality Score: 5.1/10.0	 Grade: D	Components: 210 	 EngineVersion: 6	File: ../sbomasm/samples/cdx/sbomqs-cdx.json

Industry Profile Overviews:
+--------------------------------+----------+-------+
|            PROFILE             |  SCORE   | GRADE |
+--------------------------------+----------+-------+
| Interlynk                      | 4.9/10.0 | F     |
+--------------------------------+----------+-------+
| NTIA Minimum Elements (2021)   | 6.9/10.0 | D     |
+--------------------------------+----------+-------+
| NTIA Minimum Elements (2025) - | 5.4/10.0 | D     |
| RFC                            |          |       |
+--------------------------------+----------+-------+
| Framing 3rd Edition Compliance | 0.0/10.0 | F     |
+--------------------------------+----------+-------+
| BSI TR-03183-2 v1.1            | 4.2/10.0 | F     |
+--------------------------------+----------+-------+
| OpenChain Telco v1.1           | 3.5/10.0 | F     |
+--------------------------------+----------+-------+

Category Breakdown:
+-------------------+--------+-----------+-------+
|     CATEGORY      | WEIGHT |   SCORE   | GRADE |
+-------------------+--------+-----------+-------+
| Identification    | 12.2%  | 9.4/10.0  | A     |
+-------------------+--------+-----------+-------+
| Provenance        | 14.6%  | 5.5/10.0  | D     |
+-------------------+--------+-----------+-------+
| Integrity         | 18.3%  | 0.0/10.0  | F     |
+-------------------+--------+-----------+-------+
| Completeness      | 14.6%  | 3.0/10.0  | F     |
+-------------------+--------+-----------+-------+
| Licensing         | 18.3%  | 4.1/10.0  | F     |
+-------------------+--------+-----------+-------+
| Vulnerability     | 12.2%  | 7.8/10.0  | C     |
+-------------------+--------+-----------+-------+
| Structural        | 9.8%   | 10.0/10.0 | A     |
+-------------------+--------+-----------+-------+
| Component Quality | 12.2%  | 6.0/10.0  | D     |
+-------------------+--------+-----------+-------+

Score Breakdown:
+------------------------+--------------------------------+-----------+-------------------------------------+
|        CATEGORY        |            FEATURE             |   SCORE   |                DESC                 |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Identification (12.2%) | comp_with_name (4.9%)          | 10.0/10.0 | complete                            |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_version (4.3%)       | 8.4/10.0  | add to 34 components                |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_local_id (3.0%)      | 10.0/10.0 | complete                            |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Provenance (14.6%)     | sbom_creation_timestamp (2.9%) | 10.0/10.0 | complete                            |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_authors (2.9%)            | 0.0/10.0  | add author                          |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_tool_version (2.9%)       | 10.0/10.0 | complete                            |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_supplier (2.2%)           | 0.0/10.0  | add supplier                        |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_namespace (2.2%)          | 10.0/10.0 | complete                            |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_lifecycle (1.5%)          | 0.0/10.0  | add lifecycle                       |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Integrity (18.3%)      | comp_with_strong_checksums     | 0.0/10.0  | add to 210 components               |
|                        | (9.1%)                         |           |                                     |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_weak_checksums       | 0.0/10.0  | no checksums found                  |
|                        | (7.3%)                         |           |                                     |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_signature (1.8%)          | 0.0/10.0  | add signature                       |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Completeness (14.6%)   | comp_with_dependencies (3.7%)  | 0.0/10.0  | no dependency graph present         |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_completeness_declared     | 0.0/10.0  | SBOM completeness not declared      |
|                        | (2.2%)                         |           |                                     |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_primary_component (2.9%)  | 10.0/10.0 | complete                            |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_source_code (2.2%)   | 0.0/10.0  | add to 210 components               |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_supplier (2.2%)      | 0.0/10.0  | add to 210 components               |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_purpose (1.5%)       | 10.0/10.0 | complete                            |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Licensing (18.3%)      | comp_with_licenses (3.7%)      | 1.6/10.0  | add to 176 components               |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_valid_licenses       | 1.5/10.0  | add to 179 components               |
|                        | (3.7%)                         |           |                                     |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_no_deprecated_licenses    | 10.0/10.0 | complete                            |
|                        | (2.7%)                         |           |                                     |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_no_restrictive_licenses   | 9.7/10.0  | review 6 components                 |
|                        | (3.7%)                         |           |                                     |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_declared_licenses    | 0.0/10.0  | add to 210 components               |
|                        | (2.7%)                         |           |                                     |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_data_license (1.8%)       | 0.0/10.0  | add data license                    |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Vulnerability (12.2%)  | comp_with_purl (12.2% OR)      | 8.3/10.0  | add to 35 components                |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_with_cpe (12.2% OR)       | 7.3/10.0  | add to 56 components                |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Structural (9.8%)      | sbom_spec_declared (2.9%)      | 10.0/10.0 | cyclonedx                           |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_spec_version (2.9%)       | 10.0/10.0 | v1.4                                |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_file_format (2.0%)        | 10.0/10.0 | json                                |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | sbom_schema_valid (2.0%)       | 10.0/10.0 | complete                            |
+------------------------+--------------------------------+-----------+-------------------------------------+
| Component Quality      | comp_eol_eos                   | 0.0/10.0  | N/A                                 |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_malicious                 | 0.0/10.0  | N/A                                 |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_vuln_sev_critical         | 0.0/10.0  | N/A                                 |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_kev                       | 0.0/10.0  | N/A                                 |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_purl_valid                | 9.2/10.0  | add to 16 components                |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | comp_cpe_valid                 | 2.7/10.0  | add to 154 components               |
+                        +--------------------------------+-----------+-------------------------------------+
|                        | NOTE: Register Interest for    |           | https://forms.gle/WVoB3DrX9NKnzfhV8 |
|                        | Component Analysis             |           |                                     |
+------------------------+--------------------------------+-----------+-------------------------------------+


Love to hear your feedback https://forms.gle/anFSspwrk7uSfD7Q6


```