### PR TITLE
support feature for profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ In today's software landscape, understanding and managing your software supply c
 ### 🎯 Guides
 
 - **[Customization](docs/guides/customization.md)** - Create custom scoring profiles
+- **[Weightage Scoring](docs/guides/weightage-scoring.md)** - Customize scoring weights and categories
 - **[Integrations](docs/guides/integrations.md)** - CI/CD and tool integrations
 - **[Policy](docs/guides/policy.md)** - Policy enforcement and validation
 
@@ -90,7 +91,12 @@ sbomqs score my-app.spdx.json --category integrity
 
 # check specific profile 
 sbomqs score my-app.spdx.json --category NTIA-minimum-elements --profile ntia
+
+# Use custom weights configuration
+sbomqs score my-app.spdx.json --configpath my-weights.yaml
 ```
+
+See [Weightage Scoring Guide](docs/guides/weightage-scoring.md) for details on customizing scoring weights.
 
 ### Verify Compliance
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ sbomqs compliance --fsct my-app.spdx.json
 sbomqs compliance --oct my-app.spdx.json
 ```
 
+### Score Specific Features
+
+```bash
+# Score comprehensive features (default profile)
+sbomqs score my-app.spdx.json --feature comp_with_name,comp_with_version
+
+# Score NTIA-specific features
+sbomqs score my-app.spdx.json --profile ntia --feature comp_name,comp_version,sbom_timestamp
+
+# Score BSI v2.1-specific features
+sbomqs score my-app.cdx.json --profile bsi --feature sbom_spec_version,sbom_creator,comp_name
+
+# Score with JSON output for automation
+sbomqs score my-app.spdx.json --profile ntia --feature comp_name --json
+```
+
 ### Find Missing Data
 
 ```bash

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -77,13 +77,25 @@ func init() {
 }
 
 func generateYaml(_ context.Context) error {
-	return os.WriteFile(featuresFileName, []byte(scorer.DefaultConfig()), 0o600)
+	if err := os.WriteFile(featuresFileName, []byte(scorer.DefaultConfig()), 0o600); err != nil {
+		return err
+	}
+	fmt.Printf("Configuration written to %s\n", featuresFileName)
+	return nil
 }
 
 func generateComprYaml(_ context.Context) error {
-	return os.WriteFile(comprFileName, []byte(registry.DefaultComprConfig()), 0o600)
+	if err := os.WriteFile(comprFileName, []byte(registry.DefaultComprConfig()), 0o600); err != nil {
+		return err
+	}
+	fmt.Printf("Configuration written to %s\n", comprFileName)
+	return nil
 }
 
 func generateProfYaml(_ context.Context) error {
-	return os.WriteFile(profFileName, []byte(registry.DefaultProfConfig()), 0o600)
+	if err := os.WriteFile(profFileName, []byte(registry.DefaultProfConfig()), 0o600); err != nil {
+		return err
+	}
+	fmt.Printf("Configuration written to %s\n", profFileName)
+	return nil
 }

--- a/cmd/score.go
+++ b/cmd/score.go
@@ -412,7 +412,7 @@ func init() {
 
 	// Filter Control
 	scoreCmd.Flags().StringP("category", "c", "", "filter by category (e.g. 'identification', 'provenance', 'integrity', 'completeness', 'licensing', 'vulnerability', 'structural', 'cinfo')")
-	scoreCmd.Flags().StringP("feature", "f", "", "filter by feature (e.g. 'sbom_authors',  'comp_with_name', 'sbom_creation_timestamp') ")
+	scoreCmd.Flags().StringP("feature", "f", "", "filter by feature (comma-separated). Features depend on profile: use 'sbom_authors,comp_with_name' for default (Interlynk) or profile-specific keys like 'comp_name,comp_version' with --profile)")
 
 	// Spec Control
 	scoreCmd.Flags().BoolP("spdx", "", false, "limit scoring to spdx sboms")

--- a/docs/commands/score.md
+++ b/docs/commands/score.md
@@ -273,12 +273,85 @@ $ sbomqs score --legacy --category ntia my-app.spdx.json
 
 #### Specific Feature Scoring
 
-```bash
-# Score specific features
-$ sbomqs score --feature comp_with_name,comp_with_version my-app.spdx.json
+The `--feature` flag allows you to score specific features within a profile context. When used with `--profile`, only profile-specific features are available. When used without `--profile` (default Interlynk profile), comprehensive features are available.
 
-# Combine with categories
-$ sbomqs score --category identification --feature comp_with_identifiers my-app.spdx.json
+**Default Profile (Interlynk) - Comprehensive Features:**
+```bash
+# Score comprehensive features (no profile specified)
+$ sbomqs score --feature comp_with_name,comp_with_version my-app.spdx.json
+```
+
+**Profile-Specific Feature Scoring:**
+```bash
+# Score NTIA-specific features
+$ sbomqs score --profile ntia --feature comp_name,comp_version,sbom_timestamp my-app.spdx.json
+
+# Score BSI v2.1-specific features
+$ sbomqs score --profile bsi --feature sbom_spec_version,sbom_creator,comp_name my-app.cdx.json
+
+# Score multiple features with profile
+$ sbomqs score --profile ntia --feature comp_supplier,comp_name,comp_version,comp_uniq_id my-app.spdx.json
+```
+
+##### Profile-Specific Feature Reference
+
+Each profile has its own set of feature keys:
+
+| Profile | Feature Keys |
+|---------|-------------|
+| **ntia** | `comp_supplier`, `comp_name`, `comp_version`, `comp_uniq_id`, `comp_dependencies`, `sbom_relationships`, `sbom_timestamp` |
+| **ntia-2025** | `sbom_machine_format`, `sbom_author`, `software_producer`, `comp_name`, `comp_version`, `software_identifiers`, `comp_hash`, `license`, `sbom_dependencies`, `comp_supplier`, `tool_name`, `sbom_timestamp`, `generation_context` |
+| **bsi-v1.1** | `sbom_creator`, `sbom_timestamp`, `comp_creator`, `comp_name`, `comp_version`, `comp_depth`, `comp_license`, `comp_hash`, `sbom_uri`, `comp_source_url`, `comp_executable_url`, `comp_source_hash`, `comp_unique_identifiers` |
+| **bsi-v2.0** | `sbom_creator`, `sbom_timestamp`, `sbom_uri`, `comp_creator`, `comp_name`, `comp_version`, `comp_filename`, `comp_depth`, `comp_associated_license`, `comp_deployable_hash`, `comp_executable_property`, `comp_archive_property`, `comp_structured_property` |
+| **bsi** (v2.1) | `sbom_spec_version`, `sbom_creator`, `sbom_timestamp`, `sbom_uri`, `comp_creator`, `comp_name`, `comp_version`, `comp_filename`, `comp_depth`, `comp_distribution_license`, `comp_deployable_hash`, `comp_executable_prop`, `comp_archive_prop`, `comp_structured_prop`, `comp_source_code_url`, `comp_download_url`, `comp_other_identifiers`, `comp_original_licenses`, `comp_effective_license`, `comp_source_hash`, `comp_security_txt_url` |
+| **oct-v1.1** | `sbom_spec`, `sbom_spec_version`, `sbom_data_license`, `sbom_identifier`, `sbom_name`, `sbom_namespace`, `sbom_creator`, `sbom_timestamp`, `sbom_creator_comment`, `comp_name`, `comp_identifier`, `comp_version`, `comp_supplier`, `comp_download_location`, `comp_license_concluded`, `comp_license_declared`, `comp_copyright`, `sbom_relationships` |
+| **fsct** | `sbom_provenance`, `sbom_primary_component`, `comp_identity`, `supplier_attribution`, `comp_unique_id`, `artifact_integrity`, `relationships_coverage`, `license_coverage`, `copyright_coverage` |
+
+**Error Messages:**
+If you try to use a feature that doesn't belong to the specified profile, you'll get a helpful error message:
+```bash
+$ sbomqs score --profile ntia --feature sbom_spec_version my-app.spdx.json
+Error: feature 'sbom_spec_version' is not evaluated in NTIA Minimum Elements (2021) profile (this feature belongs to: bsi profile); supported features: [comp_supplier comp_name comp_version comp_uniq_id comp_dependencies sbom_relationships sbom_timestamp]
+```
+
+**Feature Scoring Output:**
+When using `--feature`, the output shows a Feature Quality Score with a breakdown table:
+```bash
+$ sbomqs score --profile ntia --feature comp_name,comp_version my-app.spdx.json
+Feature Quality Score: 9.9/10.0     Grade: A    Components: 38      EngineVersion: 7    File: my-app.spdx.json
+Profile Context: NTIA Minimum Elements (2021)
+
+Feature Breakdown:
++--------------+-----------+-------+--------------------+
+|   FEATURE    |   SCORE   | GRADE |        DESC        |
++--------------+-----------+-------+--------------------+
+| comp_name    | 10.0/10.0 | A     | complete           |
++--------------+-----------+-------+--------------------+
+| comp_version | 9.7/10.0  | A     | add to 1 component |
++--------------+-----------+-------+--------------------+
+
+Overall: 2/2 NTIA Minimum Elements (2021) requirements passed
+```
+
+**JSON Output for Feature Scoring:**
+```bash
+$ sbomqs score --profile ntia --feature comp_name --json my-app.spdx.json
+{
+  "run_id": "...",
+  "files": [{
+    "comprehenssive": [{
+      "category": "Feature Scoring",
+      "score": 10.0,
+      "grade": "A",
+      "features": [{
+        "key": "comp_name",
+        "score": 10.0,
+        "description": "complete",
+        "ignored": false
+      }]
+    }]
+  }]
+}
 ```
 
 ### Automation-Friendly Output

--- a/docs/commands/score.md
+++ b/docs/commands/score.md
@@ -44,7 +44,7 @@ sbomqs score [flags] <SBOM file(s)>
 
 - `--category, -c <category>`: Score only specific categories (comma-separated)
 - `--feature, -f <features>`: Score only specific features (comma-separated)
-- `--configpath <path>`: Use custom scoring configuration file
+- `--configpath <path>`: Use custom scoring configuration file. See [Weightage Scoring Guide](../guides/weightage-scoring.md) for details on creating custom weight configurations.
 - `--profile <profiles>`: Apply specific compliance profiles (comma-separated: 'ntia', 'bsi', 'bsi-v1.1', 'bsi-v2.0', 'bsi-v2.1', 'oct', 'interlynk')
 - `--legacy, -e`: Use legacy scoring mode (prior to sbomqs version 2.0)
 
@@ -276,12 +276,14 @@ $ sbomqs score --legacy --category ntia my-app.spdx.json
 The `--feature` flag allows you to score specific features within a profile context. When used with `--profile`, only profile-specific features are available. When used without `--profile` (default Interlynk profile), comprehensive features are available.
 
 **Default Profile (Interlynk) - Comprehensive Features:**
+
 ```bash
 # Score comprehensive features (no profile specified)
 $ sbomqs score --feature comp_with_name,comp_with_version my-app.spdx.json
 ```
 
 **Profile-Specific Feature Scoring:**
+
 ```bash
 # Score NTIA-specific features
 $ sbomqs score --profile ntia --feature comp_name,comp_version,sbom_timestamp my-app.spdx.json
@@ -309,6 +311,7 @@ Each profile has its own set of feature keys:
 
 **Error Messages:**
 If you try to use a feature that doesn't belong to the specified profile, you'll get a helpful error message:
+
 ```bash
 $ sbomqs score --profile ntia --feature sbom_spec_version my-app.spdx.json
 Error: feature 'sbom_spec_version' is not evaluated in NTIA Minimum Elements (2021) profile (this feature belongs to: bsi profile); supported features: [comp_supplier comp_name comp_version comp_uniq_id comp_dependencies sbom_relationships sbom_timestamp]
@@ -316,6 +319,7 @@ Error: feature 'sbom_spec_version' is not evaluated in NTIA Minimum Elements (20
 
 **Feature Scoring Output:**
 When using `--feature`, the output shows a Feature Quality Score with a breakdown table:
+
 ```bash
 $ sbomqs score --profile ntia --feature comp_name,comp_version my-app.spdx.json
 Feature Quality Score: 9.9/10.0     Grade: A    Components: 38      EngineVersion: 7    File: my-app.spdx.json
@@ -334,6 +338,7 @@ Overall: 2/2 NTIA Minimum Elements (2021) requirements passed
 ```
 
 **JSON Output for Feature Scoring:**
+
 ```bash
 $ sbomqs score --profile ntia --feature comp_name --json my-app.spdx.json
 {
@@ -357,6 +362,7 @@ $ sbomqs score --profile ntia --feature comp_name --json my-app.spdx.json
 ### Automation-Friendly Output
 
 #### JSON Output for CI/CD
+
 ```bash
 ➜  sbomqs git:(feature/sbomqs-2.0-docs) ✗ ./build/sbomqs score -j samples/photon.spdx.json
 {
@@ -408,6 +414,8 @@ $ vim custom-profile.yaml
 # Use custom profile
 $ sbomqs score my-app.json --configpath custom-profile.yaml
 ```
+
+**For detailed information on customizing weights, see the [Weightage Scoring Guide](../guides/weightage-scoring.md).**
 
 ### Directory Processing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -555,6 +555,7 @@ sbomqs score my-app.spdx.json --basic
 ### Understanding Your Score
 
 Scores range from 0-10:
+
 - **9-10**: Excellent quality
 - **7-8.9**: Good, minor improvements needed  
 - **5-6.9**: Fair, has gaps to address
@@ -582,8 +583,43 @@ sbomqs score my-app.spdx.json --category ntia
 # Check BSI compliance (latest v2.1)
 sbomqs compliance --bsi-v2 my-app.cdx.json
 
-# Check FSCT compliance  
+# Check FSCT compliance
 sbomqs compliance --fsct my-app.spdx.json
+```
+
+### Score Specific Features
+
+Score individual features within a profile context:
+
+```bash
+# Score NTIA-specific features
+sbomqs score my-app.spdx.json --profile ntia --feature comp_name,comp_version
+
+# Score BSI v2.1-specific features (21 features available)
+sbomqs score my-app.cdx.json --profile bsi --feature sbom_spec_version,sbom_creator,comp_name
+
+# Score multiple NTIA features
+sbomqs score my-app.spdx.json --profile ntia --feature comp_supplier,comp_name,comp_version,comp_uniq_id,comp_dependencies,sbom_relationships,sbom_timestamp
+
+# Score comprehensive features (default Interlynk profile)
+sbomqs score my-app.spdx.json --feature comp_with_name,comp_with_version
+```
+
+**Feature Scoring Output:**
+
+```bash
+Feature Quality Score: 9.9/10.0     Grade: A    Components: 38      EngineVersion: 7
+Profile Context: NTIA Minimum Elements (2021)
+
+Feature Breakdown:
++--------------+-----------+-------+--------------------+
+|   FEATURE    |   SCORE   | GRADE |        DESC        |
++--------------+-----------+-------+--------------------+
+| comp_name    | 10.0/10.0 | A     | complete           |
+| comp_version | 9.7/10.0  | A     | add to 1 component |
++--------------+-----------+-------+--------------------+
+
+Overall: 2/2 NTIA Minimum Elements (2021) requirements passed
 ```
 
 ### Share Your Results

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -13,6 +13,22 @@ SBOMQS uses a weighted scoring system across multiple categories:
 - **Features**: Individual scoring criteria
 - **Weights**: Importance multipliers (0.0-1.0)
 
+### Profile-Specific Feature Scoring
+
+Each compliance profile has its own set of feature keys. When using `--feature` with `--profile`, you must use the profile-specific feature keys:
+
+| Profile | Available Feature Keys |
+|---------|------------------------|
+| ntia | `comp_supplier`, `comp_name`, `comp_version`, `comp_uniq_id`, `comp_dependencies`, `sbom_relationships`, `sbom_timestamp` |
+| ntia-2025 | `sbom_machine_format`, `sbom_author`, `software_producer`, `comp_name`, `comp_version`, `software_identifiers`, `comp_hash`, `license`, `sbom_dependencies`, `comp_supplier`, `tool_name`, `sbom_timestamp`, `generation_context` |
+| bsi-v1.1 | `sbom_creator`, `sbom_timestamp`, `comp_creator`, `comp_name`, `comp_version`, `comp_depth`, `comp_license`, `comp_hash`, `sbom_uri`, `comp_source_url`, `comp_executable_url`, `comp_source_hash`, `comp_unique_identifiers` |
+| bsi-v2.0 | `sbom_creator`, `sbom_timestamp`, `sbom_uri`, `comp_creator`, `comp_name`, `comp_version`, `comp_filename`, `comp_depth`, `comp_associated_license`, `comp_deployable_hash`, `comp_executable_property`, `comp_archive_property`, `comp_structured_property` |
+| bsi (v2.1) | `sbom_spec_version`, `sbom_creator`, `sbom_timestamp`, `sbom_uri`, `comp_creator`, `comp_name`, `comp_version`, `comp_filename`, `comp_depth`, `comp_distribution_license`, `comp_deployable_hash`, `comp_executable_prop`, `comp_archive_prop`, `comp_structured_prop`, `comp_source_code_url`, `comp_download_url`, `comp_other_identifiers`, `comp_original_licenses`, `comp_effective_license`, `comp_source_hash`, `comp_security_txt_url` |
+| oct-v1.1 | `sbom_spec`, `sbom_spec_version`, `sbom_data_license`, `sbom_identifier`, `sbom_name`, `sbom_namespace`, `sbom_creator`, `sbom_timestamp`, `sbom_creator_comment`, `comp_name`, `comp_identifier`, `comp_version`, `comp_supplier`, `comp_download_location`, `comp_license_concluded`, `comp_license_declared`, `comp_copyright`, `sbom_relationships` |
+| fsct | `sbom_provenance`, `sbom_primary_component`, `comp_identity`, `supplier_attribution`, `comp_unique_id`, `artifact_integrity`, `relationships_coverage`, `license_coverage`, `copyright_coverage` |
+
+**Note:** Using a feature key that doesn't belong to the specified profile will result in an error message showing the supported features for that profile.
+
 ### Default Scoring Categories
 
 | Category | Default Weight | Focus |

--- a/docs/guides/customization.md
+++ b/docs/guides/customization.md
@@ -41,6 +41,8 @@ Each compliance profile has its own set of feature keys. When using `--feature` 
 
 ## Creating Custom Profiles
 
+For comprehensive documentation on weightage-based scoring, including detailed examples and edge cases, see the **[Weightage Scoring Guide](weightage-scoring.md)**.
+
 ### Generate Base Configuration
 
 ```bash

--- a/docs/guides/weightage-scoring.md
+++ b/docs/guides/weightage-scoring.md
@@ -1,0 +1,451 @@
+# Weightage Scoring Guide
+
+This comprehensive guide explains how to customize SBOMQS scoring using weightage configuration files. With weightage scoring, you can tailor the importance of different categories and features to match your organization's specific SBOM quality requirements.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Configuration File Format](#configuration-file-format)
+- [Weightage Rules](#weightage-rules)
+- [Examples](#examples)
+- [Edge Cases](#edge-cases)
+- [Validation](#validation)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+SBOMQS comprehensive scoring evaluates SBOMs across multiple categories (Identification, Provenance, Integrity, etc.). By default, each category has a predefined weight that contributes to the final quality score.
+
+**Weightage scoring allows you to:**
+- Disable categories you don't care about (set weight to 0)
+- Increase importance of critical categories
+- Focus only on specific aspects of SBOM quality
+- Create organization-specific scoring profiles
+
+## Quick Start
+
+### 1. Generate Default Configuration
+
+```bash
+sbomqs generate comprehensive > my-weights.yaml
+```
+
+This creates a YAML file with all default weights that you can customize.
+
+### 2. Edit Weights
+
+Open `my-weights.yaml` and modify weights:
+
+```yaml
+categories:
+  - name: "Identification"
+    key: "identification"
+    weight: 15      # Increased from default 10
+    features:
+      - name: "Component With Name"
+        key: "comp_with_name"
+        weight: 0.50  # Increased from default 0.40
+```
+
+### 3. Run Scoring
+
+```bash
+sbomqs score --configpath my-weights.yaml my-sbom.json
+```
+
+## Configuration File Format
+
+### Structure
+
+```yaml
+metadata:
+  version: "2.0.0"
+  description: "Custom scoring weights"
+  last_updated: "2026-06-10"
+
+categories:
+  - name: "Category Name"
+    key: "category_key"
+    weight: <number>        # Category weight
+    features:
+      - name: "Feature Name"
+        key: "feature_key"
+        weight: <number>    # Feature weight (0.0-1.0)
+        ignore: <boolean>   # Skip this feature
+```
+
+### Available Categories and Keys
+
+| Category | Key | Default Weight |
+|----------|-----|----------------|
+| Identification | `identification` | 10 |
+| Provenance | `provenance` | 12 |
+| Integrity | `integrity` | 15 |
+| Completeness | `completeness` | 12 |
+| Licensing | `licensing_and_compliance` | 15 |
+| Vulnerability | `vulnerability_and_traceability` | 10 |
+| Structural | `structural` | 8 |
+| Component Quality | `compinfo` | 10 |
+
+### Category Feature Keys
+
+#### Identification
+- `comp_with_name` - Component has a name
+- `comp_with_version` - Component has a version
+- `comp_with_local_id` - Component has local identifiers
+
+#### Provenance
+- `sbom_creation_timestamp` - Document creation time
+- `sbom_authors` - Document authors
+- `sbom_tool_version` - Creator tool & version
+- `sbom_supplier` - Document supplier
+- `sbom_namespace` - Document URI/Namespace
+- `sbom_lifecycle` - Document lifecycle
+
+#### Integrity
+- `comp_with_strong_checksums` - Component with SHA256+ checksums
+- `comp_with_weak_checksums` - Component with weak checksums
+- `sbom_signature` - Document signature
+
+#### Completeness
+- `comp_with_dependencies` - Component dependencies defined
+- `sbom_completeness_declared` - Declared completeness
+- `sbom_primary_component` - Primary component identified
+- `comp_with_source_code` - Source code location
+- `comp_with_supplier` - Component supplier
+- `comp_with_purpose` - Component purpose/type
+
+#### Licensing
+- `comp_with_licenses` - Components have licenses
+- `comp_with_valid_licenses` - Valid license identifiers
+- `comp_no_deprecated_licenses` - No deprecated licenses
+- `comp_no_restrictive_licenses` - No restrictive licenses
+- `comp_with_declared_licenses` - Declared/original licenses
+- `sbom_data_license` - Document data license
+
+#### Vulnerability
+- `comp_with_purl` - Components have PURL
+- `comp_with_cpe` - Components have CPE
+- `comp_with_purl_or_cpe` - Either PURL or CPE
+
+#### Structural
+- `sbom_spec_declared` - SBOM spec declared
+- `sbom_spec_version` - Spec version identified
+- `sbom_file_format` - File format (JSON/XML)
+- `sbom_schema_valid` - Schema validation passed
+
+## Weightage Rules
+
+### How Weights Work
+
+**Category Weights:**
+- Categories with `weight: 0` are completely excluded
+- Higher category weights increase their contribution to the final score
+- The final score is calculated as a weighted average: `Σ(category_score × category_weight) / Σ(category_weight)`
+
+**Feature Weights:**
+- Feature weights are relative within a category (should sum to 1.0)
+- Features marked `ignore: true` are skipped entirely
+- Features are weighted within their category to produce the category score
+
+### Score Calculation Example
+
+With this configuration:
+```yaml
+categories:
+  - name: "Licensing"
+    weight: 15
+    features:
+      - weight: 0.4  # 40% of licensing score
+      - weight: 0.6  # 60% of licensing score
+  - name: "Structural"
+    weight: 8
+    features:
+      - weight: 1.0  # 100% of structural score
+```
+
+Calculation:
+- Total category weight: 15 + 8 = 23
+- Licensing contributes: 15/23 = 65.2%
+- Structural contributes: 8/23 = 34.8%
+- Final score: `(licensing_score × 0.652) + (structural_score × 0.348)`
+
+## Examples
+
+### Example 1: Focus on Licensing Only
+
+Only evaluate licensing compliance:
+
+```yaml
+metadata:
+  version: "2.0.0"
+  description: "Licensing-only scoring"
+
+categories:
+  - name: "Licensing"
+    key: "licensing_and_compliance"
+    weight: 15
+    features:
+      - name: "Components With Licenses"
+        key: "comp_with_licenses"
+        weight: 0.20
+      - name: "Component With Valid Licenses"
+        key: "comp_with_valid_licenses"
+        weight: 0.30
+      - name: "Component Without Deprecated Licenses"
+        key: "comp_no_deprecated_licenses"
+        weight: 0.25
+      - name: "Component Without Restrictive Licenses"
+        key: "comp_no_restrictive_licenses"
+        weight: 0.25
+```
+
+**Result:** Only Licensing category appears in output.
+
+### Example 2: Exclude Specific Categories
+
+Evaluate everything except Component Quality:
+
+```yaml
+categories:
+  - name: "Identification"
+    key: "identification"
+    weight: 10
+    features:
+      - key: comp_with_name
+        weight: 0.40
+      - key: comp_with_version
+        weight: 0.35
+      - key: comp_with_local_id
+        weight: 0.25
+  - name: "Provenance"
+    key: "provenance"
+    weight: 12
+    features: ...
+  # ... other categories ...
+  # Component Quality omitted entirely
+```
+
+**Result:** Component Quality is not evaluated or displayed.
+
+### Example 3: Custom Weights
+
+Prioritize structural integrity and licensing:
+
+```yaml
+categories:
+  - name: "Structural"
+    key: "structural"
+    weight: 20      # Increased importance
+    features:
+      - key: sbom_spec_declared
+        weight: 0.30
+      - key: sbom_spec_version
+        weight: 0.30
+      - key: sbom_file_format
+        weight: 0.20
+      - key: sbom_schema_valid
+        weight: 0.20
+  
+  - name: "Licensing"
+    key: "licensing_and_compliance"
+    weight: 20      # Increased importance
+    features: ...
+  
+  - name: "Identification"
+    key: "identification"
+    weight: 5       # Reduced importance
+    features: ...
+  
+  - name: "Vulnerability"
+    key: "vulnerability_and_traceability"
+    weight: 0       # Disabled
+    features: ...
+```
+
+### Example 4: Skip Specific Features
+
+Evaluate Identification but skip version checking:
+
+```yaml
+categories:
+  - name: "Identification"
+    key: "identification"
+    weight: 10
+    features:
+      - name: "Component With Name"
+        key: "comp_with_name"
+        weight: 0.60  # Increased since version is ignored
+      - name: "Component With Version"
+        key: "comp_with_version"
+        weight: 0.35
+        ignore: true  # Skip this feature
+      - name: "Component With Local IDs"
+        key: "comp_with_local_id"
+        weight: 0.40
+```
+
+**Result:** Version checking is skipped; name and ID contribute to category score.
+
+## Edge Cases
+
+### Case 1: All Categories Weight = 0
+
+```yaml
+categories:
+  - name: "Identification"
+    weight: 0
+  - name: "Structural"
+    weight: 0
+```
+
+**Result:** Score 0.0/10.0, no categories displayed. Total weight is 0.
+
+### Case 2: Category Weight > 0 but All Features Ignored
+
+```yaml
+categories:
+  - name: "Identification"
+    weight: 10
+    features:
+      - key: comp_with_name
+        ignore: true
+      - key: comp_with_version
+        ignore: true
+```
+
+**Result:** Category is excluded (no features to evaluate).
+
+### Case 3: Mix of Ignored and Non-Ignored Features
+
+```yaml
+categories:
+  - name: "Identification"
+    weight: 10
+    features:
+      - key: comp_with_name
+        weight: 0.40
+        ignore: false
+      - key: comp_with_version
+        weight: 0.35
+        ignore: true
+      - key: comp_with_local_id
+        weight: 0.25
+        ignore: true
+```
+
+**Result:** Only `comp_with_name` is evaluated and displayed.
+
+### Case 4: Features with Zero Weight
+
+```yaml
+categories:
+  - name: "Identification"
+    weight: 10
+    features:
+      - key: comp_with_name
+        weight: 0
+      - key: comp_with_version
+        weight: 1.0
+```
+
+**Result:** Features with weight 0 are evaluated but contribute 0% to category score.
+
+### Case 5: Empty Features List
+
+```yaml
+categories:
+  - name: "Empty Category"
+    weight: 10
+    features: []
+```
+
+**Result:** Category is excluded (no features to evaluate).
+
+### Case 6: Single Category
+
+```yaml
+categories:
+  - name: "Structural"
+    weight: 8
+    features:
+      - key: sbom_spec_declared
+        weight: 0.30
+```
+
+**Result:** Category shown with 100% weight contribution.
+
+## Validation
+
+SBOMQS validates your configuration and provides clear error messages:
+
+### Negative Weights
+
+```yaml
+categories:
+  - name: "Identification"
+    weight: -5
+```
+
+**Error:** `invalid weight -5.00 for category "Identification": weights must be non-negative`
+
+### Negative Feature Weights
+
+```yaml
+categories:
+  - name: "Identification"
+    weight: 10
+    features:
+      - name: "Component With Name"
+        weight: -0.5
+```
+
+**Error:** `invalid weight -0.50 for feature "Component With Name" in category "Identification": weights must be non-negative`
+
+## Troubleshooting
+
+### Issue: Category Not Appearing in Output
+
+**Possible Causes:**
+1. Category weight is 0
+2. All features in category are marked `ignore: true`
+3. Features list is empty
+
+**Solution:** Check weight and ignore settings in your configuration.
+
+### Issue: Feature Percentage Shows 0%
+
+**Cause:** Feature weight is 0 within the category.
+
+**Solution:** Increase feature weight or check your configuration.
+
+### Issue: Total Category Weight Shows Negative or Weird Percentages
+
+**Cause:** Negative weights in configuration.
+
+**Solution:** Ensure all weights are non-negative (≥ 0).
+
+### Issue: Config File Not Loading
+
+**Causes:**
+1. File path is incorrect
+2. YAML syntax error
+3. Missing required fields
+
+**Solution:** Validate YAML syntax and check file path.
+
+## Best Practices
+
+1. **Start with defaults:** Generate default config and modify incrementally
+2. **Document your changes:** Add comments explaining why weights were changed
+3. **Version your configs:** Include version in metadata for tracking
+4. **Test thoroughly:** Validate configs with sample SBOMs before deployment
+5. **Keep feature weights balanced:** Feature weights within a category should ideally sum to 1.0
+6. **Use meaningful descriptions:** Help your team understand the scoring rationale
+
+## See Also
+
+- [Customization Guide](./customization.md) - General customization options
+- [Command Reference](../commands/score.md) - Score command documentation
+- [Getting Started](../getting-started.md) - Basic usage guide

--- a/docs/guides/weightage-scoring.md
+++ b/docs/guides/weightage-scoring.md
@@ -135,6 +135,16 @@ categories:
 - `sbom_file_format` - File format (JSON/XML)
 - `sbom_schema_valid` - Schema validation passed
 
+#### Component Quality
+- `comp_eol_eos` - Component No Longer Maintained or Declared EOL (weight: 0.10)
+- `comp_malicious` - Component tagged as malicious in threat databases (weight: 0.15)
+- `comp_vuln_sev_critical` - Component with critical vulnerabilities (weight: 0.15)
+- `comp_kev` - Component which are actively exploited (CISA KEV) (weight: 0.15)
+- `comp_purl_valid` - Component PURL Valid (weight: 0.225)
+- `comp_cpe_valid` - Component CPE Valid (weight: 0.225)
+
+**Note:** Component Quality features require API key and are informational only (do not affect overall score).
+
 ## Weightage Rules
 
 ### How Weights Work

--- a/pkg/reporter/v2/basic.go
+++ b/pkg/reporter/v2/basic.go
@@ -16,30 +16,126 @@ package v2
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/interlynk-io/sbomqs/v2/pkg/sbom"
+	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/api"
+	"github.com/olekukonko/tablewriter"
 )
 
 func (r *Reporter) basicReport() {
-	for _, r := range r.Results {
-		format := r.Meta.FileFormat
-		spec := r.Meta.Spec
-		version := r.Meta.SpecVersion
+	for _, result := range r.Results {
+		format := result.Meta.FileFormat
+		spec := result.Meta.Spec
+		version := result.Meta.SpecVersion
 
 		if spec == string(sbom.SBOMSpecSPDX) {
 			version = strings.Replace(version, "SPDX-", "", 1)
 		}
 
+		// Check for feature-only scoring mode
+		if result.ProfileContext != "" && result.Comprehensive != nil && len(result.Comprehensive.CatResult) > 0 && result.Comprehensive.CatResult[0].Key == "feature_scoring" {
+			r.renderFeatureScore(result)
+			continue
+		}
+
 		// If comprehensive scoring is present, we're in default mode (no specific profile requested)
 		// Show only the Interlynk comprehensive score
-		if r.Comprehensive != nil {
-			fmt.Printf("%0.1f\t%s\t%s\t%s\t%s\t%s\n", r.Comprehensive.InterlynkScore, r.Comprehensive.Grade, "Interlynk", version, format, r.Meta.Filename)
-		} else if r.Profiles != nil && len(r.Profiles.ProfResult) > 0 {
+		if result.Comprehensive != nil {
+			fmt.Printf("%0.1f\t%s\t%s\t%s\t%s\t%s\n", result.Comprehensive.InterlynkScore, result.Comprehensive.Grade, "Interlynk", version, format, result.Meta.Filename)
+		} else if result.Profiles != nil && len(result.Profiles.ProfResult) > 0 {
 			// Profile-only mode: specific profiles were requested, show them
-			for _, prof := range r.Profiles.ProfResult {
-				fmt.Printf("%0.1f\t%s\t%s\t%s\t%s\t%s\n", prof.InterlynkScore, prof.Grade, prof.Name, version, format, r.Meta.Filename)
+			for _, prof := range result.Profiles.ProfResult {
+				fmt.Printf("%0.1f\t%s\t%s\t%s\t%s\t%s\n", prof.InterlynkScore, prof.Grade, prof.Name, version, format, result.Meta.Filename)
 			}
 		}
+	}
+}
+
+// renderFeatureScore outputs feature-level scoring results
+func (r *Reporter) renderFeatureScore(result api.Result) {
+	catResult := result.Comprehensive.CatResult[0]
+	numComponents := result.Meta.NumComponents
+	fileName := result.Meta.Filename
+
+	// Header with Profile Context
+	fmt.Printf("Feature Quality Score: %.1f/10.0     Grade: %s    Components: %d      EngineVersion: %s    File: %s\n",
+		result.Comprehensive.InterlynkScore,
+		result.Comprehensive.Grade,
+		numComponents,
+		EngineVersion,
+		fileName)
+
+	// Show profile context
+	if result.ProfileContext != "" && result.ProfileContext != "interlynk" {
+		fmt.Printf("Profile Context: %s\n\n", getProfileDisplayName(result.ProfileContext))
+	} else {
+		fmt.Println()
+	}
+
+	// Feature Breakdown table using tablewriter
+	fmt.Println("Feature Breakdown:")
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"FEATURE", "SCORE", "GRADE", "DESC"})
+	table.SetRowLine(true)
+	table.SetAutoWrapText(false)
+
+	for _, feat := range catResult.Features {
+		grade := scoreToGrade(feat.Score)
+		table.Append([]string{feat.Key, fmt.Sprintf("%.1f/10.0", feat.Score), grade, feat.Desc})
+	}
+	table.Render()
+
+	// Overall summary for profile context
+	if result.ProfileContext != "" && result.ProfileContext != "interlynk" {
+		passed := 0
+		for _, feat := range catResult.Features {
+			if feat.Score >= 5.0 { // PASS threshold
+				passed++
+			}
+		}
+		total := len(catResult.Features)
+		fmt.Printf("\nOverall: %d/%d %s requirements passed\n", passed, total, getProfileDisplayName(result.ProfileContext))
+	}
+}
+
+// getProfileDisplayName returns human-readable profile name
+func getProfileDisplayName(profile string) string {
+	switch profile {
+	case "ntia":
+		return "NTIA Minimum Elements (2021)"
+	case "ntia-2025":
+		return "NTIA Minimum Elements (2025)"
+	case "bsi-v1.1":
+		return "BSI TR-03183-2 v1.1"
+	case "bsi-v2.0":
+		return "BSI TR-03183-2 v2.0"
+	case "bsi", "bsi-v2.1":
+		return "BSI TR-03183-2 v2.1"
+	case "oct-v1.1":
+		return "OpenChain Telco v1.1"
+	case "fsct":
+		return "Framing 3rd Edition"
+	case "interlynk":
+		return "Interlynk Comprehensive"
+	default:
+		return profile
+	}
+}
+
+// scoreToGrade converts a score to a grade letter
+func scoreToGrade(score float64) string {
+	switch {
+	case score >= 9.0:
+		return "A"
+	case score >= 8.0:
+		return "B"
+	case score >= 7.0:
+		return "C"
+	case score >= 5.0:
+		return "D"
+	default:
+		return "F"
 	}
 }

--- a/pkg/reporter/v2/detailed.go
+++ b/pkg/reporter/v2/detailed.go
@@ -31,8 +31,18 @@ type proTable struct {
 
 func (r *Reporter) detailedReport() {
 	form := "https://forms.gle/anFSspwrk7uSfD7Q6"
+	hasNonFeatureResults := false
 
-	for _, r := range r.Results {
+	for _, res := range r.Results {
+		// Check for feature-only scoring mode
+		if res.ProfileContext != "" && res.Comprehensive != nil && len(res.Comprehensive.CatResult) > 0 && res.Comprehensive.CatResult[0].Key == "feature_scoring" {
+			r.renderFeatureScoreDetailed(res)
+			fmt.Println()
+			continue
+		}
+
+		hasNonFeatureResults = true
+
 		// buffers for table rows
 		outDoc := [][]string{}     // detailed comprehensive rows
 		profOutDoc := [][]string{} // profile summary rows
@@ -42,19 +52,19 @@ func (r *Reporter) detailedReport() {
 		header := []string{}
 		profHeader := []string{}
 
-		if r.Comprehensive != nil && r.Profiles != nil {
-			fmt.Printf("SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s\n\n", r.Comprehensive.InterlynkScore, r.Comprehensive.Grade, r.Meta.NumComponents, EngineVersion, r.Meta.Filename)
+		if res.Comprehensive != nil && res.Profiles != nil {
+			fmt.Printf("SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s\n\n", res.Comprehensive.InterlynkScore, res.Comprehensive.Grade, res.Meta.NumComponents, EngineVersion, res.Meta.Filename)
 
 			profHeader = []string{"PROFILE", "SCORE", "GRADE"}
 
-			for _, proResult := range r.Profiles.ProfResult {
+			for _, proResult := range res.Profiles.ProfResult {
 				l := []string{proResult.Name, fmt.Sprintf("%.1f/10.0", proResult.Score), proResult.Grade}
 				profOutDoc = append(profOutDoc, l)
 			}
 
-			totalCatWeight := calculateTotalCategoryWeight(r.Comprehensive.CatResult)
+			totalCatWeight := calculateTotalCategoryWeight(res.Comprehensive.CatResult)
 			header = []string{"CATEGORY", "FEATURE", "SCORE", "DESC"}
-			for _, cat := range r.Comprehensive.CatResult {
+			for _, cat := range res.Comprehensive.CatResult {
 				isCompInfo := cat.Key == "compinfo"
 				catNameWithWeight := formatCategoryWithWeight(cat.Name, cat.Weight, totalCatWeight, isCompInfo)
 				for _, feat := range cat.Features {
@@ -70,12 +80,12 @@ func (r *Reporter) detailedReport() {
 				}
 			}
 
-		} else if r.Comprehensive != nil {
-			fmt.Printf("SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s\n", r.Comprehensive.InterlynkScore, r.Comprehensive.Grade, r.Meta.NumComponents, EngineVersion, r.Meta.Filename)
+		} else if res.Comprehensive != nil {
+			fmt.Printf("SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s\n", res.Comprehensive.InterlynkScore, res.Comprehensive.Grade, res.Meta.NumComponents, EngineVersion, res.Meta.Filename)
 
-			totalCatWeight := calculateTotalCategoryWeight(r.Comprehensive.CatResult)
+			totalCatWeight := calculateTotalCategoryWeight(res.Comprehensive.CatResult)
 			header = []string{"CATEGORY", "FEATURE", "SCORE", "DESC"}
-			for _, cat := range r.Comprehensive.CatResult {
+			for _, cat := range res.Comprehensive.CatResult {
 				isCompInfo := cat.Key == "compinfo"
 				catNameWithWeight := formatCategoryWithWeight(cat.Name, cat.Weight, totalCatWeight, isCompInfo)
 				for _, feat := range cat.Features {
@@ -85,12 +95,12 @@ func (r *Reporter) detailedReport() {
 					outDoc = append(outDoc, l)
 				}
 			}
-		} else if r.Profiles != nil {
-			for _, proResult := range r.Profiles.ProfResult {
+		} else if res.Profiles != nil {
+			for _, proResult := range res.Profiles.ProfResult {
 				var prs proTable
 
 				prs.profilesHeader = []string{"PROFILE", "FEATURE", "STATUS", "DESC"}
-				prs.messages = fmt.Sprintf("SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s", proResult.InterlynkScore, proResult.Grade, r.Meta.NumComponents, EngineVersion, r.Meta.Filename)
+				prs.messages = fmt.Sprintf("SBOM Quality Score: %0.1f/10.0\t Grade: %s\tComponents: %d \t EngineVersion: %s\tFile: %s", proResult.InterlynkScore, proResult.Grade, res.Meta.NumComponents, EngineVersion, res.Meta.Filename)
 
 				for _, pFeatResult := range proResult.Items {
 					var status string
@@ -120,9 +130,9 @@ func (r *Reporter) detailedReport() {
 		}
 
 		// Show category summary table before detailed table
-		if r.Comprehensive != nil {
-			totalCatWeight := calculateTotalCategoryWeight(r.Comprehensive.CatResult)
-			catSummaryRows, catSummaryHeader := buildCategorySummary(r.Comprehensive.CatResult, totalCatWeight)
+		if res.Comprehensive != nil {
+			totalCatWeight := calculateTotalCategoryWeight(res.Comprehensive.CatResult)
+			catSummaryRows, catSummaryHeader := buildCategorySummary(res.Comprehensive.CatResult, totalCatWeight)
 			newTable(catSummaryRows, catSummaryHeader, "Category Breakdown:")
 		}
 
@@ -187,7 +197,9 @@ func (r *Reporter) detailedReport() {
 
 		fmt.Println()
 	}
-	fmt.Println("Love to hear your feedback", form)
+	if hasNonFeatureResults {
+		fmt.Println("Love to hear your feedback", form)
+	}
 }
 
 func formatScore(feat api.FeatureResult) string {
@@ -266,5 +278,54 @@ func newTable(doc [][]string, header []string, msg string) {
 		dt.AppendBulk(doc)
 		dt.Render()
 		fmt.Println()
+	}
+}
+
+// renderFeatureScoreDetailed outputs feature-level scoring results for detailed view
+func (r *Reporter) renderFeatureScoreDetailed(result api.Result) {
+	if result.Comprehensive == nil || len(result.Comprehensive.CatResult) == 0 {
+		return
+	}
+	catResult := result.Comprehensive.CatResult[0]
+	numComponents := result.Meta.NumComponents
+	fileName := result.Meta.Filename
+
+	// Header with Profile Context
+	fmt.Printf("Feature Quality Score: %.1f/10.0     Grade: %s    Components: %d      EngineVersion: %s    File: %s\n",
+		result.Comprehensive.InterlynkScore,
+		result.Comprehensive.Grade,
+		numComponents,
+		EngineVersion,
+		fileName)
+
+	// Show profile context
+	if result.ProfileContext != "" && result.ProfileContext != "interlynk" {
+		fmt.Printf("Profile Context: %s\n\n", getProfileDisplayName(result.ProfileContext))
+	} else {
+		fmt.Println()
+	}
+
+	// Feature Breakdown table using tablewriter
+	fmt.Println("Feature Breakdown:")
+	dt := tablewriter.NewWriter(os.Stdout)
+	dt.SetHeader([]string{"FEATURE", "SCORE", "GRADE", "DESC"})
+	dt.SetRowLine(true)
+
+	for _, feat := range catResult.Features {
+		grade := scoreToGrade(feat.Score)
+		dt.Append([]string{feat.Key, fmt.Sprintf("%.1f/10.0", feat.Score), grade, feat.Desc})
+	}
+	dt.Render()
+
+	// Overall summary for profile context
+	if result.ProfileContext != "" && result.ProfileContext != "interlynk" {
+		passed := 0
+		for _, feat := range catResult.Features {
+			if feat.Score >= 5.0 { // PASS threshold
+				passed++
+			}
+		}
+		total := len(catResult.Features)
+		fmt.Printf("\nOverall: %d/%d %s requirements passed\n", passed, total, getProfileDisplayName(result.ProfileContext))
 	}
 }

--- a/pkg/scorer/v2/api/result.go
+++ b/pkg/scorer/v2/api/result.go
@@ -32,8 +32,9 @@ type Result struct {
 	// InterlynkScore float64
 	// Grade          string
 
-	Comprehensive *ComprehensiveResult
-	Profiles      *ProfilesResult
+	Comprehensive  *ComprehensiveResult
+	Profiles       *ProfilesResult
+	ProfileContext string // Profile context for feature-only scoring
 }
 
 // SBOMMeta represents common metadata extracted from an SBOM document.

--- a/pkg/scorer/v2/catalog/catalog.go
+++ b/pkg/scorer/v2/catalog/catalog.go
@@ -61,8 +61,9 @@ type Catalog struct {
 	Profiles        []ProfSpec
 	ProfFeatures    []ProfFeatSpec
 
-	Order   []ComprCatSpec
-	Aliases Aliases
+	Order          []ComprCatSpec
+	Aliases        Aliases
+	ProfileContext string // Profile context for feature-only scoring
 }
 
 // HasFeature checks if a comprehensive feature with the given key exists in the catalog.

--- a/pkg/scorer/v2/registry/compr.go
+++ b/pkg/scorer/v2/registry/compr.go
@@ -15,6 +15,7 @@
 package registry
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -97,6 +98,15 @@ func ReadComprConfigFile(path string) ([]catalog.ComprCatSpec, error) {
 	var cat []catalog.ComprCatSpec
 
 	for _, c := range cfg.Categories {
+		// Skip categories with zero weight - user has disabled them
+		if c.Weight == 0 {
+			continue
+		}
+
+		// Reject negative category weights
+		if c.Weight < 0 {
+			return nil, fmt.Errorf("invalid weight %.2f for category %q: weights must be non-negative", c.Weight, c.Name)
+		}
 
 		category := catalog.ComprCatSpec{
 			Name:        c.Name,
@@ -109,6 +119,11 @@ func ReadComprConfigFile(path string) ([]catalog.ComprCatSpec, error) {
 				continue
 			}
 
+			// Reject negative feature weights
+			if f.Weight < 0 {
+				return nil, fmt.Errorf("invalid weight %.2f for feature %q in category %q: weights must be non-negative", f.Weight, f.Name, c.Name)
+			}
+
 			feat := catalog.ComprFeatSpec{
 				Name:     f.Name,
 				Ignore:   f.Ignore,
@@ -119,6 +134,12 @@ func ReadComprConfigFile(path string) ([]catalog.ComprCatSpec, error) {
 
 			category.Features = append(category.Features, feat)
 		}
+
+		// Skip categories with no features (all features were ignored)
+		if len(category.Features) == 0 {
+			continue
+		}
+
 		cat = append(cat, category)
 
 	}

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -194,6 +194,57 @@ var OCTV11KeyToEvaluatingFunction = map[string]catalog.ProfFeatEval{
 	"comp_purl":              profiles.OCTV11CompPURL,
 }
 
+// ProfileSpecificFeatures maps profile keys to their feature keys for feature-level scoring
+var ProfileSpecificFeatures = map[string][]string{
+	"ntia": {
+		"comp_supplier", "comp_name", "comp_version", "comp_uniq_id",
+		"comp_dependencies", "sbom_relationships", "sbom_timestamp",
+	},
+	"ntia-2025": {
+		// Profile-specific keys (aliases)
+		"sbom_machine_format", "sbom_author", "software_producer",
+		"comp_name", "comp_version", "software_identifiers", "comp_hash",
+		"license", "sbom_dependencies", "comp_supplier", "tool_name",
+		"sbom_timestamp", "generation_context",
+	},
+	"bsi-v1.1": {
+		"sbom_creator", "sbom_timestamp", "comp_creator", "comp_name",
+		"comp_version", "comp_depth", "comp_license", "comp_hash",
+		"sbom_uri", "comp_source_url", "comp_executable_url", "comp_source_hash",
+		"comp_unique_identifiers",
+	},
+	"bsi-v2.0": {
+		// Profile-specific keys (aliases)
+		"sbom_creator", "sbom_timestamp", "sbom_uri", "comp_creator",
+		"comp_name", "comp_version", "comp_filename", "comp_depth",
+		"comp_associated_license", "comp_deployable_hash", "comp_executable_property",
+		"comp_archive_property", "comp_structured_property",
+	},
+	"bsi": {
+		// Profile-specific keys (aliases)
+		"sbom_spec_version", "sbom_creator", "sbom_timestamp", "sbom_uri",
+		"comp_creator", "comp_name", "comp_version", "comp_filename", "comp_depth",
+		"comp_distribution_license", "comp_deployable_hash", "comp_executable_prop",
+		"comp_archive_prop", "comp_structured_prop", "comp_source_code_url",
+		"comp_download_url", "comp_other_identifiers", "comp_original_licenses",
+		"comp_effective_license", "comp_source_hash", "comp_security_txt_url",
+	},
+	"oct-v1.1": {
+		// Profile-specific keys (aliases)
+		"sbom_spec", "sbom_spec_version", "sbom_data_license", "sbom_identifier",
+		"sbom_name", "sbom_namespace", "sbom_creator", "sbom_timestamp",
+		"sbom_creator_comment", "comp_name", "comp_identifier", "comp_version",
+		"comp_supplier", "comp_download_location", "comp_license_concluded",
+		"comp_license_declared", "comp_copyright", "sbom_relationships",
+	},
+	"fsct": {
+		// Profile-specific keys (aliases)
+		"sbom_provenance", "sbom_primary_component", "comp_identity",
+		"supplier_attribution", "comp_unique_id", "artifact_integrity",
+		"relationships_coverage", "license_coverage", "copyright_coverage",
+	},
+}
+
 var InterlynkKeyToEvaluatingFunction = map[string]catalog.ProfFeatEval{
 	"comp_name":     profiles.InterCompWithName,
 	"comp_version":  profiles.InterCompWithVersion,
@@ -234,6 +285,7 @@ var InterlynkKeyToEvaluatingFunction = map[string]catalog.ProfFeatEval{
 }
 
 var CompKeyToEvaluatingFunction = map[string]catalog.ComprFeatEval{
+	// Comprehensive feature keys
 	"comp_with_name":     extractors.CompWithName,
 	"comp_with_version":  extractors.CompWithVersion,
 	"comp_with_local_id": extractors.CompWithUniqLocalIDs,
@@ -263,14 +315,76 @@ var CompKeyToEvaluatingFunction = map[string]catalog.ComprFeatEval{
 	"comp_with_declared_licenses":  extractors.CompWithDeclaredLicenses,
 	"sbom_data_license":            extractors.SBOMDataLicense,
 
-	"comp_with_purl":           extractors.CompWithPURL,
-	"comp_with_cpe":            extractors.CompWithCPE,
-	"comp_with_purl_or_cpe":    extractors.CompWithPURLOrCPE,
+	"comp_with_purl":        extractors.CompWithPURL,
+	"comp_with_cpe":         extractors.CompWithCPE,
+	"comp_with_purl_or_cpe": extractors.CompWithPURLOrCPE,
 
-	"sbom_spec_declared": extractors.SBOMWithSpec,
-	"sbom_spec_version":  extractors.SBOMSpecVersion,
-	"sbom_file_format":   extractors.SBOMFileFormat,
-	"sbom_schema_valid":  extractors.SBOMSchemaValid,
+	"sbom_spec_declared":  extractors.SBOMWithSpec,
+	"sbom_spec_version":   extractors.SBOMSpecVersion,
+	"sbom_machine_format": extractors.SBOMWithSpec,
+	"sbom_author":         extractors.SBOMAuthors,
+	"software_producer":   extractors.SBOMSupplier,
+	"tool_name":           extractors.SBOMCreationTool,
+	"generation_context":  extractors.SBOMWithDeclaredCompleteness,
+	"sbom_file_format":    extractors.SBOMFileFormat,
+	"sbom_schema_valid":   extractors.SBOMSchemaValid,
+
+	// Profile-specific feature key aliases (NTIA, BSI, OCT, etc.)
+	"comp_name":                 extractors.CompWithName,
+	"comp_version":              extractors.CompWithVersion,
+	"comp_uniq_id":              extractors.CompWithUniqLocalIDs,
+	"comp_supplier":             extractors.CompWithSupplier,
+	"comp_dependencies":         extractors.CompWithDependencies,
+	"sbom_timestamp":            extractors.SBOMCreationTimestamp,
+	"sbom_relationships":        extractors.CompWithDependencies,
+	"sbom_creator":              extractors.SBOMAuthors,
+	"sbom_uri":                  extractors.SBOMNamespace,
+	"comp_creator":              extractors.SBOMSupplier,
+	"comp_hash":                 extractors.CompWithStrongChecksums,
+	"comp_license":              extractors.CompWithLicenses,
+	"comp_source_url":           extractors.CompWithSourceCode,
+	"comp_executable_url":       extractors.CompWithPackagePurpose,
+	"comp_source_hash":          extractors.CompWithStrongChecksums,
+	"comp_filename":             extractors.CompWithName,
+	"comp_associated_license":   extractors.CompWithLicenses,
+	"comp_deployable_hash":      extractors.CompWithStrongChecksums,
+	"comp_executable_property":  extractors.CompWithPackagePurpose,
+	"comp_archive_property":     extractors.CompWithPackagePurpose,
+	"comp_structured_property":  extractors.CompWithPackagePurpose,
+	"comp_distribution_license": extractors.CompWithLicenses,
+	"comp_executable_prop":      extractors.CompWithPackagePurpose,
+	"comp_archive_prop":         extractors.CompWithPackagePurpose,
+	"comp_structured_prop":      extractors.CompWithPackagePurpose,
+	"comp_download_url":         extractors.CompWithSourceCode,
+	"comp_source_code_url":      extractors.CompWithSourceCode,
+	"comp_other_identifiers":    extractors.CompWithUniqLocalIDs,
+	"comp_original_licenses":    extractors.CompWithLicenses,
+	"comp_effective_license":    extractors.CompWithLicenses,
+	"comp_security_txt_url":     extractors.SBOMNamespace,
+	"comp_identifier":           extractors.CompWithUniqLocalIDs,
+	"comp_download_location":    extractors.CompWithSourceCode,
+	"comp_license_concluded":    extractors.CompWithLicenses,
+	"comp_license_declared":     extractors.CompWithDeclaredLicenses,
+	"comp_copyright":            extractors.CompWithValidLicenses,
+	"comp_checksum":             extractors.CompWithStrongChecksums,
+	"comp_purl":                 extractors.CompWithPURL,
+	"sbom_identifier":           extractors.SBOMNamespace,
+	"sbom_name":                 extractors.SBOMWithSpec,
+	"sbom_creator_comment":      extractors.SBOMAuthors,
+	"sbom_provenance":           extractors.SBOMAuthors,
+	"comp_identity":             extractors.CompWithName,
+	"supplier_attribution":      extractors.CompWithSupplier,
+	"sbom_spec":                 extractors.SBOMWithSpec,
+	"license":                   extractors.CompWithLicenses,
+	"sbom_dependencies":         extractors.CompWithDependencies,
+	"comp_unique_id":            extractors.CompWithUniqLocalIDs,
+	"comp_unique_identifiers":   extractors.CompWithUniqLocalIDs,
+	"comp_depth":                extractors.CompWithDependencies,
+	"software_identifiers":      extractors.CompWithUniqLocalIDs,
+	"artifact_integrity":        extractors.CompWithStrongChecksums,
+	"relationships_coverage":    extractors.CompWithDependencies,
+	"license_coverage":          extractors.CompWithLicenses,
+	"copyright_coverage":        extractors.CompWithValidLicenses,
 }
 
 // ProfileKey lists all profiles
@@ -285,22 +399,6 @@ const (
 	ProfileInterlynk catalog.ProfileKey = "interlynk"
 	ProfileFSCT      catalog.ProfileKey = "fsct"
 )
-
-var categoryAlias = map[string]catalog.ComprCatKey{
-	"identification":                 CatIdentification,
-	"provenance":                     CatProvenance,
-	"integrity":                      CatIntegrity,
-	"completeness":                   CatCompleteness,
-	"licensing":                      CatLicensingAndCompliance,
-	"licensingandcompliance":         CatLicensingAndCompliance,
-	"licensing_and_compliance":       CatLicensingAndCompliance,
-	"vulnerability":                  CatVulnerabilityAndTrace,
-	"vulnerabilityandtraceability":   CatVulnerabilityAndTrace,
-	"vulnerability_and_traceability": CatVulnerabilityAndTrace,
-	"structural":                     CatStructural,
-	"componentquality(info)":         CatComponentQualityInfo,
-	"component_quality_info":         CatComponentQualityInfo,
-}
 
 var profileAliases = map[string]catalog.ProfileKey{
 	"ntia":                  ProfileNTIA,
@@ -371,6 +469,48 @@ func InitializeCatalog(ctx context.Context, conf config.Config) (*catalog.Catalo
 		return catal, nil
 	}
 
+	// Features provided inline (check first, takes precedence over profiles)
+	if len(conf.Features) > 0 {
+		log.Info("Initializing catalog using inline features",
+			zap.Int("requested", len(conf.Features)),
+			zap.Strings("features", conf.Features),
+		)
+
+		// Determine profile context
+		profileContext := "interlynk"
+		if len(conf.Profile) > 0 {
+			profileContext = conf.Profile[0]
+		}
+
+		features, err := filterFeatures(ctx, conf.Features, profileContext)
+		if err != nil {
+			log.Error("Failed to filter features",
+				zap.Error(err),
+			)
+			return nil, err
+		}
+
+		if len(features) > 0 {
+			// Create virtual category for feature-only scoring
+			virtualCategory := catalog.ComprCatSpec{
+				Key:         "feature_scoring",
+				Name:        "Feature Scoring",
+				Weight:      10,
+				Description: "Feature-level scoring",
+				Features:    features,
+			}
+			catal.ComprCategories = []catalog.ComprCatSpec{virtualCategory}
+			catal.ProfileContext = profileContext
+		}
+
+		log.Info("Catalog initialized with features",
+			zap.Int("features", len(features)),
+			zap.String("profile_context", profileContext),
+		)
+
+		return catal, nil
+	}
+
 	// Profiles provided command inline
 	if len(conf.Profile) > 0 {
 		log.Info("Initializing catalog using inline profiles",
@@ -390,14 +530,6 @@ func InitializeCatalog(ctx context.Context, conf config.Config) (*catalog.Catalo
 			zap.Int("profiles", len(catal.Profiles)),
 		)
 
-		return catal, nil
-	}
-
-	// Features provided inline
-	if len(conf.Features) > 0 {
-		log.Info("Catalog initialized with selected profiles",
-			zap.Int("profiles", len(catal.Profiles)),
-		)
 		return catal, nil
 	}
 
@@ -556,6 +688,155 @@ func filterCategories(ctx context.Context, categories []string) []catalog.ComprC
 		zap.Int("requested", len(categories)),
 	)
 	return finalCats
+}
+
+// filterFeatures filters and validates requested features against profile context
+func filterFeatures(ctx context.Context, features []string, profile string) ([]catalog.ComprFeatSpec, error) {
+	log := logger.FromContext(ctx)
+	log.Debug("Filtering requested features",
+		zap.Int("requested", len(features)),
+		zap.String("profile", profile),
+	)
+
+	var finalFeats []catalog.ComprFeatSpec
+	var unknownFeatures []string
+
+	// Normalize profile key (handle aliases like "bsi-v2.1" -> "bsi")
+	normalizedProfile := strings.ToLower(strings.TrimSpace(profile))
+	if alias, ok := profileAliases[normalizedProfile]; ok {
+		normalizedProfile = string(alias)
+	}
+	// Normalize profile keys to match ProfileSpecificFeatures keys
+	switch normalizedProfile {
+	case "bsi-v2.1":
+		normalizedProfile = "bsi"
+	}
+
+	// Build valid features map from comprehensive categories
+	validFeatures := make(map[string]catalog.ComprFeatSpec)
+	for _, cat := range comprehenssiveCategories {
+		for _, feat := range cat.Features {
+			validFeatures[feat.Key] = feat
+		}
+	}
+
+	// Validate each requested feature
+	for _, feat := range features {
+		if feat == "" {
+			continue
+		}
+
+		featureKey := strings.ToLower(strings.TrimSpace(feat))
+
+		// Check if feature is in requested profile (if not interlynk)
+		if normalizedProfile != "interlynk" {
+			profileFeatures, ok := ProfileSpecificFeatures[normalizedProfile]
+			if !ok {
+				return nil, fmt.Errorf("unknown profile: %s", profile)
+			}
+
+			foundInProfile := false
+			for _, k := range profileFeatures {
+				if k == featureKey {
+					foundInProfile = true
+					break
+				}
+			}
+			if !foundInProfile {
+				unknownFeatures = append(unknownFeatures, featureKey)
+				continue
+			}
+		}
+
+		// Check if feature exists in comprehensive categories OR has an evaluator
+		if featSpec, exists := validFeatures[featureKey]; exists {
+			// Get evaluator function from comprehensive features
+			if evalFn, ok := CompKeyToEvaluatingFunction[featureKey]; ok {
+				finalFeats = append(finalFeats, catalog.ComprFeatSpec{
+					Key:         featSpec.Key,
+					Name:        featSpec.Name,
+					Description: featSpec.Description,
+					Weight:      featSpec.Weight,
+					Evaluate:    evalFn,
+				})
+			}
+		} else if evalFn, ok := CompKeyToEvaluatingFunction[featureKey]; ok {
+			// Feature is a profile-specific key that has an evaluator
+			// Get metadata from profile spec if available
+			name := featureKey
+			description := ""
+
+			if normalizedProfile != "interlynk" {
+				if profFeat, found := getProfileFeatureInfo(normalizedProfile, featureKey); found {
+					name = profFeat.Name
+					description = profFeat.Description
+				}
+			}
+
+			finalFeats = append(finalFeats, catalog.ComprFeatSpec{
+				Key:         featureKey,
+				Name:        name,
+				Description: description,
+				Evaluate:    evalFn,
+			})
+		} else {
+			unknownFeatures = append(unknownFeatures, featureKey)
+		}
+	}
+
+	// Handle unknown features
+	if len(unknownFeatures) > 0 {
+		if normalizedProfile != "interlynk" {
+			// Find which profile the unknown feature belongs to
+			suggestedProfile := findFeatureProfile(unknownFeatures[0])
+			// Get supported features for the requested profile
+			supportedFeatures := ProfileSpecificFeatures[normalizedProfile]
+			return nil, fmt.Errorf("feature '%s' is not evaluated in %s profile (this feature belongs to: %s profile); supported features: %v",
+				unknownFeatures[0], getProfileDisplayName(normalizedProfile), suggestedProfile, supportedFeatures)
+		}
+		return nil, fmt.Errorf("unknown feature(s): %v", unknownFeatures)
+	}
+
+	log.Debug("Feature filtering completed",
+		zap.Int("selected", len(finalFeats)),
+	)
+	return finalFeats, nil
+}
+
+// findFeatureProfile finds which profile a feature belongs to
+func findFeatureProfile(feature string) string {
+	for profile, features := range ProfileSpecificFeatures {
+		for _, f := range features {
+			if f == feature {
+				return profile
+			}
+		}
+	}
+	return "interlynk"
+}
+
+// getProfileDisplayName returns human-readable profile name
+func getProfileDisplayName(profile string) string {
+	switch profile {
+	case "ntia":
+		return "NTIA Minimum Elements (2021)"
+	case "ntia-2025":
+		return "NTIA Minimum Elements (2025)"
+	case "bsi-v1.1":
+		return "BSI TR-03183-2 v1.1"
+	case "bsi-v2.0":
+		return "BSI TR-03183-2 v2.0"
+	case "bsi", "bsi-v2.1":
+		return "BSI TR-03183-2 v2.1"
+	case "oct-v1.1":
+		return "OpenChain Telco v1.1"
+	case "fsct":
+		return "Framing 3rd Edition"
+	case "interlynk":
+		return "Interlynk Comprehensive"
+	default:
+		return profile
+	}
 }
 
 // filterProfiles keeps only requested profile keys (preserving order).
@@ -1014,4 +1295,33 @@ var Profile = []catalog.ProfSpec{
 	profileOCTV11Spec,
 	profileInterlynkSpec,
 	profileFSCTSpec,
+}
+
+// ProfileSpecsMap provides easy access to profile specifications by key
+var ProfileSpecsMap = map[string]catalog.ProfSpec{
+	"ntia":      profileNTIASpec,
+	"ntia-2025": profileNTIA2025Spec,
+	"bsi-v1.1":  profileBSI11Spec,
+	"bsi-v2.0":  profileBSI20Spec,
+	"bsi-v2.1":  profileBSI21Spec,
+	"bsi":       profileBSI21Spec,
+	"oct-v1.1":  profileOCTV11Spec,
+	"fsct":      profileFSCTSpec,
+	"interlynk": profileInterlynkSpec,
+}
+
+// getProfileFeatureInfo looks up a feature in a profile spec and returns its metadata
+func getProfileFeatureInfo(profileKey string, featureKey string) (catalog.ProfFeatSpec, bool) {
+	profileSpec, ok := ProfileSpecsMap[profileKey]
+	if !ok {
+		return catalog.ProfFeatSpec{}, false
+	}
+
+	for _, feat := range profileSpec.Features {
+		if feat.Key == featureKey {
+			return feat, true
+		}
+	}
+
+	return catalog.ProfFeatSpec{}, false
 }

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -777,6 +777,7 @@ func filterFeatures(ctx context.Context, features []string, profile string) ([]c
 				Key:         featureKey,
 				Name:        name,
 				Description: description,
+				Weight:      1.0, // Default weight for profile-specific features
 				Evaluate:    evalFn,
 			})
 		} else {

--- a/pkg/scorer/v2/score/score.go
+++ b/pkg/scorer/v2/score/score.go
@@ -279,6 +279,7 @@ func evaluateComprehensive(ctx context.Context, catal *catalog.Catalog, input ca
 	)
 
 	result := api.NewResult(input.Doc)
+	result.ProfileContext = catal.ProfileContext
 
 	comprResult := compr.Evaluate(ctx, catal, input)
 	result.Comprehensive = &comprResult
@@ -291,6 +292,7 @@ func evaluateBoth(ctx context.Context, catal *catalog.Catalog, input catalog.Eva
 	log.Debug("Evaluating comprehensive and profile scoring")
 
 	result := api.NewResult(input.Doc)
+	result.ProfileContext = catal.ProfileContext
 
 	profResults := profiles.Evaluate(ctx, catal, input.Doc)
 	result.Profiles = &profResults


### PR DESCRIPTION
This PR adds the following changes:
- It adds feature support for all major profiles: interlynk(default), ntia, bsi, and many more.
- Updates all docs related to it.
- perform testing for all 7 profiles tested with all their respective features.
- also closes: https://github.com/interlynk-io/sbomqs/issues/680
  - fixes wieghtage issue
  - added doc on weightage scoring
Usage Examples
```bash  
  # Score NTIA-specific features
  sbomqs score samples/photon.spdx.json --profile ntia --feature comp_name,comp_version,sbom_timestamp

  # Score BSI v2.1-specific features
  sbomqs score samples/photon.spdx.json --profile bsi --feature sbom_spec_version,sbom_creator,comp_name
  
  # Score comprehensive features (default Interlynk profile)
  sbomqs score samples/photon.spdx.json --feature comp_with_name,comp_with_version

  # JSON output for automation
  sbomqs score samples/photon.spdx.json --profile ntia --feature comp_name --json
 
```