### PR TITLE
Skip null entries in SPDX package, file and relationship arrays

### DIFF
--- a/pkg/sbom/sbom_test.go
+++ b/pkg/sbom/sbom_test.go
@@ -264,6 +264,14 @@ var spdx3_missing_CreationInfo = []byte(`
 }
 `)
 
+// A null entry inside an SPDX array decodes to a nil element, which used to be
+// dereferenced while walking packages, files and relationships.
+var spdxNullPackageEntry = []byte(`{"spdxVersion":"SPDX-2.1","SPDXID":"SPDXRef-DOCUMENT","name":"x","documentNamespace":"http://example.com/x","dataLicense":"CC0-1.0","creationInfo":{"created":"2020-01-01T00:00:00Z","creators":["Tool: t"]},"packages":[null]}`)
+
+var spdxNullFileEntry = []byte(`{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"x","documentNamespace":"http://example.com/x","dataLicense":"CC0-1.0","creationInfo":{"created":"2020-01-01T00:00:00Z","creators":["Tool: t"]},"files":[null]}`)
+
+var spdxNullRelationshipEntry = []byte(`{"spdxVersion":"SPDX-2.1","SPDXID":"SPDXRef-DOCUMENT","name":"x","documentNamespace":"http://example.com/x","dataLicense":"CC0-1.0","creationInfo":{"created":"2020-01-01T00:00:00Z","creators":["Tool: t"]},"relationships":[null]}`)
+
 func TestNewSBOMDocumentFromBytes(t *testing.T) {
 	ctx := context.Background()
 
@@ -370,6 +378,24 @@ func TestNewSBOMDocumentFromBytes(t *testing.T) {
 			input:    spdx3_invalid_version_in_context,
 			wantSpec: SBOMSpecUnknown,
 			wantErr:  true,
+		},
+		{
+			name:     "spdx null package entry",
+			input:    spdxNullPackageEntry,
+			wantSpec: SBOMSpecSPDX,
+			wantErr:  false,
+		},
+		{
+			name:     "spdx null file entry",
+			input:    spdxNullFileEntry,
+			wantSpec: SBOMSpecSPDX,
+			wantErr:  false,
+		},
+		{
+			name:     "spdx null relationship entry",
+			input:    spdxNullRelationshipEntry,
+			wantSpec: SBOMSpecSPDX,
+			wantErr:  false,
 		},
 		{
 			name:     "spdx3_missing_CreationInfo",

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -342,6 +342,11 @@ func (s *SpdxDoc) parseComps() {
 	s.Comps = []GetComponent{}
 
 	for index, sc := range s.doc.Packages {
+		// a null entry in the packages array decodes to a nil element
+		if sc == nil {
+			continue
+		}
+
 		nc := NewComponent()
 
 		nc.Version = sc.PackageVersion
@@ -405,6 +410,11 @@ func (s *SpdxDoc) parseFiles() {
 	s.File = []GetComponent{}
 
 	for _, sf := range s.doc.Files {
+		// a null entry in the files array decodes to a nil element
+		if sf == nil {
+			continue
+		}
+
 		nc := NewComponent()
 
 		// Basic file information
@@ -532,6 +542,11 @@ func isSpdxInverseRel(rel string) (string, bool) {
 // It accepts both forward (DESCRIBES) and inverse (DESCRIBED_BY) forms.
 func (s *SpdxDoc) parsePrimaryComponent() {
 	for _, r := range s.doc.Relationships {
+		// a null entry in the relationships array decodes to a nil element
+		if r == nil {
+			continue
+		}
+
 		relUpper := strings.ToUpper(r.Relationship)
 
 		// Forward: DOCUMENT DESCRIBES component (RefB is the component)
@@ -592,6 +607,11 @@ func (s *SpdxDoc) parseRelationships() {
 	rawRels := make([]GetRelationship, 0, len(s.doc.Relationships))
 
 	for _, r := range s.doc.Relationships {
+		// a null entry in the relationships array decodes to a nil element
+		if r == nil {
+			continue
+		}
+
 		// Skip DESCRIBES relationships (and their inverse DESCRIBED_BY)
 		if strings.EqualFold(r.Relationship, spdx.RelationshipDescribes) ||
 			strings.EqualFold(r.Relationship, spdx_common.TypeRelationshipDescribeBy) {


### PR DESCRIPTION
A `null` element inside an SPDX array decodes to a nil pointer, and the document walks dereference it immediately, so `sbomqs score` dies on the file it was asked to score:

```
$ sbomqs score bad.spdx.json
panic: runtime error: invalid memory address or nil pointer dereference
  github.com/interlynk-io/sbomqs/v2/pkg/sbom.(*SpdxDoc).parseComps
    pkg/sbom/spdx.go:347
```

Three inputs, each a valid SPDX JSON document apart from the one null:

- `"packages":[null]` panics in `parseComps`
- `"files":[null]` panics in `parseFiles`
- `"relationships":[null]` panics in `parsePrimaryComponent`

All four affected loops now skip nil entries. `parseComps` keys `pkgRequiredFields`, `purls`, `cpes`, `checksums` and `externalRefs` off the loop index, and `continue` leaves the index untouched, so those stay aligned with the packages they describe.

Three cases added to `TestNewSBOMDocumentFromBytes`, one per array. They panic without the change.

This is the same shape as #704, which guarded a nil `CreationInfo` in `parseDoc`.
