### PR TITLE
fix(bsi): read the effective licence property for CycloneDX again

### DIFF
--- a/pkg/compliance/bsiV21.go
+++ b/pkg/compliance/bsiV21.go
@@ -563,7 +563,9 @@ func bsiV21ComponentOtherIdentifiers(component sbom.GetComponent) *db.Record {
 }
 
 // bsiV21ComponentEffectiveLicense checks for the effective license (MAY).
-// CDX: bsi:component:effectiveLicense property.
+// CDX: bsi:component:effectiveLicence property. The BSI property taxonomy spells it
+// "effectiveLicence"; TR-03183-2 v2.1.0 (Table 12) spells it "effectiveLicense".
+// Both spellings are accepted.
 // SPDX 3.0: hasEffectiveLicense relationship (non-standard BSI extension).
 func bsiV21ComponentEffectiveLicense(component sbom.GetComponent) *db.Record {
 	id := common.UniqueElementID(component)
@@ -577,8 +579,12 @@ func bsiV21ComponentEffectiveLicense(component sbom.GetComponent) *db.Record {
 		return db.NewRecordStmtOptional(COMP_EFFECTIVE_LICENSE, id, "compliant", 10.0)
 	}
 
-	// CDX: bsi:component:effectiveLicense property
-	value := strings.TrimSpace(component.GetPropertyValue("bsi:component:effectiveLicense"))
+	// CDX: bsi:component:effectiveLicence property (both spellings accepted)
+	value := strings.TrimSpace(component.GetPropertyValue("bsi:component:effectiveLicence"))
+	if value == "" {
+		value = strings.TrimSpace(component.GetPropertyValue("bsi:component:effectiveLicense"))
+	}
+
 	if value != "" {
 		return db.NewRecordStmtOptional(COMP_EFFECTIVE_LICENSE, id, value, 10.0)
 	}

--- a/pkg/list/extractors/bsiv21.go
+++ b/pkg/list/extractors/bsiv21.go
@@ -535,7 +535,8 @@ func BSIV21CompOriginalLicenses(_ sbom.Document, comp sbom.GetComponent) (bool, 
 }
 
 // BSIV21CompEffectiveLicense extracts the effective licence property.
-// CDX: bsi:component:effectiveLicense property.
+// CDX: bsi:component:effectiveLicence property; the TR-03183-2 spelling
+// "effectiveLicense" is accepted as well.
 // SPDX 3.0: hasEffectiveLicense relationship (non-standard BSI extension).
 // Mirrors: profiles.BSIV21CompEffectiveLicence
 func BSIV21CompEffectiveLicense(doc sbom.Document, comp sbom.GetComponent) (bool, string, error) {
@@ -545,7 +546,11 @@ func BSIV21CompEffectiveLicense(doc sbom.Document, comp sbom.GetComponent) (bool
 
 	switch spec {
 	case string(sbom.SBOMSpecCDX):
-		val := strings.TrimSpace(comp.GetPropertyValue("bsi:component:effectiveLicense"))
+		val := strings.TrimSpace(comp.GetPropertyValue("bsi:component:effectiveLicence"))
+		if val == "" {
+			val = strings.TrimSpace(comp.GetPropertyValue("bsi:component:effectiveLicense"))
+		}
+
 		if val != "" {
 			return true, val, nil
 		}

--- a/pkg/scorer/v2/profiles/bsiv21.go
+++ b/pkg/scorer/v2/profiles/bsiv21.go
@@ -106,6 +106,9 @@ func BSIV21CompStructuredProperty(doc sbom.Document) catalog.ProfFeatScore {
 
 // BSIV21CompEffectiveLicence checks that components have effective licenses declared.
 // SPDX 3.0: uses hasEffectiveLicense relationship (non-standard but used by BSI v2.1).
+// CDX: bsi:component:effectiveLicence property. The BSI property taxonomy spells it
+// "effectiveLicence"; TR-03183-2 v2.1.0 (Table 12) spells it "effectiveLicense".
+// Both spellings are accepted.
 func BSIV21CompEffectiveLicence(doc sbom.Document) catalog.ProfFeatScore {
 	comps := doc.Components()
 	total := len(comps)
@@ -120,7 +123,10 @@ func BSIV21CompEffectiveLicence(doc sbom.Document) catalog.ProfFeatScore {
 				return true
 			}
 		}
-		return false
+
+		return bsiPropertyValue(c,
+			"bsi:component:effectiveLicence",
+			"bsi:component:effectiveLicense") != ""
 	})
 
 	return componentScore(valid, total, "effective licence")
@@ -368,6 +374,17 @@ func bsiPropertyCheck(doc sbom.Document, propertyName, fieldLabel string) catalo
 	})
 
 	return componentScore(valid, total, fieldLabel)
+}
+
+// bsiPropertyValue returns the first non-empty value among the given property names.
+func bsiPropertyValue(c sbom.GetComponent, propertyNames ...string) string {
+	for _, name := range propertyNames {
+		if value := strings.TrimSpace(c.GetPropertyValue(name)); value != "" {
+			return value
+		}
+	}
+
+	return ""
 }
 
 // extRefURLCheck checks that components have an externalReference of one of the given types with a non-empty URL.

--- a/pkg/scorer/v2/profiles/bsiv21_test.go
+++ b/pkg/scorer/v2/profiles/bsiv21_test.go
@@ -3010,3 +3010,110 @@ func TestBSIV21CompStructuredProperty(t *testing.T) {
 		assert.False(t, got.Ignore)
 	})
 }
+
+//
+// TestBSIV21CompEffectiveLicence
+//
+
+// CDX: component carrying the taxonomy spelling, bsi:component:effectiveLicence.
+var cdx21CompEffectiveLicenceBritish = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:bsiv21-cdx-eff-lic-001",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "comp-eff-lic-british",
+      "name": "lib-effective-licence",
+      "version": "1.0.0",
+      "properties": [
+        {
+          "name": "bsi:component:effectiveLicence",
+          "value": "Apache-2.0"
+        }
+      ]
+    }
+  ]
+}
+`)
+
+// CDX: component carrying the TR-03183-2 spelling, bsi:component:effectiveLicense.
+var cdx21CompEffectiveLicenseAmerican = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:bsiv21-cdx-eff-lic-002",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "comp-eff-lic-american",
+      "name": "lib-effective-license",
+      "version": "1.0.0",
+      "properties": [
+        {
+          "name": "bsi:component:effectiveLicense",
+          "value": "MIT"
+        }
+      ]
+    }
+  ]
+}
+`)
+
+// CDX: component without any effective licence property.
+var cdx21CompWithoutEffectiveLicence = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:bsiv21-cdx-eff-lic-003",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "comp-no-eff-lic",
+      "name": "lib-without-effective-licence",
+      "version": "1.0.0"
+    }
+  ]
+}
+`)
+
+func TestBSIV21CompEffectiveLicence(t *testing.T) {
+	ctx := context.Background()
+
+	// taxonomy spelling (effectiveLicence) -> score 10.0
+	t.Run("taxonomySpelling", func(t *testing.T) {
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdx21CompEffectiveLicenceBritish, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := BSIV21CompEffectiveLicence(doc)
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, "effective licence declared for all components", got.Desc)
+	})
+
+	// TR-03183-2 spelling (effectiveLicense) -> score 10.0
+	t.Run("technicalGuidelineSpelling", func(t *testing.T) {
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdx21CompEffectiveLicenseAmerican, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := BSIV21CompEffectiveLicence(doc)
+
+		assert.InDelta(t, 10.0, got.Score, 1e-9)
+		assert.Equal(t, "effective licence declared for all components", got.Desc)
+	})
+
+	// property missing entirely -> score 0.0
+	t.Run("missing", func(t *testing.T) {
+		doc, err := sbom.NewSBOMDocumentFromBytes(ctx, cdx21CompWithoutEffectiveLicence, sbom.Signature{})
+		require.NoError(t, err)
+
+		got := BSIV21CompEffectiveLicence(doc)
+
+		assert.InDelta(t, 0.0, got.Score, 1e-9)
+		assert.Equal(t, "no components declare effective licence", got.Desc)
+	})
+}


### PR DESCRIPTION
Fixes #711.

`comp_effective_license` scores 0 for every CycloneDX SBOM on current `main`, and
the two spellings of the property are still handled inconsistently. This fixes both.

### The CycloneDX regression

#712 rewrote `BSIV21CompEffectiveLicence` to read only `c.EffectiveLicenses()`.
That slice is populated in exactly one place — `pkg/sbom/spdx3.go:759`, from SPDX 3.0
`hasEffectiveLicense` relationships — so it is always empty for a CycloneDX document.
The scorer no longer looks at the component property at all, while
`pkg/scorer/v2/registry/registry.go:1254` still describes the feature as the
`bsi:component:effectiveLicense` property.

`pkg/compliance` and `pkg/list/extractors` kept their CycloneDX branch, so the three
paths now disagree about whether the property exists. The scorer falls back to the
property when there is no SPDX 3.0 effective licence.

### The spelling

The [BSI property taxonomy](https://www.bsi.bund.de/) uses `bsi:component:effectiveLicence`,
TR-03183-2 v2.1.0 (Table 12, p. 31) uses `bsi:component:effectiveLicense`. Each path
looked for only one of them, and not the same one:

| path | property it looked for |
| --- | --- |
| `pkg/scorer/v2/profiles/bsiv21.go` (`BSIV21CompEffectiveLicence`) | neither, since #712 |
| `pkg/compliance/bsiV21.go` (`bsiV21ComponentEffectiveLicense`) | `…effectiveLicense` |
| `pkg/list/extractors/bsiv21.go` (`BSIV21CompEffectiveLicense`) | `…effectiveLicense` |

All three now check the taxonomy spelling first and fall back to the guideline spelling.

### Verification

`go test ./pkg/scorer/v2/profiles/ -run TestBSIV21CompEffectiveLicence -v` against
current `main` with the new tests applied:

```
--- FAIL: TestBSIV21CompEffectiveLicence/taxonomySpelling
--- FAIL: TestBSIV21CompEffectiveLicence/technicalGuidelineSpelling
--- PASS: TestBSIV21CompEffectiveLicence/missing

    Error: Max difference between 10 and 0 allowed is 1e-09, but difference was 10
    expected: "effective licence declared for all components"
    actual  : "no components declare effective licence"
```

Both CycloneDX cases score 0 instead of 10 — including the `effectiveLicense` spelling
the code comment claims to support. With this change all three pass:

```
go build ./...                     -> ok
go test ./pkg/...                  -> ok (no failures)
go test ./pkg/scorer/v2/profiles/ -run TestBSIV21CompEffectiveLicence -v
    --- PASS: TestBSIV21CompEffectiveLicence/taxonomySpelling
    --- PASS: TestBSIV21CompEffectiveLicence/technicalGuidelineSpelling
    --- PASS: TestBSIV21CompEffectiveLicence/missing
```

### Note on the rebase

This branch sat behind `main` and was rebased after #712 landed, so the diff is not the
one that was approved earlier. The original patch also swapped the argument order of
`bsiPropertyCheck` and made it variadic; #712 removed every call site of that helper
(filename, executable, archive and structured moved to `componentStringCheck` /
`componentBoolCheck` over `DistributionArtifact()`), so that part is dropped and the
change is now scoped to the effective licence path.

Happy to split the regression fix out into its own PR if you would rather keep this one
to the spelling alone.
