### PR TITLE
docs(bsi): document the full creator precedence for v2.0 and v2.1

### DIFF
--- a/docs/reference/compliance-standards.md
+++ b/docs/reference/compliance-standards.md
@@ -23,10 +23,10 @@ Key changes from v2.0.0:
 
 | TR-03183-2 Section | Data Field | Required | CycloneDX v1.6+ | SPDX v3.0.1 | SPDX v2 | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| 5.2.1 SBOM Fields | Creator of the SBOM | SHALL | `metadata.manufacturer[].url` XOR `metadata.manufacturer[].contact[].email` | `CreationInfo.createdBy` → `Person`/`Organization` with `externalIdentifiers` (email or URL) | N/A | |
+| 5.2.1 SBOM Fields | Creator of the SBOM | SHALL | `metadata.authors[].email`, then `metadata.manufacturer` (`.email`, `.url`, `.contact[].email`), then `metadata.supplier` (`.email`, `.url`, `.contact[].email`) | `CreationInfo.createdBy` → `Person`/`Organization` with `externalIdentifiers` (email or URL) | N/A | First contactable field wins; a name without email or URL is not sufficient |
 | | Timestamp | SHALL | `metadata.timestamp` | `CreationInfo.created` | N/A | |
 | | SBOM-URI | SHALL | `serialNumber` (BOM-Link: `urn:cdx:{serialNumber}/{version}`) | `SpdxDocument.namespaceMap[].namespace` or `SpdxDocument.spdxId` | N/A | Promoted from additional in v2.0 |
-| 5.2.2 Component Fields | Component creator | SHALL | `components[].manufacturer[].url` XOR `components[].manufacturer[].contact[].email` | `software_Package.originatedBy` → `Person`/`Organization` with `externalIdentifiers` (email or URL) | N/A | |
+| 5.2.2 Component Fields | Component creator | SHALL | `components[].authors[].email`, then `components[].manufacturer` (`.email`, `.url`, `.contact[].email`), then `components[].supplier` (`.email`, `.url`, `.contact[].email`) | `software_Package.originatedBy` → `Person`/`Organization` with `externalIdentifiers` (email or URL) | N/A | First contactable field wins; a name without email or URL is not sufficient |
 | | Component name | SHALL | `components[].name` | `software_Package.name` | N/A | |
 | | Component version | SHALL | `components[].version` | `software_Package.software_packageVersion` | N/A | |
 | | Filename | SHALL | `components[].properties[].name="bsi:component:filename"` | `software_File.name` linked via `hasDistributionArtifact` relationship | N/A | New in v2.1 |


### PR DESCRIPTION
Refs #708

The implementation already does what you describe — `authors` are checked first, then `manufacturer`,
then `supplier`. It is the documentation table for BSI v2.0/v2.1 that lists only
`manufacturer[].url XOR manufacturer[].contact[].email`, which is where the "authors are ignored"
impression comes from. This PR fixes the table.

`BSIV11CompCreator` (reused by v2.0 and v2.1 through `BSIV20CompCreator`) walks
authors → manufacturer → supplier, and the compliance path `bsiV11ComponentCreator` does the same in
the same order.

Verified with two CDX 1.6 fixtures against `BSIV20CompCreator`, which is what the BSI v2.1 profile
registers for `comp_creator`:

```
authors[].email only  -> score=10.0  "creator contact (email or URL) declared for all components"
authors[].name only   -> score=0.0   "1/1 components have creator info, but only valid email or URL required"
```

So a component with `authors[].email` scores full marks today. What does *not* score is an author with
a name and no email — and that is the likely explanation for the `cyclonedx-dotnet` output you saw:
that tool writes `authors[].name` without an email address. If your SBOM does carry author emails and
still scores 0.0, could you attach it? That would be a different bug from this documentation one.

The table now spells out the full precedence for both the SBOM-level and the component-level creator
fields, plus the rule that a bare name is not enough.

AI-assisted (LLM used for drafting); the fixtures, the runs and the reading of the code are mine.
