### PR TITLE
fix minor spell

### DIFF
--- a/pkg/scorer/v2/profiles/bsiv21.go
+++ b/pkg/scorer/v2/profiles/bsiv21.go
@@ -92,7 +92,7 @@ func BSIV21CompStructuredProperty(doc sbom.Document) catalog.ProfFeatScore {
 
 // BSIV21CompEffectiveLicence checks that components have the bsi:component:effectiveLicense property set.
 func BSIV21CompEffectiveLicence(doc sbom.Document) catalog.ProfFeatScore {
-	return bsiPropertyCheck(doc, "bsi:component:effectiveLicense", "effective licence")
+	return bsiPropertyCheck(doc, "bsi:component:effectiveLicence", "effective licence")
 }
 
 // BSIV21CompDeployableHash checks that components have a hash on their distribution or distribution-intake external reference.


### PR DESCRIPTION
closes #677 
This PR adds the following changes:
- fixes cdx taxomany spell for `bsi:component:effectiveLicence`