### PR TITLE
Fix/SBOM manufacturer

### DIFF
--- a/docs/reference/bsi-v11-compliance.md
+++ b/docs/reference/bsi-v11-compliance.md
@@ -44,8 +44,8 @@ BSI is built around the assumption that SBOMs must be processable by machines ac
 
 - CycloneDX:
   - [`metadata.authors[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_authors_items_email)
-  - [`metadata.manufacturer.email`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_contact_items_email) OR [`metadata.manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_url) OR [`metadata.manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_contact_items_email)
-  - [`metadata.supplier.email`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_contact_items_email) OR [`metadata.supplier.url`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_url) OR [`metadata.supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_contact_items_email)
+  - [`metadata.manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_contact_items_email) OR [`metadata.manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_url)
+  - [`metadata.supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_contact_items_email) OR [`metadata.supplier.url`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_url)
 
 ### 2. Timestamp
 
@@ -102,8 +102,8 @@ Same rationale as the SBOM creator: BSI requires a machine-actionable contact fo
 
 - CycloneDX:
   - [`components[].authors[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_authors_items_email)
-  - [`components[].manufacturer.email`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_contact_items_email) OR [`components[].manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_url) OR [`components[].manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_contact_items_email)
-  - [`components[].supplier.email`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_contact_items_email) OR [`components[].supplier.url`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_url) OR [`components[].supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_contact_items_email)
+  - [`components[].manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_contact_items_email) OR [`components[].manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_url)
+  - [`components[].supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_contact_items_email) OR [`components[].supplier.url`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_url)
 
 ### 4. Component name
 

--- a/docs/reference/bsi-v20-compliance.md
+++ b/docs/reference/bsi-v20-compliance.md
@@ -44,8 +44,8 @@ BSI is built around the assumption that SBOMs must be processable by machines ac
 
 - CycloneDX:
   - [`metadata.authors[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_authors_items_email)
-  - [`metadata.manufacturer.email`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_contact_items_email) OR [`metadata.manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_url) OR [`metadata.manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_contact_items_email)
-  - [`metadata.supplier.email`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_contact_items_email) OR [`metadata.supplier.url`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_url) OR [`metadata.supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_contact_items_email)
+  - [`metadata.manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_contact_items_email) OR [`metadata.manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#metadata_manufacturer_url)
+  - [`metadata.supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_contact_items_email) OR [`metadata.supplier.url`](https://cyclonedx.org/docs/1.7/json/#metadata_supplier_url)
 
 ### 2. Timestamp
 
@@ -102,8 +102,8 @@ Same rationale as the SBOM creator: BSI requires a machine-actionable contact fo
 
 - CycloneDX:
   - [`components[].authors[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_authors_items_email)
-  - [`components[].manufacturer.email`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_contact_items_email) OR [`components[].manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_url) OR [`components[].manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_contact_items_email)
-  - [`components[].supplier.email`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_contact_items_email) OR [`components[].supplier.url`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_url) OR [`components[].supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_contact_items_email)
+  - [`components[].manufacturer.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_contact_items_email) OR [`components[].manufacturer.url`](https://cyclonedx.org/docs/1.7/json/#components_items_manufacturer_url)
+  - [`components[].supplier.contact[].email`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_contact_items_email) OR [`components[].supplier.url`](https://cyclonedx.org/docs/1.7/json/#components_items_supplier_url)
 
 ### 4. Component name
 

--- a/docs/reference/bsi-v21-compliance.md
+++ b/docs/reference/bsi-v21-compliance.md
@@ -86,8 +86,8 @@ BSI is built around the assumption that SBOMs must be processable by machines ac
   - The `Person`/`Organization` element carries an `externalIdentifiers` entry of type `email` (`"...@..."`) XOR type `urlScheme` (`"https://..."`)
 
 - CycloneDX v1.6:
-  - [`metadata.manufacturer[].url`](https://cyclonedx.org/docs/1.6/json/#metadata_tools_oneOf_i0_components_items_supplier_url): URL of the manufacturer
-  - XOR [`metadata.manufacturer[].contact[].email`](https://cyclonedx.org/docs/1.6/json/#metadata_tools_oneOf_i0_components_items_supplier_contact_items_email): email in the manufacturer's contact list
+  - [`metadata.manufacturer[].contact[].email`](https://cyclonedx.org/docs/1.6/json/#metadata_tools_oneOf_i0_components_items_supplier_contact_items_email): email in the manufacturer's contact list
+  - XOR [`metadata.manufacturer[].url`](https://cyclonedx.org/docs/1.6/json/#metadata_tools_oneOf_i0_components_items_supplier_url): URL of the manufacturer
 
 ### 2. Timestamp
 

--- a/pkg/compliance/bsiV11_test.go
+++ b/pkg/compliance/bsiV11_test.go
@@ -146,7 +146,34 @@ var bsiSpdxSBOMCreationInfoMissing = []byte(`
 }
 `)
 
-// Manufacturer fixtures (CDX uses "manufacture" for metadata-level)
+// Manufacturer fixtures (CDX uses "manufacture" for metadata-level in older versions,
+// and "manufacturer" in CDX 1.6+)
+var bsiCdxSBOMManufacturerNewField = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {
+    "manufacturer": {
+      "bom-ref": "manufacturer-1",
+      "name": "Acme, Inc.",
+      "url": [
+        "https://example.com"
+      ],
+      "contact": [
+        {
+          "bom-ref": "contact-1",
+          "name": "Acme Professional Services",
+          "email": "professional.services@example.com"
+        }
+      ]
+    }
+  },
+  "components": []
+}
+`)
+
 var bsiCdxSBOMManufacturer = []byte(`
 {
   "bomFormat": "CycloneDX",
@@ -420,6 +447,19 @@ func TestBSISBOMCreator(t *testing.T) {
 		assert.Equal(t, "", got.CheckValue)
 	})
 
+	t.Run("cdxSBOMWithNewManufacturerField", func(t *testing.T) {
+		// Tests CDX 1.6+ "manufacturer" field (with 'r') instead of deprecated "manufacture"
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, bsiCdxSBOMManufacturerNewField, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := bsiV11SBOMCreator(doc)
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, SBOM_CREATOR, got.CheckKey)
+		assert.Equal(t, "doc", got.ID)
+		assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
+	})
+
 	t.Run("cdxSBOMWithManufacturerContactEmail", func(t *testing.T) {
 		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, bsiCdxSBOMManufacturer, sbom.Signature{})
 		require.NoError(t, err)
@@ -429,7 +469,8 @@ func TestBSISBOMCreator(t *testing.T) {
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
 		assert.Equal(t, SBOM_CREATOR, got.CheckKey)
 		assert.Equal(t, "doc", got.ID)
-		assert.Equal(t, "https://example.com (manufacturer)", got.CheckValue)
+		// Email is preferred over URL per BSI spec; extracted from contact
+		assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
 	})
 
 	t.Run("cdxSBOMWithManufacturerURLOnly", func(t *testing.T) {
@@ -453,7 +494,8 @@ func TestBSISBOMCreator(t *testing.T) {
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
 		assert.Equal(t, SBOM_CREATOR, got.CheckKey)
 		assert.Equal(t, "doc", got.ID)
-		assert.Equal(t, "professional.services@gmail.com (manufacturer contact)", got.CheckValue)
+		// Email extracted from contact is now set as manufacturer email, per BSI spec preference
+		assert.Equal(t, "professional.services@gmail.com (manufacturer)", got.CheckValue)
 	})
 
 	t.Run("cdxSBOMWithManufacturerNameOnly", func(t *testing.T) {
@@ -1058,7 +1100,8 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.InDelta(t, 10.0, got.Score, 1e-9)
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
-			assert.Equal(t, "https://example.com (manufacturer)", got.CheckValue)
+			// Email is preferred over URL per BSI spec; extracted from contact
+			assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
 		}
 	})
 
@@ -1086,7 +1129,8 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.InDelta(t, 10.0, got.Score, 1e-9)
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
-			assert.Equal(t, "professional.services@example.com (manufacturer contact)", got.CheckValue)
+			// Email extracted from contact is now set as manufacturer email, per BSI spec preference
+			assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
 		}
 	})
 

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -966,17 +966,43 @@ func (c *CdxDoc) parseSupplier() {
 }
 
 func (c *CdxDoc) parseManufacturer() {
-	if c.doc.Metadata == nil || c.doc.Metadata.Manufacture == nil {
+	if c.doc.Metadata == nil {
 		return
 	}
 
-	manufacturer := Manufacturer{Name: c.doc.Metadata.Manufacture.Name}
+	// CycloneDX 1.6+ uses "manufacturer" (new field), while older versions use "manufacture" (deprecated)
+	// Priority: manufacturer (new) > manufacture (deprecated)
+	var entity *cydx.OrganizationalEntity
+	if c.doc.Metadata.Manufacturer != nil {
+		entity = c.doc.Metadata.Manufacturer
+		c.addToLogs("cdx doc using metadata.manufacturer (CDX 1.6+)")
+	} else if c.doc.Metadata.Manufacture != nil {
+		entity = c.doc.Metadata.Manufacture
+		c.addToLogs("cdx doc using deprecated metadata.manufacture")
+	}
 
-	if urls := lo.FromPtr(c.doc.Metadata.Manufacture.URL); len(urls) > 0 {
+	if entity == nil {
+		return
+	}
+
+	manufacturer := Manufacturer{Name: entity.Name}
+
+	// Extract contact info with priority: email > URL > contacts email
+	// Per BSI spec: "Valid email address (preferred)", "Valid URL (accepted only when no email address is available)"
+	if urls := lo.FromPtr(entity.URL); len(urls) > 0 {
 		manufacturer.URL = urls[0]
 	}
 
-	contacts := lo.FromPtr(c.doc.Metadata.Manufacture.Contact)
+	// Extract email from contacts
+	contacts := lo.FromPtr(entity.Contact)
+	for _, contact := range contacts {
+		if contact.Email != "" {
+			manufacturer.Email = contact.Email
+			break
+		}
+	}
+
+	// Store all contacts
 	if len(contacts) > 0 {
 		manufacturer.Contacts = make([]Contact, len(contacts))
 		for i, contact := range contacts {
@@ -1117,7 +1143,17 @@ func (c *CdxDoc) assignManufacturer(comp *cydx.Component) *Manufacturer {
 		manufacturer.URL = urls[0]
 	}
 
+	// Extract contact info with priority: email from contacts
+	// Per BSI spec: "Valid email address (preferred)", "Valid URL (accepted only when no email address is available)"
 	contacts := lo.FromPtr(comp.Manufacturer.Contact)
+	for _, contact := range contacts {
+		if contact.Email != "" {
+			manufacturer.Email = contact.Email
+			break
+		}
+	}
+
+	// Store all contacts
 	if len(contacts) > 0 {
 		manufacturer.Contacts = make([]Contact, len(contacts))
 		for i, contact := range contacts {


### PR DESCRIPTION
closes #701 

This PR adds the following changes:
- added support for extracting field `metadata.manufacturer` for cdx:1.6+ onwards, earlier it only extracts from `metadata.manufacture`, which is now deprecated.
- updated docs regarding priority of bsi:sbom_creator for manufacturer, which is `contacts[].email` > `url` 