### PR TITLE
update license check for list feature

### DIFF
--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -207,13 +207,25 @@ When `--profile` is specified, feature extraction follows the rules of that comp
 | `comp_source_code` | Component | Completeness | Source code reference |
 | `comp_supplier` | Component | Completeness | Component supplier |
 | `comp_purpose` | Component | Completeness | Component purpose / type |
-| `comp_licenses` | Component | Licensing | License expressions |
-| `comp_valid_licenses` | Component | Licensing | Valid SPDX expression syntax (accepts LicenseRef-*) |
-| `comp_spdx_listed_license` | Component | Licensing | SPDX standard listed licenses only |
-| `comp_no_deprecated_licenses` | Component | Licensing | No deprecated licenses |
-| `comp_no_restrictive_licenses` | Component | Licensing | No restrictive licenses |
-| `comp_declared_licenses` | Component | Licensing | Declared (original) licenses |
-| `sbom_data_license` | SBOM | Licensing | SBOM data license |
+
+**License Features (Generic Mode):**
+
+Generic license features check **all licenses** on a component, regardless of whether they are:
+- Concluded licenses (`acknowledgement: concluded` in CDX)
+- Declared licenses (`acknowledgement: declared` in CDX)
+- Generic licenses (no acknowledgement field in CDX, e.g., CDX 1.5 or licenses without explicit acknowledgement)
+
+| Feature | Scope | Description |
+|---------|-------|-------------|
+| `comp_licenses` | All licenses | Any license present (regardless of SPDX validity) |
+| `comp_valid_licenses` | All licenses | Valid SPDX syntax (accepts LicenseRef-*, AND/OR expressions) |
+| `comp_spdx_listed_license` | All licenses | SPDX standard listed licenses only (excludes LicenseRef-*) |
+| `comp_concluded_license` | Concluded only | Concluded licenses only (from `acknowledgement: concluded` or SPDX concluded fields) |
+| `comp_declared_license` | Declared only | Declared licenses only (from `acknowledgement: declared` or SPDX declared fields) |
+| `comp_declared_licenses` | Declared only | Alias for `comp_declared_license` |
+| `comp_no_deprecated_licenses` | All licenses | No deprecated licenses present |
+| `comp_no_restrictive_licenses` | All licenses | No restrictive licenses present |
+| `sbom_data_license` | SBOM-level | SBOM data license |
 | `comp_purl` | Component | Vulnerability | Component PURL |
 | `comp_cpe` | Component | Vulnerability | Component CPE |
 | `sbom_spec_declared` | SBOM | Structural | SBOM spec declared |

--- a/pkg/list/compeval.go
+++ b/pkg/list/compeval.go
@@ -129,9 +129,11 @@ func normalizeAlgoName(algo string) string {
 }
 
 // evaluateCompWithValidLicenses evaluates if the component has valid SPDX syntax licenses.
+// Checks all licenses regardless of concluded/declared categorization.
 // Accepts: standard SPDX IDs, LicenseRef-* custom licenses, AND/OR expressions.
 func evaluateCompWithValidLicenses(comp sbom.GetComponent) (bool, string, error) {
-	lics := comp.ConcludedLicenses()
+	// Check all licenses (concluded, declared, or generic)
+	lics := comp.GetLicenses()
 	if len(lics) == 0 {
 		return false, "missing", nil
 	}
@@ -164,17 +166,19 @@ func evaluateCompWithValidLicenses(comp sbom.GetComponent) (bool, string, error)
 }
 
 // evaluateCompWithSPDXListedLicense evaluates if the component has SPDX standard listed licenses.
+// Checks all licenses regardless of concluded/declared categorization.
 // Only accepts officially listed SPDX licenses. LicenseRef-* custom licenses are not valid.
 func evaluateCompWithSPDXListedLicense(comp sbom.GetComponent) (bool, string, error) {
-	licenses := comp.ConcludedLicenses()
-	if len(licenses) == 0 {
+	// Check all licenses (concluded, declared, or generic)
+	lics := comp.GetLicenses()
+	if len(lics) == 0 {
 		return false, "missing", nil
 	}
 
-	listedLicenses := make([]string, 0, len(licenses))
+	listedLicenses := make([]string, 0)
 	notListed := make([]string, 0)
 
-	for _, l := range licenses {
+	for _, l := range lics {
 		if l == nil {
 			continue
 		}


### PR DESCRIPTION
closes #715 

This PR adds the following changes:
- By default the `sbomqs list` command supports generic feature. Therefore added a generic definition of license feature:
  - `comp_licenses`: checks any license presence
  - `comp_valid_licenses`: checks valid SPDX syntax (accepts LicenseRef-*, AND/OR expressions)
  - `comp_spdx_listed_license`: checks SPDX standard listed licenses only
  
  And these all looks for all type of license: declared, concluded, id. Earlier they were following interlynk feature and only look for concluded by default.