### PR TITLE
fix(spdx): guard nil CreationInfo when parsing SPDX documents

### DIFF
--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -248,8 +248,10 @@ func (s *SpdxDoc) parseDoc() {
 		s.addToLogs("cdx doc is not parsable")
 		return
 	}
-	if comment := s.doc.CreationInfo.CreatorComment; comment != "" {
-		s.Lifecycle = comment
+	if s.doc.CreationInfo != nil {
+		if comment := s.doc.CreationInfo.CreatorComment; comment != "" {
+			s.Lifecycle = comment
+		}
 	}
 }
 
@@ -274,7 +276,6 @@ func (s *SpdxDoc) parseSpec() {
 	}
 
 	sp.Spdxid = string(s.doc.SPDXIdentifier)
-	sp.Comment = s.doc.CreationInfo.CreatorComment
 
 	sp.SpecType = string(SBOMSpecSPDX)
 	sp.Name = s.doc.DocumentName


### PR DESCRIPTION
SPDX lets a document omit the `creationInfo` object, and real-world component-inventory SBOMs sometimes do. Two spots in the SPDX reader dereference it without a nil check, so loading such a file panics:

- `parseDoc` reads `s.doc.CreationInfo.CreatorComment` directly.
- `parseSpec` already guards `CreationInfo` in one block, but a stray `sp.Comment = s.doc.CreationInfo.CreatorComment` right after that block derefs it again.

Every command (score, compliance, list) goes through this loader, so a single valid SPDX file with no `creationInfo` takes the whole run down with a nil-pointer panic.

Minimal repro (SPDX 2.3, no `creationInfo`):

```json
{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"t","documentNamespace":"https://x","dataLicense":"CC0-1.0","packages":[{"name":"pkgA","SPDXID":"SPDXRef-pkgA","versionInfo":"1.0"}]}
```

The fix wraps the `parseDoc` access in the same `if s.doc.CreationInfo != nil` guard the rest of the reader already uses, and drops the redundant `sp.Comment` assignment (the guarded block a few lines up already sets it). `go test ./pkg/sbom/` passes.