### PR TITLE
Docs/policy examples

### DIFF
--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -147,6 +147,71 @@ policy:
 - **Multiple values/patterns in a rule**: Combined with **OR** (any value passes)
 - **Multiple actual values**: For whitelist, ALL must match; for blacklist, NONE must match
 
+### `values` vs `patterns`
+
+Rules can use either (or both) `values` and `patterns`:
+
+| Option | Matching Type | Use Case | Example |
+|--------|--------------|----------|---------|
+| `values` | **Exact string match** | Specific versions, exact license IDs | `MIT`, `Apache-2.0`, `log4j-core-2.17.1` |
+| `patterns` | **Regular expression** | License families, version ranges, naming conventions | `GPL-.*`, `.*-SNAPSHOT`, `log4j-1\..*` |
+
+#### Using `values` (Exact Match)
+
+Use for precise matching when you know the exact values:
+
+```yaml
+rules:
+  - field: license
+    values:
+      - MIT
+      - Apache-2.0
+      - BSD-3-Clause
+```
+
+#### Using `patterns` (Regex Match)
+
+Use for matching **groups** or **families** of values:
+
+```yaml
+rules:
+  - field: license
+    patterns:
+      - "^GPL-.*"      # Any GPL variant (starts with "GPL-")
+      - "^LGPL-.*"     # Any LGPL variant
+      - "^AGPL-.*"     # Any AGPL variant
+```
+
+**Common Regex Patterns:**
+
+| Pattern | Matches | Example Values |
+|---------|---------|----------------|
+| `^GPL-.*` | GPL variants (start with "GPL-") | `GPL-2.0`, `GPL-3.0-only` |
+| `.*-SNAPSHOT` | Snapshot versions | `1.0.0-SNAPSHOT`, `2.1-SNAPSHOT` |
+| `log4j-1\..*` | Log4j 1.x versions | `log4j-1.2.17`, `log4j-1.2.19` |
+| `log4j-core-2\.1[0-6]\..*` | Log4j vulnerable (2.10-2.16) | `log4j-core-2.14.0` |
+| `^Apache-.*` | Apache licenses | `Apache-2.0`, `Apache-1.1` |
+
+> **Note:** The `^` anchor ensures the match is at the **start** of the string. Without it, `GPL-.*` would also match `MIT OR GPL-2.0`.
+
+#### Combining `values` and `patterns`
+
+You can use both together (combined with OR):
+
+```yaml
+rules:
+  - field: license
+    values:
+      - SSPL-1.0
+      - CC-BY-SA-4.0
+    patterns:
+      - "^GPL-.*"
+      - "^LGPL-.*"
+      - "^AGPL-.*"
+```
+
+This blocks: All GPL/LGPL/AGPL variants, plus SSPL-1.0 and CC-BY-SA-4.0.
+
 ## Examples
 
 ### From Policy File

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -11,6 +11,7 @@ The policy command:
 - Provides detailed violation reports with specific component and field information
 - Returns non-zero exit codes on policy failures for CI/CD integration
 - Works with both SPDX and CycloneDX formats
+- **Document-level policies** (`sbom_*` fields) are evaluated once per SBOM, not per-component
 
 ## Usage
 
@@ -84,13 +85,20 @@ The action defines the outcome when violations are found:
 
 ## Available Fields
 
-### Component-Level Fields
+Fields are evaluated at either the **component level** (checked for each component) or **document level** (checked once per SBOM). The `LEVEL` column in policy results indicates this:
+
+- **`comp`**: Component-level: checked for every component
+- **`doc`**: Document-level: checked once per SBOM
+
+### Component-Level Fields (`comp`)
 
 | Field | Description | Example Values |
 |-------|-------------|----------------|
 | `name` | Component name | `log4j-core`, `react` |
 | `version` | Component version | `2.14.1`, `18.2.0` |
 | `license` | License identifier(s) | `MIT`, `Apache-2.0` |
+| `concluded_license` | Concluded license (CycloneDX 1.6+) | `MIT`, `Apache-2.0` |
+| `declared_license` | Declared license (CycloneDX 1.6+) | `MIT`, `Apache-2.0` |
 | `supplier` | Component supplier | `Apache Software Foundation` |
 | `author` | Component author | `John Doe <john@example.com>` |
 | `purl` | Package URL | `pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1` |
@@ -100,9 +108,9 @@ The action defines the outcome when violations are found:
 | `type` | Component type/purpose | `library`, `application` |
 | `downloadlocation` | Download URL | `https://example.com/pkg-1.0.jar` |
 
-### Document-Level Fields
+### Document-Level Fields (`doc`)
 
-Prefix with `sbom_` to check SBOM-level metadata:
+Prefix with `sbom_` to check SBOM-level metadata. These are evaluated **once per SBOM**, not per-component:
 
 | Field | Description | Example Values |
 |-------|-------------|----------------|
@@ -112,6 +120,8 @@ Prefix with `sbom_` to check SBOM-level metadata:
 | `sbom_tool` | SBOM generation tool | `syft`, `trivy` |
 | `sbom_lifecycle` | SBOM lifecycle phase | `build`, `deployed` |
 | `sbom_pc` | Primary component | `my-application:1.0.0` |
+
+> **Note:** Document-level policies show `-` in the `COMPONENTS` column since they don't apply to individual components.
 
 ## Policy File Format
 
@@ -229,11 +239,11 @@ Run:
 $ sbomqs policy -f approved-licenses.yaml my-app.spdx.json
 
                                      BASIC POLICY REPORT
-+-------------------+-----------+--------+--------+------------+------------+---------------+
-|      POLICY       |   TYPE    | ACTION | RESULT | COMPONENTS | VIOLATIONS | RULES APPLIED |
-+-------------------+-----------+--------+--------+------------+------------+---------------+
-| approved_licenses | whitelist | fail   | fail   |          3 |          1 |             1 |
-+-------------------+-----------+--------+--------+------------+------------+---------------+
++-------------------+-----------+--------+--------+-------+------------+------------+---------------+
+|      POLICY       |   TYPE    | ACTION | RESULT | LEVEL | COMPONENTS | VIOLATIONS | RULES APPLIED |
++-------------------+-----------+--------+--------+-------+------------+------------+---------------+
+| approved_licenses | whitelist | fail   | fail   | comp  |          3 |          1 |             1 |
++-------------------+-----------+--------+--------+-------+------------+------------+---------------+
 exit status 1
 ```
 
@@ -272,6 +282,7 @@ policy:
 ```
 
 <details>
+
 <summary><b>security-test.spdx.json</b></summary>
 
 ```json
@@ -345,7 +356,7 @@ $ sbomqs policy -f security-policy.yaml security-test.spdx.json -o table
 
                                  DETAILED POLICY REPORT
 
-Policy: banned_log4j_versions (result=fail, violations=2, total_checks=3, components=3, total_rules_applied=1)
+Policy: banned_log4j_versions (result=fail, level=comp, violations=2, total_checks=3, components=3, total_rules_applied=1)
 +-------------------+-------+-------------------+--------------------------------------+
 |     COMPONENT     | FIELD |      ACTUAL       |                REASON                |
 +-------------------+-------+-------------------+--------------------------------------+
@@ -355,7 +366,7 @@ Policy: banned_log4j_versions (result=fail, violations=2, total_checks=3, compon
 | safe-library      | name  | safe-library      | present                              |
 +-------------------+-------+-------------------+--------------------------------------+
 
-Policy: prohibited_licenses (result=fail, violations=1, total_checks=3, components=3, total_rules_applied=1)
+Policy: prohibited_licenses (result=fail, level=comp, violations=1, total_checks=3, components=3, total_rules_applied=1)
 +-------------------+---------+------------+--------------------------------+
 |     COMPONENT     |  FIELD  |   ACTUAL   |             REASON             |
 +-------------------+---------+------------+--------------------------------+
@@ -364,7 +375,7 @@ Policy: prohibited_licenses (result=fail, violations=1, total_checks=3, componen
 | safe-library      | license | MIT        | present                        |
 +-------------------+---------+------------+--------------------------------+
 
-Policy: required_security_fields (result=warn, violations=4, total_checks=6, components=3, total_rules_applied=2)
+Policy: required_security_fields (result=warn, level=comp, violations=4, total_checks=6, components=3, total_rules_applied=2)
 +-------------------+----------+-----------------+---------------+
 |     COMPONENT     |  FIELD   |     ACTUAL      |    REASON     |
 +-------------------+----------+-----------------+---------------+
@@ -377,13 +388,13 @@ Policy: required_security_fields (result=warn, violations=4, total_checks=6, com
 +-------------------+----------+-----------------+---------------+
 
                              --- SUMMARY TABLE ---
-+--------------------------+--------+------------+------------+---------------+
-|          POLICY          | RESULT | COMPONENTS | VIOLATIONS | RULES APPLIED |
-+--------------------------+--------+------------+------------+---------------+
-| banned_log4j_versions    | fail   |          3 |          2 |             1 |
-| prohibited_licenses      | fail   |          3 |          1 |             1 |
-| required_security_fields | warn   |          3 |          4 |             2 |
-+--------------------------+--------+------------+------------+---------------+
++--------------------------+--------+-------+------------+------------+---------------+
+|          POLICY          | RESULT | LEVEL | COMPONENTS | VIOLATIONS | RULES APPLIED |
++--------------------------+--------+-------+------------+------------+---------------+
+| banned_log4j_versions    | fail   | comp  |          3 |          2 |             1 |
+| prohibited_licenses      | fail   | comp  |          3 |          1 |             1 |
+| required_security_fields | warn   | comp  |          3 |          4 |             2 |
++--------------------------+--------+-------+------------+------------+---------------+
 exit status 1
 ```
 
@@ -445,6 +456,7 @@ policy:
 ```
 
 <details>
+
 <summary><b>incomplete.spdx.json</b></summary>
 
 ```json
@@ -534,11 +546,11 @@ $ sbomqs policy \
 
 
                                      BASIC POLICY REPORT
-+-------------------+-----------+--------+--------+------------+------------+---------------+
-|      POLICY       |   TYPE    | ACTION | RESULT | COMPONENTS | VIOLATIONS | RULES APPLIED |
-+-------------------+-----------+--------+--------+------------+------------+---------------+
-| approved_licenses | whitelist | fail   | fail   |          3 |          1 |             1 |
-+-------------------+-----------+--------+--------+------------+------------+---------------+
++-------------------+-----------+--------+--------+-------+------------+------------+---------------+
+|      POLICY       |   TYPE    | ACTION | RESULT | LEVEL | COMPONENTS | VIOLATIONS | RULES APPLIED |
++-------------------+-----------+--------+--------+-------+------------+------------+---------------+
+| approved_licenses | whitelist | fail   | fail   | comp  |          3 |          1 |             1 |
++-------------------+-----------+--------+--------+-------+------------+------------+---------------+
 exit status 1
 ```
 
@@ -624,6 +636,7 @@ policy:
 ```
 
 <details>
+
 <summary><b>comprehensive-test.cdx.json</b></summary>
 
 ```json
@@ -788,6 +801,7 @@ policy:
 ```
 
 <details>
+
 <summary><b>acme-test.spdx.json</b></summary>
 
 ```json
@@ -888,31 +902,32 @@ policy:
 
 ### Basic (Default)
 
-Summary table showing policy results:
+Summary table showing policy results. The `LEVEL` column indicates whether the policy is evaluated at the component level (`comp`) or document level (`doc`). Document-level policies show `-` in the `COMPONENTS` column since they apply to the entire SBOM:
 
 ```bash
 $ sbomqs policy -f policy.yaml sbom.json
 
                                      BASIC POLICY REPORT
-+--------------------+-----------+--------+--------+------------+------------+---------------+
-|       POLICY       |   TYPE    | ACTION | RESULT | COMPONENTS | VIOLATIONS | RULES APPLIED |
-+--------------------+-----------+--------+--------+------------+------------+---------------+
-| approved_suppliers | whitelist | fail   | fail   |          4 |          1 |             1 |
-| no_copyleft        | blacklist | fail   | fail   |          4 |          1 |             1 |
-+--------------------+-----------+--------+--------+------------+------------+---------------+
++--------------------+-----------+--------+--------+-------+------------+------------+---------------+
+|       POLICY       |   TYPE    | ACTION | RESULT | LEVEL | COMPONENTS | VIOLATIONS | RULES APPLIED |
++--------------------+-----------+--------+--------+-------+------------+------------+---------------+
+| approved_suppliers | whitelist | fail   | fail   | comp  |          4 |          1 |             1 |
+| no_copyleft        | blacklist | fail   | fail   | comp  |          4 |          1 |             1 |
+| sbom_has_author    | required  | warn   | pass   | doc   |          - |          0 |             1 |
++--------------------+-----------+--------+--------+-------+------------+------------+---------------+
 exit status 1
 ```
 
 ### Table (Detailed)
 
-Per-component, per-violation details:
+Per-component, per-violation details. Document-level policies show a single check result:
 
 ```bash
 $ sbomqs policy -f policy.yaml sbom.json -o table
 
                                         DETAILED POLICY REPORT
 
-Policy: approved_suppliers (result=fail, violations=1, total_checks=4, components=4, total_rules_applied=1)
+Policy: approved_suppliers (result=fail, level=comp, violations=1, total_checks=4, components=4, total_rules_applied=1)
 +----------------------+----------+----------------------------+--------------------------------------+
 |      COMPONENT       |  FIELD   |           ACTUAL           |                REASON                |
 +----------------------+----------+----------------------------+--------------------------------------+
@@ -923,7 +938,7 @@ Policy: approved_suppliers (result=fail, violations=1, total_checks=4, component
 | legacy-gpl-lib       | supplier | ACME Internal              | value in whitelist                   |
 +----------------------+----------+----------------------------+--------------------------------------+
 
-Policy: no_copyleft (result=fail, violations=1, total_checks=4, components=4, total_rules_applied=1)
+Policy: no_copyleft (result=fail, level=comp, violations=1, total_checks=4, components=4, total_rules_applied=1)
 +----------------------+---------+------------+--------------------------------+
 |      COMPONENT       |  FIELD  |   ACTUAL   |             REASON             |
 +----------------------+---------+------------+--------------------------------+
@@ -933,13 +948,21 @@ Policy: no_copyleft (result=fail, violations=1, total_checks=4, components=4, to
 | legacy-gpl-lib       | license | GPL-2.0    | value(s) in blacklist: GPL-2.0 |
 +----------------------+---------+------------+--------------------------------+
 
+Policy: sbom_has_timestamp (result=fail, level=doc, violations=1, total_checks=1, total_rules_applied=1)
++-----------+----------------+---------+---------------+
+| COMPONENT |     FIELD      | ACTUAL  |    REASON     |
++-----------+----------------+---------+---------------+
+| document  | sbom_timestamp | -       | missing field |
++-----------+----------------+---------+---------------+
+
                           --- SUMMARY TABLE ---
-+--------------------+--------+------------+------------+---------------+
-|       POLICY       | RESULT | COMPONENTS | VIOLATIONS | RULES APPLIED |
-+--------------------+--------+------------+------------+---------------+
-| approved_suppliers | fail   |          4 |          1 |             1 |
-| no_copyleft        | fail   |          4 |          1 |             1 |
-+--------------------+--------+------------+------------+---------------+
++--------------------+--------+-------+------------+------------+---------------+
+|       POLICY       | RESULT | LEVEL | COMPONENTS | VIOLATIONS | RULES APPLIED |
++--------------------+--------+-------+------------+------------+---------------+
+| approved_suppliers | fail   | comp  |          4 |          1 |             1 |
+| no_copyleft        | fail   | comp  |          4 |          1 |             1 |
+| sbom_has_timestamp | fail   | doc   |          - |          1 |             1 |
++--------------------+--------+-------+------------+------------+---------------+
 exit status 1
 
 ```
@@ -1164,6 +1187,79 @@ cat results.json | jq '.[] | {policy: .name, result: .overall_result, violations
 ```
 
 </details>
+
+## Sample Policies and Test SBOMs
+
+The repository includes comprehensive sample policies and test SBOMs for reference:
+
+### Sample Policies (`testdata/policy/`)
+
+| Category | Policy File | Description |
+|----------|-------------|-------------|
+| **License** | `license-allowlist.yaml` | Permissive OSS licenses only |
+| | `license-block-copyleft.yaml` | Blocks GPL variants |
+| | `license-block-proprietary.yaml` | Blocks custom licenses |
+| | `license-dual-check.yaml` | Requires both declared & concluded licenses |
+| **Security** | `security-ban-vulnerables.yaml` | Blocks known vulnerable packages |
+| | `security-required-fields.yaml` | Requires checksums, PURLs, versions |
+| | `security-no-snapshots.yaml` | Blocks SNAPSHOT versions |
+| | `security-verified-sources.yaml` | Requires source URLs and hashes |
+| **Metadata** | `metadata-required.yaml` | Basic metadata completeness |
+| | `metadata-provenance.yaml` | Author, supplier, timestamp |
+| | `metadata-identifiers.yaml` | PURL or CPE required |
+| **Enterprise** | `enterprise-approved-suppliers.yaml` | Vendor whitelist |
+| | `enterprise-complete-sbom.yaml` | Production-ready SBOM gate |
+| **Industry** | `industry-finance-compliance.yaml` | Finance sector requirements |
+| **Community** | `open-source-distribution.yaml` | OSS compliance checks |
+| | `community-health.yaml` | OSI-approved licenses |
+| **Advanced** | `advanced-comprehensive.yaml` | All checks combined |
+
+See `testdata/policy/README.md` for detailed documentation.
+
+### Test SBOMs (`testdata/sboms/`)
+
+Each policy has a corresponding `-violations.cdx.json` test file:
+
+```bash
+# Test license policies
+sbomqs policy -f testdata/policy/license-allowlist.yaml testdata/sboms/license-allowlist-violations.cdx.json
+
+# Test security policies
+sbomqs policy -f testdata/policy/security-ban-vulnerables.yaml testdata/sboms/security-ban-vulnerables-violations.cdx.json
+
+# Test comprehensive policy
+sbomqs policy -f testdata/policy/advanced-comprehensive.yaml testdata/sboms/advanced-comprehensive-violations.cdx.json
+```
+
+## License Field Behavior
+
+### Missing Licenses
+
+When a component has **no license information**, the policy check returns an **empty value** (not `NOASSERTION`). This means:
+
+- **Required field check** on `license` will fail (field is missing)
+- **Whitelist check** will fail (empty value is not in the whitelist)
+- **Blacklist check** will pass (empty value doesn't match any blacklist pattern)
+
+### CycloneDX License Expressions
+
+For CycloneDX 1.6+ SBOMs, license expressions with `acknowledgement: concluded` or `acknowledgement: declared` are supported:
+
+```yaml
+# Check concluded licenses
+policy:
+  - name: check-concluded-license
+    type: required
+    rules:
+      - field: concluded_license
+    action: fail
+
+  - name: check-declared-license
+    type: required
+    rules:
+      - field: declared_license
+    action: warn
+```
 
 ## CI/CD Integration
 

--- a/docs/guides/policy.md
+++ b/docs/guides/policy.md
@@ -68,6 +68,33 @@ Each rule contains:
 - **Multiple rules in a policy** → combined with **AND** (all must pass)
 - **Multiple values/patterns in a rule** → combined with **OR** (any value passes)
 
+### `values` vs `patterns`
+
+Rules can match using either exact values or regex patterns:
+
+| Option | Matching | Best For | Examples |
+|--------|----------|----------|----------|
+| `values` | Exact string match | Specific known values | `MIT`, `Apache-2.0`, `log4j-2.17.1` |
+| `patterns` | Regular expressions | Groups, families, ranges | `^GPL-.*`, `.*-SNAPSHOT` |
+
+**Example - Using values (exact match):**
+```yaml
+rules:
+  - field: license
+    values: [MIT, Apache-2.0]  # Only these exact values
+```
+
+**Example - Using patterns (regex):**
+```yaml
+rules:
+  - field: license
+    patterns:
+      - "^GPL-.*"     # All GPL variants
+      - "^LGPL-.*"    # All LGPL variants
+```
+
+> **Tip:** Use `^` at the start of patterns to match from the beginning. `^GPL-.*` matches `GPL-2.0` but NOT `MIT OR GPL-2.0`.
+
 ## Policy Types
 
 The type defines **how rules are interpreted**:

--- a/docs/guides/policy.md
+++ b/docs/guides/policy.md
@@ -31,7 +31,27 @@ policy:
     action: fail
 ```
 
-This policy ensures every component license is one of the approved or defined values. If not(or violates), the policy fails as per the defined action.
+This policy ensures every component license is one of the approved or defined values. If not (or violates), the policy fails as per the defined action.
+
+## Policy Levels
+
+Policies operate at two levels:
+
+- **Component Level (`comp`)**: Rules are evaluated for **each component** in the SBOM. The policy result depends on whether all components pass.
+- **Document Level (`doc`)**: Rules are evaluated **once per SBOM** for SBOM-level metadata. Fields starting with `sbom_` prefix are document-level.
+
+Example document-level policy:
+
+```yaml
+policy:
+  - name: sbom_has_author
+    type: required
+    rules:
+      - field: sbom_author
+    action: fail
+```
+
+This checks the SBOM document has an author field, not individual components.
 
 ## What is Rule?
 
@@ -168,27 +188,29 @@ policy:
 Output:
 
 ```bash
-$ sbomqs policy -f samples/policy/custom/custom-policies.yaml samples/policy/in-complete.spdx.sbom.json 
-+-------------------+-----------+--------+--------+---------+------------+----------------------+
-|      POLICY       |   TYPE    | ACTION | RESULT | CHECKED | VIOLATIONS |     GENERATED AT     |
-+-------------------+-----------+--------+--------+---------+------------+----------------------+
-| approved_licenses | whitelist | warn   | warn   |       6 |          6 | 2025-09-16T08:24:57Z |
-| banned_components | blacklist | fail   | fail   |       6 |          1 | 2025-09-16T08:24:57Z |
-| required_metadata | required  | fail   | pass   |       6 |          0 | 2025-09-16T08:24:57Z |
-+-------------------+-----------+--------+--------+---------+------------+----------------------+
+$ sbomqs policy -f samples/policy/custom/custom-policies.yaml samples/policy/in-complete.spdx.sbom.json
++-------------------+-----------+--------+--------+-------+---------+------------+----------------------+
+|      POLICY       |   TYPE    | ACTION | RESULT | LEVEL | CHECKED | VIOLATIONS |     GENERATED AT     |
++-------------------+-----------+--------+--------+-------+---------+------------+----------------------+
+| approved_licenses | whitelist | warn   | warn   | comp  |       6 |          6 | 2025-09-16T08:24:57Z |
+| banned_components | blacklist | fail   | fail   | comp  |       6 |          1 | 2025-09-16T08:24:57Z |
+| required_metadata | required  | fail   | pass   | comp  |       6 |          0 | 2025-09-16T08:24:57Z |
++-------------------+-----------+--------+--------+-------+---------+------------+----------------------+
 
 ```
 
 ```bash
-$ sbomqs policy -f samples/policy/custom/custom-policies.yaml samples/policy/complete-sbom.spdx.json   
-+-------------------+-----------+--------+--------+---------+------------+----------------------+
-|      POLICY       |   TYPE    | ACTION | RESULT | CHECKED | VIOLATIONS |     GENERATED AT     |
-+-------------------+-----------+--------+--------+---------+------------+----------------------+
-| approved_licenses | whitelist | warn   | pass   |       5 |          0 | 2025-09-16T08:25:05Z |
-| banned_components | blacklist | fail   | pass   |       5 |          0 | 2025-09-16T08:25:05Z |
-| required_metadata | required  | fail   | pass   |       5 |          0 | 2025-09-16T08:25:05Z |
-+-------------------+-----------+--------+--------+---------+------------+----------------------+
+$ sbomqs policy -f samples/policy/custom/custom-policies.yaml samples/policy/complete-sbom.spdx.json
++-------------------+-----------+--------+--------+-------+---------+------------+----------------------+
+|      POLICY       |   TYPE    | ACTION | RESULT | LEVEL | CHECKED | VIOLATIONS |     GENERATED AT     |
++-------------------+-----------+--------+--------+-------+---------+------------+----------------------+
+| approved_licenses | whitelist | warn   | pass   | comp  |       5 |          0 | 2025-09-16T08:25:05Z |
+| banned_components | blacklist | fail   | pass   | comp  |       5 |          0 | 2025-09-16T08:25:05Z |
+| required_metadata | required  | fail   | pass   | comp  |       5 |          0 | 2025-09-16T08:25:05Z |
++-------------------+-----------+--------+--------+-------+---------+------------+----------------------+
 ```
+
+The `LEVEL` column indicates whether the policy is evaluated at the **component** (`comp`) or **document** (`doc`) level.
 
 ## Applying Policies
 
@@ -200,13 +222,13 @@ Policies can be applied in two ways:
 ### 1. From a Policy File
 
 ```bash
-sbomqs policy -f samples/policy/custom/custom-policies.yaml samples/policy/complete-sbom.spdx.json 
+sbomqs policy -f samples/policy/custom/custom-policies.yaml samples/policy/complete-sbom.spdx.json
 ```
 
 ### 2. From CLI (Inline Rules)
 
 ```bash
-sbomqs apply \
+sbomqs policy \
   --name approved_licenses \
   --type whitelist \
   --rules "field=license,values=MIT,Apache-2.0" \
@@ -217,13 +239,15 @@ sbomqs apply \
 Example: 2
 
 ```bash
-sbomqs apply \
-  --name supplier_noassertion_rule \
-  --type blacklist \
-  --rules "field=supplier,values=NOASSERTION" \
+sbomqs policy \
+  --name supplier_required \
+  --type required \
+  --rules "field=supplier" \
   --action fail \
   samples/policy/in-complete-sbom.spdx.json
 ```
+
+> **Note:** Missing fields return an empty value, not `NOASSERTION`.
 
 ## sbomqs policy flowchart
 
@@ -270,3 +294,17 @@ Z2 --> AA
 Z3 --> AA
 AA --> AB[End]
 ```
+
+## Sample Policies
+
+The repository includes a comprehensive set of sample policies in `testdata/policy/`:
+
+- **License Policies**: Allowlists, blocklists, dual-license checks
+- **Security Policies**: Vulnerability bans, required fields, verified sources
+- **Metadata Policies**: Completeness, provenance, identifiers
+- **Enterprise Policies**: Approved suppliers, complete SBOM requirements
+- **Industry-Specific**: Finance compliance, open source distribution
+
+Each policy has corresponding test SBOMs in `testdata/sboms/` with `-violations.cdx.json` suffix.
+
+See `testdata/policy/README.md` for full documentation.

--- a/pkg/policy/evaluator.go
+++ b/pkg/policy/evaluator.go
@@ -60,28 +60,108 @@ func EvaluatePolicyAgainstSBOMs(ctx context.Context, policy Policy, doc sbom.Doc
 	totalChecks := 0
 	policyResults := make([]RuleResult, 0, len(components)*len(compiledRules))
 
-	// evaluate components against list of all rules in a single policy
+	// Separate document-level fields (sbom_*) from component-level fields
+	var docRules, compRules []compiledRule
+	for _, cr := range compiledRules {
+		if strings.HasPrefix(cr.Rule.Field, "sbom_") {
+			docRules = append(docRules, cr)
+		} else {
+			compRules = append(compRules, cr)
+		}
+	}
+
+	log.Debug("Separated rules by level",
+		zap.Int("document_rules", len(docRules)),
+		zap.Int("component_rules", len(compRules)),
+	)
+
+	// Evaluate document-level rules ONCE per SBOM (not per component)
+	for _, compileRule := range docRules {
+		totalChecks++
+
+		declaredRule := compileRule.Rule
+		declaredField := declaredRule.Field
+		declaredValues := declaredRule.Values
+		patterns := compileRule.Patterns
+
+		// Retrieve document-level values (using nil component for document fields)
+		actualValues := fieldExtractor.RetrieveValues(nil, declaredField)
+
+		// default outcome/pass reason based on policy type
+		result := "pass"
+		var reason string
+
+		// Set default pass reason based on policy type
+		switch RULE_TYPE(policy.Type) {
+		case REQUIRED:
+			reason = "field present"
+		case WHITELIST:
+			reason = "value in whitelist"
+		case BLACKLIST:
+			reason = "not in blacklist"
+		default:
+			reason = "pass"
+		}
+
+		// required rule: presence check
+		if RULE_TYPE(policy.Type) == REQUIRED {
+			ok := fieldExtractor.HasField(nil, declaredField)
+			if !ok {
+				result = "fail"
+				reason = "missing field"
+			}
+
+		} else {
+			// for whitelist/blacklist do matching
+			switch RULE_TYPE(policy.Type) {
+			case WHITELIST:
+				// For whitelist: ALL actual values must be in the whitelist
+				violations := findViolations(actualValues, declaredValues, patterns)
+				if len(violations) > 0 {
+					result = "fail"
+					reason = fmt.Sprintf("value(s) not in whitelist: %s", strings.Join(violations, ", "))
+				}
+			case BLACKLIST:
+				// For blacklist: NONE of the actual values should be in the blacklist
+				violations := findMatches(actualValues, declaredValues, patterns)
+				if len(violations) > 0 {
+					result = "fail"
+					reason = fmt.Sprintf("value(s) in blacklist: %s", strings.Join(violations, ", "))
+				}
+			default:
+				// if unknown type, treat as pass
+			}
+		}
+
+		pr := RuleResult{
+			ComponentID:   "-", // Document-level, no component
+			ComponentName: "-",
+			DeclaredField: declaredField,
+			ActualValues:  actualValues,
+			Result:        result,
+			Reason:        reason,
+		}
+
+		policyResults = append(policyResults, pr)
+	}
+
+	// Evaluate component-level rules per component
 	for _, comp := range components {
 		var compID, compName string
 		if comp != nil {
 			compID = comp.GetID()
-		}
-		if comp != nil {
 			compName = comp.GetName()
 		}
 
-		// evaluate each component against list of all rules
-		for _, compileRule := range compiledRules {
+		for _, compileRule := range compRules {
 			totalChecks++
-			// evaluate rule
 
 			declaredRule := compileRule.Rule
 			declaredField := declaredRule.Field
 			declaredValues := declaredRule.Values
 			patterns := compileRule.Patterns
 
-			// retreive the actual values from component for that respective field
-			// example: `license`, `supplier`, `checksum`, `author`, etc
+			// Retrieve component-level values
 			actualValues := fieldExtractor.RetrieveValues(comp, declaredField)
 
 			// default outcome/pass reason based on policy type
@@ -113,7 +193,6 @@ func EvaluatePolicyAgainstSBOMs(ctx context.Context, policy Policy, doc sbom.Doc
 				switch RULE_TYPE(policy.Type) {
 				case WHITELIST:
 					// For whitelist: ALL actual values must be in the whitelist
-					// If ANY actual value is not in the whitelist, it's a violation
 					violations := findViolations(actualValues, declaredValues, patterns)
 					if len(violations) > 0 {
 						result = "fail"
@@ -121,20 +200,19 @@ func EvaluatePolicyAgainstSBOMs(ctx context.Context, policy Policy, doc sbom.Doc
 					}
 				case BLACKLIST:
 					// For blacklist: NONE of the actual values should be in the blacklist
-					// If ANY actual value matches, it's a violation
 					violations := findMatches(actualValues, declaredValues, patterns)
 					if len(violations) > 0 {
 						result = "fail"
 						reason = fmt.Sprintf("value(s) in blacklist: %s", strings.Join(violations, ", "))
 					}
 				default:
-					// if unknown type, treat as pass (or change to fail depending on your policy)
+					// if unknown type, treat as pass
 				}
 			}
 
 			pr := RuleResult{
 				ComponentID:   compID,
-				ComponentName: compName,
+				ComponentName:  compName,
 				DeclaredField: declaredField,
 				ActualValues:  actualValues,
 				Result:        result,
@@ -142,7 +220,6 @@ func EvaluatePolicyAgainstSBOMs(ctx context.Context, policy Policy, doc sbom.Doc
 			}
 
 			policyResults = append(policyResults, pr)
-
 		}
 	}
 

--- a/pkg/policy/evaluator.go
+++ b/pkg/policy/evaluator.go
@@ -250,8 +250,16 @@ func EvaluatePolicyAgainstSBOMs(ctx context.Context, policy Policy, doc sbom.Doc
 		}
 	}
 
+	// Determine the level: "doc" if document-level rules exist, "comp" otherwise
+	if len(docRules) > 0 {
+		policyResult.Level = "doc"
+	} else {
+		policyResult.Level = "comp"
+	}
+
 	log.Info("Policy evaluation completed",
 		zap.String("policy", policy.Name),
+		zap.String("level", policyResult.Level),
 		zap.Int("checks", totalChecks),
 		zap.Int("violations", violationCount),
 		zap.String("result", policyResult.OverallResult),

--- a/pkg/policy/extractor.go
+++ b/pkg/policy/extractor.go
@@ -62,10 +62,6 @@ func (extractor *Extractor) MapFieldWithFunction(ctx context.Context) {
 
 	extractor.compGetters["license"] = func(c sbom.GetComponent) []string {
 		licenses := []string{}
-		if len(c.GetLicenses()) == 0 {
-			licenses = append(licenses, "NOASSERTION")
-		}
-
 		for _, l := range c.GetLicenses() {
 			// preferring ID instead of Name, coz, user prefer ID over names.
 			if ln := l.ShortID(); ln != "" {

--- a/pkg/policy/reporter.go
+++ b/pkg/policy/reporter.go
@@ -73,15 +73,21 @@ func ReportBasic(ctx context.Context, results []PolicyResult) error {
 	// Render table to buffer first to calculate width
 	var buf strings.Builder
 	summary := tablewriter.NewWriter(&buf)
-	summary.SetHeader([]string{"POLICY", "TYPE", "ACTION", "RESULT", "COMPONENTS", "VIOLATIONS", "RULES APPLIED"})
+	summary.SetHeader([]string{"POLICY", "TYPE", "ACTION", "RESULT", "LEVEL", "COMPONENTS", "VIOLATIONS", "RULES APPLIED"})
 
 	for _, r := range sorted {
+		// Show "-" for document-level policies in COMPONENTS column
+		componentsDisplay := fmt.Sprintf("%d", r.TotalComponents)
+		if r.Level == "doc" {
+			componentsDisplay = "-"
+		}
 		summary.Append([]string{
 			r.PolicyName,
 			r.PolicyType,
 			r.PolicyAction,
 			r.OverallResult,
-			fmt.Sprintf("%d", r.TotalComponents),
+			r.Level,
+			componentsDisplay,
 			fmt.Sprintf("%d", r.ViolationCnt),
 			fmt.Sprintf("%d", r.TotalRules),
 		})
@@ -316,12 +322,18 @@ func ReportTable(ctx context.Context, results []PolicyResult) error {
 
 	// Render summary table
 	sum = tablewriter.NewWriter(os.Stdout)
-	sum.SetHeader([]string{"POLICY", "RESULT", "COMPONENTS", "VIOLATIONS", "RULES APPLIED"})
+	sum.SetHeader([]string{"POLICY", "RESULT", "LEVEL", "COMPONENTS", "VIOLATIONS", "RULES APPLIED"})
 	for _, r := range sorted {
+		// Show "-" for document-level policies in COMPONENTS column
+		componentsDisplay := fmt.Sprintf("%d", r.TotalComponents)
+		if r.Level == "doc" {
+			componentsDisplay = "-"
+		}
 		sum.Append([]string{
 			r.PolicyName,
 			r.OverallResult,
-			fmt.Sprintf("%d", r.TotalComponents),
+			r.Level,
+			componentsDisplay,
 			fmt.Sprintf("%d", r.ViolationCnt),
 			fmt.Sprintf("%d", r.TotalRules),
 		})

--- a/pkg/policy/result.go
+++ b/pkg/policy/result.go
@@ -25,6 +25,7 @@ type PolicyResult struct {
 	TotalRules      int          `json:"total_rules,omitempty"`
 	TotalComponents int          `json:"total_components,omitempty"` // number of components scanned
 	ViolationCnt    int          `json:"violation_count,omitempty"`  // number of failed policy_results
+	Level           string       `json:"level,omitempty"`            // "doc" for document-level, "comp" for component-level
 }
 
 type RuleResult struct {

--- a/testdata/policy/README.md
+++ b/testdata/policy/README.md
@@ -1,0 +1,107 @@
+# SBOM Policy Examples
+
+This directory contains comprehensive policy examples for the `sbomqs policy` command. These policies demonstrate various use cases from license compliance to security enforcement.
+
+## Quick Start
+
+```bash
+# Run a policy against an SBOM
+sbomqs policy -f testdata/policy/license-allowlist.yaml my-sbom.cdx.json
+
+# Use table output for detailed results
+sbomqs policy -f testdata/policy/security-ban-vulnerables.yaml my-sbom.cdx.json -o table
+
+# Multiple policies at once
+sbomqs policy -f testdata/policy/license-allowlist.yaml -f testdata/policy/security-required-fields.yaml my-sbom.cdx.json
+```
+
+## Policy Categories
+
+### 1. License Compliance
+
+Policies for enforcing license compliance in your organization.
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `license-allowlist.yaml` | Only permits OSI-approved permissive licenses | Commercial products, distribution |
+| `license-block-copyleft.yaml` | Blocks all GPL variants | Proprietary software development |
+| `license-block-proprietary.yaml` | Blocks custom/proprietary licenses | Open source projects |
+| `license-dual-check.yaml` | Requires both declared and concluded licenses | High-compliance environments |
+
+### 2. Security
+
+Policies for preventing security risks and vulnerabilities.
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `security-ban-vulnerables.yaml` | Blocks known vulnerable package versions | Production deployments |
+| `security-required-fields.yaml` | Requires checksums, PURLs, versions | Supply chain security |
+| `security-no-snapshots.yaml` | Blocks SNAPSHOT/pre-release versions | Stable releases |
+| `security-verified-sources.yaml` | Requires source code URLs and hashes | Reproducible builds |
+
+### 3. Metadata Quality
+
+Policies for ensuring SBOM completeness and quality.
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `metadata-required.yaml` | Requires all basic metadata fields | SBOM completeness checks |
+| `metadata-provenance.yaml` | Requires author, supplier, timestamp | Audit trails |
+| `metadata-identifiers.yaml` | Requires PURL or CPE for all components | Vulnerability scanning |
+
+### 4. Enterprise/Organizational
+
+Policies for organizational governance.
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `enterprise-approved-suppliers.yaml` | Whitelist approved vendors | Vendor management |
+| `enterprise-complete-sbom.yaml` | Comprehensive production-ready SBOM | Release gates |
+
+### 5. Industry-Specific
+
+Policies tailored to specific industry requirements.
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `industry-finance-compliance.yaml` | Finance sector requirements | Banking, fintech |
+
+### 6. Community/Open Source
+
+Policies for open source project health and distribution.
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `open-source-distribution.yaml` | Ensures OSS compliance before publishing | Open source releases |
+| `community-health.yaml` | Checks OSI-approved licenses and provenance | Community projects |
+
+### 7. Advanced/Multi-Policy
+
+Complex policies combining multiple rules.
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `advanced-comprehensive.yaml` | All compliance checks combined | Ultimate compliance gate |
+
+## Testing Policies
+
+### Using Provided Test SBOMs
+
+A dedicated test SBOMs directory is provided for validating policies:
+
+```bash
+# Test license policies
+sbomqs policy -f testdata/policy/license-allowlist.yaml testdata/sboms/license-allowlist-violations.cdx.json
+sbomqs policy -f testdata/policy/license-block-copyleft.yaml testdata/sboms/license-block-copyleft-violations.cdx.json
+
+# Test security policies
+sbomqs policy -f testdata/policy/security-ban-vulnerables.yaml testdata/sboms/security-ban-vulnerables-violations.cdx.json
+sbomqs policy -f testdata/policy/security-required-fields.yaml testdata/sboms/security-required-fields-violations.cdx.json
+
+# Test metadata policies
+sbomqs policy -f testdata/policy/metadata-required.yaml testdata/sboms/metadata-required-violations.cdx.json
+sbomqs policy -f testdata/policy/metadata-provenance.yaml testdata/sboms/metadata-provenance-violations.cdx.json
+
+# Test comprehensive policy
+sbomqs policy -f testdata/policy/advanced-comprehensive.yaml testdata/sboms/advanced-comprehensive-violations.cdx.json
+```

--- a/testdata/policy/advanced-comprehensive.yaml
+++ b/testdata/policy/advanced-comprehensive.yaml
@@ -1,0 +1,118 @@
+# Advanced: Comprehensive Compliance Policy
+#
+# This policy combines:
+# - License compliance (whitelist + copyleft block)
+# - Security (vulnerability checks + required fields)
+# - Metadata (provenance + identifiers)
+# - Enterprise (approved suppliers)
+
+policy:
+  # ===== LICENSE COMPLIANCE =====
+  - name: allowed_licenses_only
+    description: |
+      CRITICAL: Only approved licenses allowed.
+      Blocks all GPL variants and proprietary licenses.
+    type: whitelist
+    rules:
+      - field: license
+        values:
+          - MIT
+          - MIT-0
+          - Apache-2.0
+          - BSD-2-Clause
+          - BSD-3-Clause
+          - BSD-4-Clause
+          - ISC
+          - Unlicense
+          - 0BSD
+          - CC0-1.0
+          - MPL-2.0
+          - EPL-2.0
+    action: fail
+
+  - name: no_strong_copyleft
+    description: |
+      CRITICAL: No GPL/AGPL/LGPL allowed.
+    type: blacklist
+    rules:
+      - field: license
+        patterns:
+          - "^GPL-.*"
+          - "^LGPL-.*"
+          - "^AGPL-.*"
+    action: fail
+
+  # ===== SECURITY =====
+  - name: no_vulnerable_log4j
+    description: |
+      CRITICAL: Blocks vulnerable Log4j versions.
+    type: blacklist
+    rules:
+      - field: name
+        patterns:
+          - "log4j-1\\..*"
+          - "log4j-core-2\\.1[0-6]\\..*"
+          - "log4j-core-2\\.0\\..*"
+    action: fail
+
+  - name: no_snapshot_in_production
+    description: |
+      WARNING: Pre-release versions in production.
+    type: blacklist
+    rules:
+      - field: version
+        patterns:
+          - ".*-SNAPSHOT$"
+          - ".*-RC[0-9]+$"
+          - ".*-BETA[0-9]*$"
+    action: warn
+
+  # ===== REQUIRED FIELDS =====
+  - name: require_version
+    description: |
+      CRITICAL: All components must have versions.
+    type: required
+    rules:
+      - field: version
+    action: fail
+
+  - name: require_checksums
+    description: |
+      CRITICAL: All components must have checksums.
+    type: required
+    rules:
+      - field: checksum
+    action: fail
+
+  - name: require_purl_for_scanning
+    description: |
+      WARNING: PURL needed for vulnerability scanning.
+    type: required
+    rules:
+      - field: purl
+    action: warn
+
+  - name: require_license
+    description: |
+      WARNING: License information required.
+    type: required
+    rules:
+      - field: license
+    action: warn
+
+  # ===== METADATA =====
+  - name: sbom_timestamp_required
+    description: |
+      CRITICAL: SBOM must have creation timestamp.
+    type: required
+    rules:
+      - field: sbom_timestamp
+    action: warn
+
+  - name: supplier_info_required
+    description: |
+      WARNING: Supplier information recommended.
+    type: required
+    rules:
+      - field: supplier
+    action: warn

--- a/testdata/policy/community-health.yaml
+++ b/testdata/policy/community-health.yaml
@@ -1,0 +1,147 @@
+# Policy: Community Health
+# Use Case: Ensure open source projects have healthy metadata for community adoption
+# Description: Checks for documentation, contribution guidelines, and project health indicators
+# Author: sbomqs
+
+policy:
+  # Require license for open source projects
+  - name: require_osi_approved_license
+    description: |
+      Open source projects should use an OSI-approved license.
+      This enables legal use and contribution by the community.
+    type: whitelist
+    rules:
+      - field: license
+        values:
+          # Popular permissive licenses
+          - MIT
+          - Apache-2.0
+          - BSD-2-Clause
+          - BSD-3-Clause
+          - BSD-4-Clause
+          - ISC
+          # Copyleft licenses (also OSI approved)
+          - GPL-2.0
+          - GPL-2.0-only
+          - GPL-2.0-or-later
+          - GPL-3.0
+          - GPL-3.0-only
+          - GPL-3.0-or-later
+          - LGPL-2.1
+          - LGPL-3.0
+          - AGPL-3.0
+          # Other popular licenses
+          - MPL-2.0
+          - EPL-2.0
+          - CC0-1.0
+          - Unlicense
+    action: warn
+    reason: "Consider using an OSI-approved license for broader adoption."
+
+  # Block restricted licenses that hinder community use
+  - name: no_restricted_licenses
+    description: |
+      Licenses that restrict use, modification, or distribution
+      hinder community health and adoption.
+    type: blacklist
+    rules:
+      - field: license
+        patterns:
+          - "(?i)proprietary"
+          - "(?i)restricted"
+          - "(?i)confidential"
+          - "CC-BY-NC"                # Non-commercial restricts use
+          - "CC-BY-ND"                # No derivatives restricts modification
+          - "CC-BY-SA"                # ShareAlike can be compatibility issue
+          - "^LicenseRef-"
+    action: fail
+    reason: "Restricted licenses limit community participation and adoption."
+
+  # Require source code availability
+  - name: require_source_code_url
+    description: |
+      Open source projects must provide source code URLs
+      to enable study, modification, and distribution.
+    type: required
+    rules:
+      - field: downloadlocation
+    action: warn
+    reason: "Source code URL enables community contributions."
+
+  # Prefer common open source suppliers
+  - name: prefer_established_oss_suppliers
+    description: |
+      Components from established open source organizations
+      tend to have better long-term maintenance.
+    type: whitelist
+    rules:
+      - field: supplier
+        patterns:
+          - "(?i)apache software foundation"
+          - "(?i)eclipse foundation"
+          - "(?i)linux foundation"
+          - "(?i)mozilla foundation"
+          - "(?i)python software foundation"
+          - "(?i)openjs foundation"
+          - "(?i)gnu"
+          - "(?i)github[.]com"
+          - "(?i)gitlab[.]com"
+          - "(?i)npm"
+          - "(?i)pypi"
+          - "(?i)rubygems"
+    action: pass
+    reason: "Component from established open source community."
+
+  # Flag solo/unmaintained projects
+  - name: flag_potentially_unmaintained
+    description: |
+      Components that appear to be personal or unmaintained
+      may pose sustainability risks for community projects.
+    type: blacklist
+    rules:
+      - field: supplier
+        patterns:
+          - "(?i)unknown"
+          - "(?i)unmaintained"
+          - "(?i)personal"
+          - "^$"                       # Empty supplier
+    action: warn
+    reason: "Verify component is actively maintained by a community."
+
+  # Require standard versioning
+  - name: encourage_semantic_versioning
+    description: |
+      Semantic versioning helps the community understand
+      compatibility and upgrade paths.
+    type: whitelist
+    rules:
+      - field: version
+        patterns:
+          - "^[0-9]+[.][0-9]+[.][0-9]+$"     # Pure semver
+          - "^[0-9]+[.][0-9]+$"              # Major.minor
+          - "^[0-9]+[.][0-9]+[.][0-9]+-"     # Prerelease semver
+    action: pass
+    reason: "Version follows semantic versioning standard."
+
+  # Check for well-known open source components
+  - name: recognize_popular_oss_components
+    description: |
+      Recognize widely-used open source components that
+      demonstrate healthy community adoption.
+    type: whitelist
+    rules:
+      - field: name
+        patterns:
+          - "(?i)^react$"
+          - "(?i)^vue$"
+          - "(?i)^angular$"
+          - "(?i)^lodash"
+          - "(?i)^express$"
+          - "(?i)^spring"
+          - "(?i)^django$"
+          - "(?i)^flask$"
+          - "(?i)^rails$"
+          - "(?i)^bootstrap$"
+          - "(?i)^jquery"
+    action: pass
+    reason: "Widely-adopted open source component."

--- a/testdata/policy/enterprise-approved-suppliers.yaml
+++ b/testdata/policy/enterprise-approved-suppliers.yaml
@@ -1,0 +1,58 @@
+# Enterprise: Approved Suppliers Policy
+#
+# Common Use Cases:
+# - Vendor management programs
+# - Supply chain security
+# - Procurement compliance
+# - Enterprise architecture standards
+
+policy:
+  - name: approved_component_suppliers
+    description: |
+      Only allows components from approved vendors.
+      Blocks components from unknown or unapproved sources.
+      Essential for supply chain governance.
+    type: whitelist
+    rules:
+      - field: supplier
+        values:
+          # Major open source foundations
+          - Apache Software Foundation
+          - Eclipse Foundation
+          - Linux Foundation
+          - Mozilla Foundation
+          - Python Software Foundation
+          - Node.js Foundation
+          # Major vendors
+          - Google LLC
+          - Microsoft Corporation
+          - Amazon Web Services
+          - Oracle Corporation
+          - Red Hat, Inc.
+          - VMware, Inc.
+          - IBM Corporation
+          - Salesforce.com, Inc.
+          # Specific maintainers
+          - Meta Platforms, Inc.
+          - Apple Inc.
+          - JetBrains s.r.o.
+          - MongoDB, Inc.
+          - Elastic N.V.
+          - HashiCorp
+          - Grafana Labs
+          - Kong Inc.
+        patterns:
+          # Allow internal/organization suppliers
+          - "ACME.*"
+          - ".*Internal.*"
+          - "Organization: ACME.*"
+    action: fail
+
+  - name: require_verified_supplier_info
+    description: |
+      All components must have supplier information.
+      Warns about components with missing supplier data.
+    type: required
+    rules:
+      - field: supplier
+    action: warn

--- a/testdata/policy/enterprise-complete-sbom.yaml
+++ b/testdata/policy/enterprise-complete-sbom.yaml
@@ -1,0 +1,154 @@
+# Policy: Enterprise Complete SBOM
+# Description: Comprehensive check requiring all critical fields for enterprise use
+# Author: sbomqs
+
+policy:
+  # --- Component Identification ---
+
+  - name: require_component_name
+    description: Every component must be named
+    type: required
+    rules:
+      - field: name
+    action: fail
+    reason: "Component name is mandatory."
+
+  - name: require_component_version
+    description: Every component must have a version
+    type: required
+    rules:
+      - field: version
+    action: fail
+    reason: "Component version is mandatory for reproducibility."
+
+  - name: require_unique_identifiers
+    description: PURL or CPE required for vulnerability tracking
+    type: required
+    rules:
+      - field: purl
+      - field: cpe
+    operator: OR
+    action: fail
+    reason: "Unique identifier (PURL or CPE) is mandatory for security tracking."
+
+  # --- License Compliance ---
+
+  - name: require_license_information
+    description: License must be specified
+    type: required
+    rules:
+      - field: license
+    action: fail
+    reason: "License information is mandatory for legal compliance."
+
+  - name: no_high_risk_licenses
+    description: Block copyleft and proprietary licenses
+    type: blacklist
+    rules:
+      - field: license
+        patterns:
+          - "GPL-[0-9]"              # Any GPL version
+          - "LGPL-[0-9]"             # Any LGPL version
+          - "AGPL-[0-9]"             # Affero GPL
+          - "^LicenseRef-"            # Proprietary licenses
+          - "(?i)proprietary"
+          - "CC-BY-NC"                # Non-commercial Creative Commons
+          - "CC-BY-ND"                # No derivatives CC
+    action: fail
+    reason: "High-risk license detected - not permitted in enterprise distribution."
+
+  # --- Security Requirements ---
+
+  - name: require_checksum_verification
+    description: Checksum required for integrity
+    type: required
+    rules:
+      - field: checksum
+    action: fail
+    reason: "Checksum mandatory for supply chain integrity."
+
+  - name: require_verified_source
+    description: Download location must be specified
+    type: required
+    rules:
+      - field: downloadlocation
+    action: warn
+    reason: "Source URL required for source code verification."
+
+  # --- Provenance ---
+
+  - name: require_supplier_information
+    description: Supplier/author must be identified
+    type: required
+    rules:
+      - field: supplier
+    action: warn
+    reason: "Supplier information required for provenance tracking."
+
+  - name: require_author_information
+    description: Author must be identified
+    type: required
+    rules:
+      - field: author
+    action: pass
+    reason: "Author information helps with support contacts."
+
+  # --- SBOM Metadata ---
+
+  - name: require_sbom_timestamp
+    description: SBOM must have creation timestamp
+    type: required
+    rules:
+      - field: sbom_timestamp
+    action: warn
+    reason: "Timestamp required for SBOM freshness assessment."
+
+  - name: require_sbom_author
+    description: SBOM must have an author
+    type: required
+    rules:
+      - field: sbom_author
+    action: warn
+    reason: "SBOM author required for audit trails."
+
+  - name: require_sbom_tool
+    description: SBOM generation tool must be documented
+    type: required
+    rules:
+      - field: sbom_tool
+    action: pass
+    reason: "Tool information helps with SBOM regeneration."
+
+  # --- Component Quality ---
+
+  - name: no_end_of_life_components
+    description: Warn about EOL components
+    type: blacklist
+    rules:
+      - field: name
+        patterns:
+          - "(?i)log4j-1"            # Log4j 1.x is EOL
+          - "(?i)python-2"           # Python 2 is EOL
+          - "(?i)openssl-1[.]0"      # OpenSSL 1.0.x is EOL
+          - "(?i)angularjs"           # AngularJS (1.x) is EOL
+    action: warn
+    reason: "Component is end-of-life and may have unpatched vulnerabilities."
+
+  # --- Version Quality ---
+
+  - name: no_snapshot_releases
+    description: No development or snapshot versions
+    type: blacklist
+    rules:
+      - field: version
+        patterns:
+          - "-SNAPSHOT$"
+          - "-snapshot$"
+          - "-alpha"
+          - "-Alpha"
+          - "-beta"
+          - "-Beta"
+          - "-RC"
+          - "-rc"
+    action: fail
+    reason: "Only stable releases are permitted in enterprise environments."

--- a/testdata/policy/industry-finance-compliance.yaml
+++ b/testdata/policy/industry-finance-compliance.yaml
@@ -1,0 +1,66 @@
+# Industry: Finance Sector Compliance Policy
+#
+#
+# Regulatory Frameworks:
+# - PCI DSS (Payment Card Industry)
+# - SOX (Sarbanes-Oxley)
+# - GDPR (Data protection)
+# - Basel III (Risk management)
+
+policy:
+  - name: finance_strict_license_control
+    description: |
+      FINANCE: Only approved commercial-friendly licenses.
+      Extremely restrictive - blocks all copyleft and unusual licenses.
+    type: whitelist
+    rules:
+      - field: license
+        values:
+          # Only the safest permissive licenses
+          - MIT
+          - Apache-2.0
+          - BSD-3-Clause
+          - ISC
+          - BSD-2-Clause
+    action: fail
+
+  - name: finance_no_gpl_any_variant
+    description: |
+      FINANCE: Zero tolerance for GPL variants.
+      Legal risk too high for financial institutions.
+    type: blacklist
+    rules:
+      - field: license
+        patterns:
+          - "GPL"
+          - "LGPL"
+          - "AGPL"
+          - "MPL"
+          - "CDDL"
+          - "EPL"
+          - "CPL"
+          - "OSL"
+          - "EUPL"
+    action: fail
+
+  - name: finance_required_identifiers
+    description: |
+      FINANCE: All components must have PURL for vulnerability tracking.
+      Required for security audits and incident response.
+    type: required
+    rules:
+      - field: purl
+      - field: version
+      - field: checksum
+    action: fail
+
+  - name: finance_provenance_tracking
+    description: |
+      FINANCE: Complete audit trail required.
+      SOX and GDPR compliance.
+    type: required
+    rules:
+      - field: sbom_timestamp
+      - field: sbom_author
+      - field: supplier
+    action: warn

--- a/testdata/policy/industry-finance-compliance.yaml
+++ b/testdata/policy/industry-finance-compliance.yaml
@@ -1,6 +1,5 @@
 # Industry: Finance Sector Compliance Policy
 #
-#
 # Regulatory Frameworks:
 # - PCI DSS (Payment Card Industry)
 # - SOX (Sarbanes-Oxley)

--- a/testdata/policy/license-allowlist.yaml
+++ b/testdata/policy/license-allowlist.yaml
@@ -1,0 +1,36 @@
+# License Allowlist Policy
+#
+# Common Use Cases:
+# - Commercial software development
+# - Products distributed to customers
+# - SaaS applications (permissive licenses only)
+# - Avoiding GPL/Copyleft contamination
+
+policy:
+  - name: approved_oss_licenses
+    description: |
+      Only permits OSI-approved permissive licenses.
+      Blocks copyleft (GPL, LGPL, AGPL) and proprietary licenses.
+      Suitable for commercial distribution.
+    type: whitelist
+    rules:
+      - field: license
+        values:
+          # Permissive licenses (safe for commercial use)
+          - MIT
+          - MIT-0
+          - Apache-2.0
+          - BSD-2-Clause
+          - BSD-3-Clause
+          - BSD-4-Clause
+          - ISC
+          - Unlicense
+          - 0BSD
+          - CC0-1.0
+          - Python-2.0
+          - Zlib
+          - JSON
+          # Microsoft licenses
+          - MS-PL
+          - MS-RL
+    action: fail

--- a/testdata/policy/license-block-copyleft.yaml
+++ b/testdata/policy/license-block-copyleft.yaml
@@ -1,0 +1,51 @@
+# Block Copyleft Licenses Policy
+#
+# Common Use Cases:
+# - Proprietary software development
+# - Commercial products
+# - SaaS platforms (internal use only)
+# - Avoiding license contamination
+
+
+policy:
+  - name: block_copyleft_licenses
+    description: |
+      Blocks all GPL variants and other strong copyleft licenses.
+      These licenses require derivative works to be open-sourced.
+      Essential for proprietary software development.
+    type: blacklist
+    rules:
+      - field: license
+        values:
+          # GPL variants (strong copyleft)
+          - GPL-2.0
+          - GPL-2.0-only
+          - GPL-2.0-or-later
+          - GPL-3.0
+          - GPL-3.0-only
+          - GPL-3.0-or-later
+          # AGPL (network copyleft)
+          - AGPL-1.0
+          - AGPL-3.0
+          # LGPL (weak copyleft, but still problematic for some)
+          - LGPL-2.0
+          - LGPL-2.1
+          - LGPL-3.0
+          # Other copyleft
+          - MPL-1.1
+          - MPL-2.0
+          - CDDL-1.0
+          - CDDL-1.1
+          - EPL-1.0
+          - EPL-2.0
+          - MPL-2.0
+          - OSL-1.0
+          - OSL-2.0
+          - OSL-2.1
+          - OSL-3.0
+        patterns:
+          # Catch any GPL/LGPL/AGPL variants
+          - "^GPL-.*"
+          - "^LGPL-.*"
+          - "^AGPL-.*"
+    action: fail

--- a/testdata/policy/license-block-proprietary.yaml
+++ b/testdata/policy/license-block-proprietary.yaml
@@ -1,0 +1,48 @@
+# Policy: Block Proprietary Licenses
+# Use Case: Ensure only standard open-source licenses are used
+# Description: Blocks custom LicenseRef-* and proprietary license identifiers
+# Author: sbomqs
+
+policy:
+  # Block proprietary/custom license identifiers
+  - name: no_proprietary_licenses
+    description: |
+      Blocks any proprietary or custom license identifiers.
+      Only SPDX standard license IDs are allowed.
+    type: blacklist
+    rules:
+      - field: license
+        patterns:
+          - "^LicenseRef-.*"           # Custom LicenseRef-* identifiers
+          - "(?i)proprietary"         # Case-insensitive "proprietary"
+          - "(?i)commercial"          # Case-insensitive "commercial"
+          - "(?i)all rights reserved"  # Traditional proprietary notice
+          - "(?i)internal use only"    # Internal/proprietary marker
+    action: fail
+    reason: "Proprietary licenses are not allowed. Only standard SPDX licenses permitted."
+
+  # Also block concluded proprietary licenses
+  - name: no_proprietary_concluded_licenses
+    description: Block proprietary licenses even when marked as concluded
+    type: blacklist
+    rules:
+      - field: concluded_license
+        patterns:
+          - "^LicenseRef-.*"
+          - "(?i)proprietary"
+          - "(?i)commercial"
+    action: fail
+    reason: "Proprietary concluded licenses are not allowed."
+
+  # Also block declared proprietary licenses
+  - name: no_proprietary_declared_licenses
+    description: Block proprietary licenses even when marked as declared
+    type: blacklist
+    rules:
+      - field: declared_license
+        patterns:
+          - "^LicenseRef-.*"
+          - "(?i)proprietary"
+          - "(?i)commercial"
+    action: fail
+    reason: "Proprietary declared licenses are not allowed."

--- a/testdata/policy/license-dual-check.yaml
+++ b/testdata/policy/license-dual-check.yaml
@@ -1,0 +1,38 @@
+# Dual License Check Policy
+#
+# Use Case: For high-compliance environments where both declared (author's stated)
+# and concluded (distributor's choice) licenses must be present.
+# This ensures license consistency and proper attribution.
+#
+# Requirements:
+# - CycloneDX 1.6+ SBOMs with acknowledgement field
+# - Both declared and concluded licenses should be present
+# - Ensures comprehensive license documentation
+
+policy:
+  - name: require_declared_and_concluded_licenses
+    description: |
+      Requires both declared (acknowledgement=declared) and
+      concluded (acknowledgement=concluded) licenses for all components.
+      Ensures complete license documentation for compliance.
+      Works only with CycloneDX 1.6+ SBOMs.
+    type: required
+    rules:
+      - field: declared_license
+      - field: concluded_license
+    action: warn
+
+  - name: check_concluded_licenses_valid
+    description: |
+      Verifies that concluded licenses are from the approved list.
+      This is the distributor's choice of license.
+    type: whitelist
+    rules:
+      - field: concluded_license
+        values:
+          - MIT
+          - Apache-2.0
+          - BSD-3-Clause
+          - ISC
+          - MPL-2.0
+    action: fail

--- a/testdata/policy/metadata-identifiers.yaml
+++ b/testdata/policy/metadata-identifiers.yaml
@@ -1,0 +1,53 @@
+# Policy: Required Identifiers
+# Use Case: Ensure components have machine-readable identifiers for vulnerability scanning
+# Description: Requires PURL or CPE for every component
+# Author: sbomqs
+
+policy:
+  # Require at least one identifier (PURL or CPE)
+  - name: require_package_identifiers
+    description: |
+      Every component must have either a PURL (Package URL) or CPE
+      (Common Platform Enumeration) identifier for vulnerability scanning.
+    type: required
+    rules:
+      - field: purl
+      - field: cpe
+    operator: OR  # Either PURL or CPE satisfies this
+    action: fail
+    reason: "PURL or CPE required for vulnerability identification."
+
+  # Prefer PURL over CPE
+  - name: prefer_purl_identifiers
+    description: |
+      PURLs are preferred over CPEs as they provide better
+      ecosystem specificity and are easier to resolve.
+    type: required
+    rules:
+      - field: purl
+    action: warn
+    reason: "PURL is preferred for modern dependency management."
+
+  # Require valid PURL format
+  - name: require_valid_purl_format
+    description: |
+      PURLs should follow the standard format:
+      pkg:type/namespace/name@version?qualifiers#subpath
+    type: whitelist
+    rules:
+      - field: purl
+        patterns:
+          - "^pkg:[a-z][a-z0-9_-]*/[^@]+@[^?]+"  # Standard PURL format
+    action: warn
+    reason: "PURL format should follow pkg:protocol/namespace/name@version"
+
+  # Require CPE for system components
+  - name: require_cpe_for_systems
+    description: |
+      System-level components should have CPE identifiers
+      for CVE vulnerability database lookup.
+    type: required
+    rules:
+      - field: cpe
+    action: pass
+    reason: "CPE enables CVE vulnerability database lookups."

--- a/testdata/policy/metadata-provenance.yaml
+++ b/testdata/policy/metadata-provenance.yaml
@@ -1,0 +1,45 @@
+# Metadata: Provenance and Traceability Policy
+#
+# Common Use Cases:
+# - Regulatory compliance (GDPR, HIPAA, SOX)
+# - Supply chain audits
+# - Security incident response
+# - Forensic analysis
+
+policy:
+  - name: sbom_provenance_info
+    description: |
+      SBOM must have creation timestamp and author information.
+      Required for audit trails and compliance.
+    type: required
+    rules:
+      - field: sbom_timestamp
+      - field: sbom_author
+    action: warn
+
+  - name: sbom_generation_tool
+    description: |
+      SBOM should document the tool used for generation.
+      Helps with reproducibility and trust.
+    type: required
+    rules:
+      - field: sbom_tool
+    action: warn
+
+  - name: component_supplier_info
+    description: |
+      All components should have supplier information.
+      Critical for supply chain transparency and vendor management.
+    type: required
+    rules:
+      - field: supplier
+    action: warn
+
+  - name: component_author_info
+    description: |
+      All components should have author information.
+      Helps with accountability and support contacts.
+    type: required
+    rules:
+      - field: author
+    action: pass

--- a/testdata/policy/metadata-required.yaml
+++ b/testdata/policy/metadata-required.yaml
@@ -1,0 +1,68 @@
+# Policy: Required Metadata Fields
+# Use Case: Ensure SBOMs have all basic required fields for completeness
+# Description: Validates that essential metadata fields are present for all components
+# Author: sbomqs
+
+policy:
+  # Require component names
+  - name: require_component_names
+    description: Every component must have a name
+    type: required
+    rules:
+      - field: name
+    action: fail
+    reason: "Component name is required."
+
+  # Require component versions
+  - name: require_component_versions
+    description: Every component must have a version
+    type: required
+    rules:
+      - field: version
+    action: fail
+    reason: "Component version is required for dependency management."
+
+  # Require license information
+  - name: require_license_info
+    description: Every component must have license information
+    type: required
+    rules:
+      - field: license
+    action: warn
+    reason: "License information is required for compliance."
+
+  # Require supplier information
+  - name: require_supplier_info
+    description: Every component must have supplier information
+    type: required
+    rules:
+      - field: supplier
+    action: warn
+    reason: "Supplier information helps track component provenance."
+
+  # Require SBOM-level metadata
+  - name: require_sbom_timestamp
+    description: SBOM must have a creation timestamp
+    type: required
+    rules:
+      - field: sbom_timestamp
+    action: warn
+    reason: "Timestamp helps determine SBOM freshness."
+
+  # Require SBOM author
+  - name: require_sbom_author
+    description: SBOM must have an author or creator
+    type: required
+    rules:
+      - field: sbom_author
+    action: warn
+    reason: "Author information is required for audit trails."
+
+  # Require component type
+  - name: require_component_type
+    description: Every component should have a type specified
+    type: required
+    rules:
+      - field: type
+    action: pass
+    reason: "Component type helps categorize dependencies."

--- a/testdata/policy/open-source-distribution.yaml
+++ b/testdata/policy/open-source-distribution.yaml
@@ -1,0 +1,76 @@
+# Open Source: Distribution-Ready Policy
+#
+# Common Use Cases:
+# - Publishing to Maven Central
+# - NPM registry publishing
+# - GitHub releases
+# - Linux Foundation projects
+# - Apache Foundation releases
+
+policy:
+  - name: oss_complete_metadata
+    description: |
+      OSS: Complete metadata for distribution.
+      Required by Maven Central, NPM, and other registries.
+    type: required
+    rules:
+      - field: name
+      - field: version
+      - field: license
+      - field: checksum
+      - field: purl
+    action: warn
+
+  - name: oss_approved_licenses
+    description: |
+      OSS: Only OSI-approved licenses for distribution.
+      Most registries require OSI-approved licenses.
+    type: whitelist
+    rules:
+      - field: license
+        values:
+          # OSI-approved licenses
+          - MIT
+          - MIT-0
+          - Apache-2.0
+          - BSD-2-Clause
+          - BSD-3-Clause
+          - BSD-4-Clause
+          - ISC
+          - Unlicense
+          - 0BSD
+          - CC0-1.0
+          - Python-2.0
+          - Zlib
+          - MPL-2.0
+          - EPL-2.0
+          - GPL-2.0
+          - GPL-3.0
+          - LGPL-2.1
+          - LGPL-3.0
+          - AGPL-3.0
+    action: warn
+
+  - name: oss_provenance_info
+    description: |
+      OSS: Timestamp and authorship for traceability.
+      Helps users verify SBOM freshness.
+    type: required
+    rules:
+      - field: sbom_timestamp
+      - field: sbom_author
+      - field: sbom_tool
+    action: pass
+
+  - name: oss_no_proprietary_licenses
+    description: |
+      OSS: Cannot distribute with proprietary licenses.
+    type: blacklist
+    rules:
+      - field: license
+        patterns:
+          - "LicenseRef-.*"
+          - "Proprietary"
+          - "Commercial"
+          - "Internal"
+    action: fail

--- a/testdata/policy/security-ban-vulnerables.yaml
+++ b/testdata/policy/security-ban-vulnerables.yaml
@@ -1,0 +1,70 @@
+# Security: Ban Vulnerable Components Policy
+#
+# Use Case: Prevent known vulnerable components from being used in production.
+# Checks component names and versions against known vulnerability patterns.
+#
+# Common Use Cases:
+# - Production deployment gates
+# - Security audits
+# - Preventing supply chain attacks
+# - Compliance with security standards
+#
+
+policy:
+  - name: ban_vulnerable_log4j
+    description: |
+      Blocks Log4j versions with known critical vulnerabilities.
+      Includes Log4Shell (CVE-2021-44228) and EOL versions.
+    type: blacklist
+    rules:
+      - field: name
+        patterns:
+          # Log4j 1.x - End of Life, multiple vulnerabilities
+          - "log4j-1\\..*"
+          - "log4j-core-1\\..*"
+          - "log4j-api-1\\..*"
+          # Log4Shell vulnerable versions (2.10-2.16)
+          - "log4j-core-2\\.1[0-6]\\..*"
+          - "log4j-api-2\\.1[0-6]\\..*"
+          # Early 2.x with other vulnerabilities
+          - "log4j-core-2\\.0\\..*"
+          - "log4j-core-2\\.[0-9]\\..*"
+    action: fail
+
+  - name: ban_vulnerable_components
+    description: |
+      Blocks other known vulnerable components.
+      Updated regularly based on security advisories.
+    type: blacklist
+    rules:
+      - field: name
+        patterns:
+          # Apache Commons Collections - Deserialization
+          - "commons-collections-3\\.2\\.1"
+          - "commons-collections4-4\\.0"
+          # Struts 2 - Multiple RCE vulnerabilities
+          - "struts2-core-2\\.3\\.[0-9]$"
+          - "struts2-core-2\\.5\\.[0-9]$"
+          # Spring Framework - vulnerable versions
+          - "spring-core-4\\.0\\..*"
+          - "spring-core-4\\.1\\..*"
+          # Jackson Databind - Multiple CVEs
+          - "jackson-databind-2\\.[0-8]\\..*"
+          # Fastjson - Deserialization vulnerabilities
+          - "fastjson-1\\.2\\.[0-5][0-9]$"
+    action: fail
+
+  - name: warn_snapshot_versions
+    description: |
+      Warns about SNAPSHOT/pre-release versions in production.
+      These are unstable and may contain unpatched vulnerabilities.
+    type: blacklist
+    rules:
+      - field: version
+        patterns:
+          - ".*-SNAPSHOT$"
+          - ".*-RC[0-9]+$"
+          - ".*-BETA[0-9]*$"
+          - ".*-ALPHA[0-9]*$"
+          - ".*-DEV$"
+    action: warn

--- a/testdata/policy/security-no-snapshots.yaml
+++ b/testdata/policy/security-no-snapshots.yaml
@@ -1,0 +1,63 @@
+# Policy: No Snapshot/Pre-release Versions
+# Use Case: Ensure only stable, released versions are used in production
+# Description: Blocks SNAPSHOT, RC, alpha, beta, and other pre-release versions
+# Author: sbomqs
+
+policy:
+  # Block SNAPSHOT versions (common in Java/Maven)
+  - name: no_snapshot_versions
+    description: |
+      Blocks SNAPSHOT versions which are development/unstable builds.
+      Only stable releases should be used in production.
+    type: blacklist
+    rules:
+      - field: version
+        patterns:
+          - ".*-SNAPSHOT$"          # Maven SNAPSHOT versions
+          - ".*-snapshot$"         # Lowercase snapshots
+    action: fail
+    reason: "SNAPSHOT versions are not allowed in production. Use stable releases only."
+
+  # Block release candidates
+  - name: no_release_candidates
+    description: Block RC (Release Candidate) versions
+    type: blacklist
+    rules:
+      - field: version
+        patterns:
+          - ".*-RC[0-9]+$"         # Release candidates (e.g., RC1, RC2)
+          - ".*-rc[0-9]+$"         # Lowercase rc
+          - ".*-CR[0-9]+$"         # Some projects use CR (Candidate Release)
+    action: warn
+    reason: "Release candidate versions should be reviewed before production use."
+
+  # Block alpha/beta/pre versions
+  - name: no_alpha_beta_versions
+    description: Block alpha, beta, and pre-release versions
+    type: blacklist
+    rules:
+      - field: version
+        patterns:
+          - ".*-alpha[0-9.]*$"     # Alpha releases
+          - ".*-Alpha[0-9.]*$"     # Capitalized Alpha
+          - ".*-beta[0-9.]*$"      # Beta releases
+          - ".*-Beta[0-9.]*$"      # Capitalized Beta
+          - ".*-pre[0-9.]*$"       # Pre-releases
+          - ".*-dev[0-9.]*$"       # Dev versions
+          - ".*-nightly[0-9.]*$"   # Nightly builds
+          - "^[0-9]+[.][0-9]+-"    # Any version with hyphen suffix (e.g., 1.0-preview)
+    action: warn
+    reason: "Pre-release versions (alpha, beta, dev) are discouraged in production."
+
+  # Require stable version format (optional, more strict)
+  - name: require_stable_version_format
+    description: Only allow clean semantic versioning (x.y.z)
+    type: whitelist
+    rules:
+      - field: version
+        patterns:
+          - "^[0-9]+[.][0-9]+[.][0-9]+$"     # Strict semver: 1.2.3
+          - "^[0-9]+[.][0-9]+$"              # Simple version: 1.2
+          - "^[0-9]+[.][0-9]+[.][0-9]+[+][a-zA-Z0-9]+$"  # With build metadata: 1.2.3+build123
+    action: pass
+    reason: "Version follows stable release format."

--- a/testdata/policy/security-required-fields.yaml
+++ b/testdata/policy/security-required-fields.yaml
@@ -1,0 +1,48 @@
+# Security: Required Fields Policy
+#
+# Use Case: Ensure all components have essential security metadata.
+# This enables vulnerability scanning, license compliance, and supply chain verification.
+#
+# Common Use Cases:
+# - SBOM completeness validation
+# - Supply chain security
+# - Vulnerability scanning preparation
+# - Compliance with security frameworks (NIST SSDF, etc.)
+#
+
+policy:
+  - name: require_version_for_all_components
+    description: |
+      All components must have version information.
+      Without versions, vulnerability scanning is impossible.
+    type: required
+    rules:
+      - field: version
+    action: fail
+
+  - name: require_checksums
+    description: |
+      All components must have checksums for integrity verification.
+      Prevents supply chain attacks through tampering.
+    type: required
+    rules:
+      - field: checksum
+    action: fail
+
+  - name: require_package_identifiers
+    description: |
+      Components must have PURL (Package URL) or CPE for vulnerability scanning.
+      These identifiers are required by security scanners.
+    type: required
+    rules:
+      - field: purl
+    action: warn
+
+  - name: require_licenses
+    description: |
+      All components must have license information.
+      Required for legal compliance and audit trails.
+    type: required
+    rules:
+      - field: license
+    action: warn

--- a/testdata/policy/security-verified-sources.yaml
+++ b/testdata/policy/security-verified-sources.yaml
@@ -1,0 +1,81 @@
+# Policy: Verified Sources
+# Use Case: Ensure all components come from verified, trusted sources
+# Description: Requires download URLs and checksums for reproducible builds
+# Author: sbomqs
+
+policy:
+  # Require download location for all components
+  - name: require_download_urls
+    description: |
+      Every component must have a download URL.
+      This ensures the source of the component can be verified.
+    type: required
+    rules:
+      - field: downloadlocation
+    action: fail
+    reason: "Download URL is required for source verification."
+
+  # Require checksums for integrity verification
+  - name: require_checksums
+    description: |
+      Requires cryptographic checksums for all components.
+      Supports SHA-256, SHA-512, SHA-1, and MD5.
+    type: required
+    rules:
+      - field: checksum
+    action: fail
+    reason: "Checksum required for integrity verification."
+
+  # Verify checksum algorithm is strong
+  - name: require_strong_hash_algorithm
+    description: |
+      Requires SHA-256 or SHA-512 for checksums.
+      MD5 and SHA-1 are considered weak for security purposes.
+    type: whitelist
+    rules:
+      - field: hashAlgorithm
+        values:
+          - SHA-256
+          - SHA-256
+          - SHA-512
+          - SHA-384
+    action: warn
+    reason: "Weak hash algorithm detected. Use SHA-256 or SHA-512."
+
+  # Verify source URL is from trusted domain
+  - name: trusted_source_domains
+    description: |
+      Ensures download URLs are from trusted domains.
+      Prevents components from unknown/unverified sources.
+    type: whitelist
+    rules:
+      - field: downloadlocation
+        patterns:
+          - "^https://repo[.]maven[.]apache[.]org/.*"      # Maven Central
+          - "^https://central[.]sonatype[.]com/.*"         # Sonatype Central
+          - "^https://registry[.]npmjs[.]com/.*"           # npm Registry
+          - "^https://pypi[.]org/.*"                       # PyPI
+          - "^https://rubygems[.]org/.*"                   # RubyGems
+          - "^https://crates[.]io/.*"                      # Rust Crates
+          - "^https://proxy[.]golang[.]org/.*"             # Go Proxy
+          - "^https://github[.]com/.*"                     # GitHub releases
+          - "^https://gitlab[.]com/.*"                     # GitLab releases
+          - "^https://downloads[.]apache[.]org/.*"         # Apache Downloads
+          - "^https://repo1[.]maven[.]org/.*"              # Maven Central (alt)
+    action: warn
+    reason: "Download URL is not from a known trusted repository."
+
+  # Block known bad sources
+  - name: block_untrusted_sources
+    description: |
+      Blocks components from known untrusted or suspicious sources.
+    type: blacklist
+    rules:
+      - field: downloadlocation
+        patterns:
+          - "^http://"               # Non-HTTPS URLs
+          - "(?i)[.]onion/"          # Dark web sources
+          - "(?i)torrent"            # Torrent sources
+          - "(?i)directdownload"     # Direct download sites
+    action: fail
+    reason: "Component source is not trusted or secure."

--- a/testdata/sboms/advanced-comprehensive-violations.cdx.json
+++ b/testdata/sboms/advanced-comprehensive-violations.cdx.json
@@ -1,0 +1,192 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [
+        {
+          "vendor": "Test",
+          "name": "test-generator",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    "component": {
+      "type": "application",
+      "name": "vulnerable-app",
+      "version": "1.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "gpl-library",
+      "version": "1.2.3",
+      "description": "GPL licensed library - should fail copyleft check",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0",
+            "name": "GNU General Public License v3.0"
+          }
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "log4j-core-2.14.1",
+      "version": "2.14.1",
+      "description": "Vulnerable Log4j version with Log4Shell CVE-2021-44228 - name includes version to trigger policy",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"
+    },
+    {
+      "type": "library",
+      "name": "log4j-1.2.17",
+      "version": "1.2.17",
+      "description": "EOL Log4j 1.x - name includes version to trigger policy",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/log4j/log4j@1.2.17"
+    },
+    {
+      "type": "library",
+      "name": "snapshot-library",
+      "version": "2.0.0-SNAPSHOT",
+      "description": "Development snapshot version - should warn",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.example/snapshot-library@2.0.0-SNAPSHOT"
+    },
+    {
+      "type": "library",
+      "name": "rc-library",
+      "version": "3.0.0-RC1",
+      "description": "Release candidate version - should warn",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.example/rc-library@3.0.0-RC1"
+    },
+    {
+      "type": "library",
+      "name": "no-checksum-library",
+      "version": "1.0.0",
+      "description": "Missing checksum - should fail required check",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.example/no-checksum@1.0.0"
+    },
+    {
+      "type": "library",
+      "name": "no-purl-library",
+      "version": "1.0.0",
+      "description": "Missing PURL - should warn",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "no-license-library",
+      "version": "1.0.0",
+      "description": "Missing license - should warn",
+      "purl": "pkg:maven/com.example/no-license@1.0.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "no-supplier-library",
+      "version": "1.0.0",
+      "description": "Missing supplier - should warn",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "name": "MIT License"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.example/no-supplier@1.0.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "compliant-library",
+      "version": "1.0.0",
+      "description": "Fully compliant library with all required fields",
+      "supplier": {
+        "name": "Apache Software Foundation"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "name": "Apache License 2.0"
+          }
+        }
+      ],
+      "purl": "pkg:maven/org.apache/compliant@1.0.0",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sboms/clean-permissive.cdx.json
+++ b/testdata/sboms/clean-permissive.cdx.json
@@ -1,0 +1,90 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:clean-permissive-001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": [
+      {
+        "vendor": "sbomqs",
+        "name": "test-generator",
+        "version": "1.0.0"
+      }
+    ],
+    "authors": [
+      {
+        "name": "Test Author",
+        "email": "test@example.com"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "mit-library",
+      "version": "1.0.0",
+      "purl": "pkg:npm/mit-library@1.0.0",
+      "supplier": {
+        "name": "MIT"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "apache-library",
+      "version": "2.0.0",
+      "purl": "pkg:maven/org.apache/apache-library@2.0.0",
+      "supplier": {
+        "name": "Apache Software Foundation"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "bsd-library",
+      "version": "1.5.0",
+      "purl": "pkg:npm/bsd-library@1.5.0",
+      "supplier": {
+        "name": "BSD Project"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sboms/community-health-violations.cdx.json
+++ b/testdata/sboms/community-health-violations.cdx.json
@@ -1,0 +1,40 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "proprietary-health",
+      "version": "1.0.0",
+      "licenses": [{"license": {"name": "Proprietary"}}],
+      "purl": "pkg:maven/com.example/proprietary@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "unknown-supplier",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.unknown/unknown@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "apache-lib",
+      "version": "1.0.0",
+      "supplier": {"name": "Apache Software Foundation"},
+      "licenses": [{"license": {"id": "Apache-2.0"}}],
+      "purl": "pkg:maven/org.apache/apache@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/enterprise-approved-suppliers-violations.cdx.json
+++ b/testdata/sboms/enterprise-approved-suppliers-violations.cdx.json
@@ -1,0 +1,33 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "apache-lib",
+      "version": "1.0.0",
+      "supplier": {"name": "Apache Software Foundation"},
+      "licenses": [{"license": {"id": "Apache-2.0"}}],
+      "purl": "pkg:maven/org.apache/apache-lib@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "unknown-supplier",
+      "version": "1.0.0",
+      "supplier": {"name": "Unknown Vendor"},
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.unknown/unknown@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/enterprise-complete-sbom-violations.cdx.json
+++ b/testdata/sboms/enterprise-complete-sbom-violations.cdx.json
@@ -1,0 +1,37 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "gpl-violation",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "GPL-3.0"}}],
+      "purl": "pkg:maven/com.example/gpl@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "snapshot-violation",
+      "version": "1.0.0-SNAPSHOT",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/snapshot@1.0.0-SNAPSHOT",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "missing-all",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}]
+    }
+  ]
+}

--- a/testdata/sboms/gpl-copyleft.cdx.json
+++ b/testdata/sboms/gpl-copyleft.cdx.json
@@ -1,0 +1,56 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:gpl-copyleft-001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": [
+      {
+        "vendor": "sbomqs",
+        "name": "test-generator",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "gpl-component",
+      "version": "3.0.0",
+      "purl": "pkg:npm/gpl-component@3.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "lgpl-component",
+      "version": "2.1.0",
+      "purl": "pkg:npm/lgpl-component@2.1.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "LGPL-2.1"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sboms/industry-finance-compliance-violations.cdx.json
+++ b/testdata/sboms/industry-finance-compliance-violations.cdx.json
@@ -1,0 +1,32 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "gpl-finance",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "GPL-3.0"}}],
+      "supplier": {"name": "Test Supplier"},
+      "purl": "pkg:maven/com.example/gpl-finance@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "no-supplier",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/no-supplier@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/license-allowlist-violations.cdx.json
+++ b/testdata/sboms/license-allowlist-violations.cdx.json
@@ -1,0 +1,39 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "gpl-component",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "GPL-3.0"}}],
+      "purl": "pkg:maven/com.example/gpl@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "proprietary-component",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "LicenseRef-Custom"}}],
+      "purl": "pkg:maven/com.example/proprietary@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "mit-component",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/mit@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/license-block-copyleft-violations.cdx.json
+++ b/testdata/sboms/license-block-copyleft-violations.cdx.json
@@ -1,0 +1,47 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "gpl-v2-component",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "GPL-2.0"}}],
+      "purl": "pkg:maven/com.example/gplv2@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "lgpl-component",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "LGPL-3.0"}}],
+      "purl": "pkg:maven/com.example/lgpl@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "agpl-component",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "AGPL-3.0"}}],
+      "purl": "pkg:maven/com.example/agpl@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "mit-component",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/mit@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/license-block-proprietary-violations.cdx.json
+++ b/testdata/sboms/license-block-proprietary-violations.cdx.json
@@ -1,0 +1,39 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "proprietary-lib",
+      "version": "1.0.0",
+      "licenses": [{"license": {"name": "Proprietary License"}}],
+      "purl": "pkg:maven/com.acme/proprietary@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "commercial-lib",
+      "version": "2.0.0",
+      "licenses": [{"license": {"id": "LicenseRef-ACME-Commercial"}}],
+      "purl": "pkg:maven/com.acme/commercial@2.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "mit-lib",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/mit@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/license-dual-check-violations.cdx.json
+++ b/testdata/sboms/license-dual-check-violations.cdx.json
@@ -1,0 +1,60 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "apache-concluded",
+      "version": "1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "concluded"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.example/apache-concluded@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "mit-declared",
+      "version": "1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.example/mit-declared@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "gpl-declared",
+      "version": "1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:maven/com.example/gpl-declared@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/license-expressions-acknowledgement.cdx.json
+++ b/testdata/sboms/license-expressions-acknowledgement.cdx.json
@@ -1,0 +1,94 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:license-expr-ack-001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": [
+      {
+        "vendor": "sbomqs",
+        "name": "test-generator",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "mit-expression-concluded",
+      "version": "1.0.0",
+      "purl": "pkg:npm/mit-expr@1.0.0",
+      "licenses": [
+        {
+          "expression": "MIT",
+          "acknowledgement": "concluded"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "apache-id-concluded",
+      "version": "2.0.0",
+      "purl": "pkg:maven/org.apache/apache@2.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "concluded"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "bsd-declared",
+      "version": "1.0.0",
+      "purl": "pkg:npm/bsd-declared@1.0.0",
+      "licenses": [
+        {
+          "expression": "BSD-3-Clause",
+          "acknowledgement": "declared"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "gpl-declared",
+      "version": "1.0.0",
+      "purl": "pkg:npm/gpl-declared@1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321fe"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sboms/metadata-identifiers-violations.cdx.json
+++ b/testdata/sboms/metadata-identifiers-violations.cdx.json
@@ -1,0 +1,29 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "no-identifiers",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}]
+    },
+    {
+      "type": "library",
+      "name": "with-purl",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/with-purl@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/metadata-provenance-violations.cdx.json
+++ b/testdata/sboms/metadata-provenance-violations.cdx.json
@@ -1,0 +1,40 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "no-supplier",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/no-supplier@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "no-author",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/no-author@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "complete",
+      "version": "1.0.0",
+      "supplier": {"name": "Apache Software Foundation"},
+      "licenses": [{"license": {"id": "Apache-2.0"}}],
+      "purl": "pkg:maven/org.apache/complete@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/metadata-required-violations.cdx.json
+++ b/testdata/sboms/metadata-required-violations.cdx.json
@@ -1,0 +1,31 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}]
+    },
+    {
+      "type": "library",
+      "name": "missing-version",
+      "licenses": [{"license": {"id": "MIT"}}]
+    },
+    {
+      "type": "library",
+      "name": "complete",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "supplier": {"name": "Test Supplier"}
+    }
+  ]
+}

--- a/testdata/sboms/missing-metadata.cdx.json
+++ b/testdata/sboms/missing-metadata.cdx.json
@@ -1,0 +1,57 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:missing-metadata-001",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "component-no-version",
+      "purl": "pkg:npm/component-no-version@unknown",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "component-no-license",
+      "version": "1.0.0",
+      "purl": "pkg:npm/component-no-license@1.0.0"
+    },
+    {
+      "type": "library",
+      "name": "component-no-checksum",
+      "version": "1.0.0",
+      "purl": "pkg:npm/component-no-checksum@1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "component-no-purl",
+      "version": "1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sboms/open-source-distribution-violations.cdx.json
+++ b/testdata/sboms/open-source-distribution-violations.cdx.json
@@ -1,0 +1,31 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "proprietary-lib",
+      "version": "1.0.0",
+      "licenses": [{"license": {"name": "LicenseRef-ACME-Commercial"}}],
+      "purl": "pkg:maven/com.acme/proprietary@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "mit-lib",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/mit@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/proprietary-licenses.cdx.json
+++ b/testdata/sboms/proprietary-licenses.cdx.json
@@ -1,0 +1,56 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:proprietary-licenses-001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": [
+      {
+        "vendor": "sbomqs",
+        "name": "test-generator",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "mit-library",
+      "version": "1.0.0",
+      "purl": "pkg:npm/mit-library@1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "custom-proprietary",
+      "version": "1.0.0",
+      "purl": "pkg:npm/custom-proprietary@1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "LicenseRef-ACME-Proprietary"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sboms/security-ban-vulnerables-violations.cdx.json
+++ b/testdata/sboms/security-ban-vulnerables-violations.cdx.json
@@ -1,0 +1,41 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "log4j-core-2.14.1",
+      "version": "2.14.1",
+      "description": "Vulnerable Log4Shell version",
+      "licenses": [{"license": {"id": "Apache-2.0"}}],
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "log4j-1.2.17",
+      "version": "1.2.17",
+      "description": "EOL Log4j 1.x",
+      "licenses": [{"license": {"id": "Apache-2.0"}}],
+      "purl": "pkg:maven/log4j/log4j@1.2.17",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "safe-library",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/safe@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/security-no-snapshots-violations.cdx.json
+++ b/testdata/sboms/security-no-snapshots-violations.cdx.json
@@ -1,0 +1,47 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "snapshot-lib",
+      "version": "1.0.0-SNAPSHOT",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/snapshot@1.0.0-SNAPSHOT",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "rc-lib",
+      "version": "2.0.0-RC1",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/rc@2.0.0-RC1",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "alpha-lib",
+      "version": "3.0.0-alpha1",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/alpha@3.0.0-alpha1",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "stable-lib",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/stable@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/security-required-fields-violations.cdx.json
+++ b/testdata/sboms/security-required-fields-violations.cdx.json
@@ -1,0 +1,37 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "no-checksum",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/no-checksum@1.0.0"
+    },
+    {
+      "type": "library",
+      "name": "no-purl",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "complete",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/complete@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/security-verified-sources-violations.cdx.json
+++ b/testdata/sboms/security-verified-sources-violations.cdx.json
@@ -1,0 +1,38 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789012",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": {
+      "services": [{"vendor": "Test", "name": "test-generator", "version": "1.0.0"}]
+    },
+    "component": {"type": "application", "name": "test-app", "version": "1.0.0"}
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "no-checksum",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/no-checksum@1.0.0"
+    },
+    {
+      "type": "library",
+      "name": "no-download-url",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/no-url@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    },
+    {
+      "type": "library",
+      "name": "complete",
+      "version": "1.0.0",
+      "licenses": [{"license": {"id": "MIT"}}],
+      "purl": "pkg:maven/com.example/complete@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}]
+    }
+  ]
+}

--- a/testdata/sboms/snapshot-versions.cdx.json
+++ b/testdata/sboms/snapshot-versions.cdx.json
@@ -1,0 +1,75 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:snapshot-versions-001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": [
+      {
+        "vendor": "sbomqs",
+        "name": "test-generator",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "stable-library",
+      "version": "1.0.0",
+      "purl": "pkg:npm/stable-library@1.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "snapshot-library",
+      "version": "1.0.0-SNAPSHOT",
+      "purl": "pkg:npm/snapshot-library@1.0.0-SNAPSHOT",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "rc-library",
+      "version": "2.0.0-RC1",
+      "purl": "pkg:npm/rc-library@2.0.0-RC1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/sboms/vulnerable-log4j.cdx.json
+++ b/testdata/sboms/vulnerable-log4j.cdx.json
@@ -1,0 +1,78 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:vulnerable-log4j-001",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-15T10:30:00Z",
+    "tools": [
+      {
+        "vendor": "sbomqs",
+        "name": "test-generator",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "log4j-core-2.14.1",
+      "version": "2.14.1",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+      "supplier": {
+        "name": "Apache Software Foundation"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "log4j-1.2.17",
+      "version": "1.2.17",
+      "purl": "pkg:maven/log4j/log4j@1.2.17",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "safe-component",
+      "version": "2.17.1",
+      "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.17.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the following changes:
- Document-Level policy evaluation fixes:
  - Fixed document-level fields (sbom_*) being evaluated per-component instead of once per SBOM
  - Document fields now show single check per SBOM.
  - Added LEVEL column to policy results distinguishing "doc" vs "comp" policies
- removed automatic NOASSERTION fallback for missing licenses, missing licenses now return empty list instead of "NOASSERTION"
- added policies samples under `testdata/policy` folder
- added sboms sample for testing under `testdata/sboms` folder
- updated documentation part
- also added docs on policy expression used for regex values matching: related to: https://github.com/interlynk-io/sbomqs/issues/697