### PR TITLE
fix(licenses): derive free-for-any-use from AboutCode public domain

### DIFF
--- a/pkg/licenses/embed_licenses.go
+++ b/pkg/licenses/embed_licenses.go
@@ -50,7 +50,13 @@ type spdxLicenseDetail struct {
 	SeeAlso            []string `json:"seeAlso"`
 	IsOsiApproved      bool     `json:"isOsiApproved"`
 	IsFsfLibre         bool     `json:"isFsfLibre"`
-	IsFreeAnyUse       bool     `json:"isFreeAnyUse"`
+	// IsFreeAnyUse is never present in the SPDX license list, which publishes
+	// only isOsiApproved and isFsfLibre. It is decoded for forward
+	// compatibility and always unmarshals to false today; free-for-any-use is
+	// derived from the AboutCode `Public Domain` category instead, in
+	// overlayFreeAnyUseFromAboutCode. Regenerating files/licenses_spdx.json
+	// from upstream will not populate this.
+	IsFreeAnyUse bool `json:"isFreeAnyUse"`
 }
 
 type aboutCodeLicenseDetail struct {

--- a/pkg/licenses/embed_licenses.go
+++ b/pkg/licenses/embed_licenses.go
@@ -163,6 +163,16 @@ func loadAboutCodeLicense() error {
 			return true
 		}
 
+		// AboutCode introduced the `Non-Commercial` category and moved 209
+		// licenses into it, 24 of them out of categories we already treated as
+		// restrictive. Without this clause a license database refresh would
+		// silently reclassify the whole CC-BY-NC family, PolyForm-Noncommercial
+		// and FSL as unrestricted, which is backwards: a ban on commercial use
+		// is the restriction downstream consumers care about most.
+		if strings.Contains(lowerCategory, "non-commercial") {
+			return true
+		}
+
 		return false
 	}
 

--- a/pkg/licenses/files/licenses_aboutcode.json
+++ b/pkg/licenses/files/licenses_aboutcode.json
@@ -63,7 +63,7 @@
   },
   {
     "license_key": "a-star-logic-memoire-temp",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-a-star-logic-memoire-temp",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -111,7 +111,7 @@
   },
   {
     "license_key": "ac3filter",
-    "category": "Copyleft",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ac3filter",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -173,7 +173,7 @@
   },
   {
     "license_key": "acm-sla",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-acm-sla",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -221,7 +221,7 @@
   },
   {
     "license_key": "activestate-community",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-activestate-community",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -257,7 +257,7 @@
   },
   {
     "license_key": "activision-eula",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-activision-eula",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -582,6 +582,18 @@
     "license": "adobe-postscript.LICENSE"
   },
   {
+    "license_key": "adobe-research-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-adobe-research-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "adobe-research-2026.json",
+    "yaml": "adobe-research-2026.yml",
+    "html": "adobe-research-2026.html",
+    "license": "adobe-research-2026.LICENSE"
+  },
+  {
     "license_key": "adobe-scl",
     "category": "Permissive",
     "spdx_license_key": "Adobe-2006",
@@ -727,7 +739,7 @@
   },
   {
     "license_key": "afpl-8.0",
-    "category": "Copyleft",
+    "category": "Non-Commercial",
     "spdx_license_key": "Aladdin",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -739,7 +751,7 @@
   },
   {
     "license_key": "afpl-9.0",
-    "category": "Copyleft",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-afpl-9.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -799,7 +811,7 @@
   },
   {
     "license_key": "ago-private-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ago-private-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -940,6 +952,42 @@
     "license": "agtpl.LICENSE"
   },
   {
+    "license_key": "ai-sweden-llm-ai-model-2023",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-ai-sweden-llm-ai-model-2023",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ai-sweden-llm-ai-model-2023.json",
+    "yaml": "ai-sweden-llm-ai-model-2023.yml",
+    "html": "ai-sweden-llm-ai-model-2023.html",
+    "license": "ai-sweden-llm-ai-model-2023.LICENSE"
+  },
+  {
+    "license_key": "aikido-dual-agpl-commercial",
+    "category": "Copyleft",
+    "spdx_license_key": "LicenseRef-scancode-aikido-dual-agpl-commercial",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "aikido-dual-agpl-commercial.json",
+    "yaml": "aikido-dual-agpl-commercial.yml",
+    "html": "aikido-dual-agpl-commercial.html",
+    "license": "aikido-dual-agpl-commercial.LICENSE"
+  },
+  {
+    "license_key": "aixfunestudio-model-1.6",
+    "category": "Commercial",
+    "spdx_license_key": "LicenseRef-scancode-aixfunestudio-model-1.6",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "aixfunestudio-model-1.6.json",
+    "yaml": "aixfunestudio-model-1.6.yml",
+    "html": "aixfunestudio-model-1.6.html",
+    "license": "aixfunestudio-model-1.6.LICENSE"
+  },
+  {
     "license_key": "aladdin-md5",
     "category": "Permissive",
     "spdx_license_key": null,
@@ -953,7 +1001,7 @@
   },
   {
     "license_key": "alasir",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-alasir",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -965,7 +1013,7 @@
   },
   {
     "license_key": "aldor-public-2.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-aldor-public-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -1000,6 +1048,18 @@
     "license": "alfresco-exception-0.5.LICENSE"
   },
   {
+    "license_key": "alglib-documentation",
+    "category": "Permissive",
+    "spdx_license_key": "ALGLIB-Documentation",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "alglib-documentation.json",
+    "yaml": "alglib-documentation.yml",
+    "html": "alglib-documentation.html",
+    "license": "alglib-documentation.LICENSE"
+  },
+  {
     "license_key": "allegro-4",
     "category": "Permissive",
     "spdx_license_key": "Giftware",
@@ -1013,7 +1073,7 @@
   },
   {
     "license_key": "allen-institute-software-2018",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-allen-institute-software-2018",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -1034,6 +1094,18 @@
     "yaml": "alliance-open-media-patent-1.0.yml",
     "html": "alliance-open-media-patent-1.0.html",
     "license": "alliance-open-media-patent-1.0.LICENSE"
+  },
+  {
+    "license_key": "alphagenome-model-tou-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-alphagenome-model-tou-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "alphagenome-model-tou-2025.json",
+    "yaml": "alphagenome-model-tou-2025.yml",
+    "html": "alphagenome-model-tou-2025.html",
+    "license": "alphagenome-model-tou-2025.LICENSE"
   },
   {
     "license_key": "altermime",
@@ -1302,6 +1374,30 @@
     "license": "angi-1.0.LICENSE"
   },
   {
+    "license_key": "answercarefully-tou-2025",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-answercarefully-tou-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "answercarefully-tou-2025.json",
+    "yaml": "answercarefully-tou-2025.yml",
+    "html": "answercarefully-tou-2025.html",
+    "license": "answercarefully-tou-2025.LICENSE"
+  },
+  {
+    "license_key": "anthropic-commercial-tos-2025",
+    "category": "Commercial",
+    "spdx_license_key": "LicenseRef-scancode-anthropic-commercial-tos-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "anthropic-commercial-tos-2025.json",
+    "yaml": "anthropic-commercial-tos-2025.yml",
+    "html": "anthropic-commercial-tos-2025.html",
+    "license": "anthropic-commercial-tos-2025.LICENSE"
+  },
+  {
     "license_key": "anti-capitalist-1.4",
     "category": "Free Restricted",
     "spdx_license_key": "LicenseRef-scancode-anti-capitalist-1.4",
@@ -1512,7 +1608,7 @@
   },
   {
     "license_key": "apl-1.1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-apl-1.1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -1548,7 +1644,7 @@
   },
   {
     "license_key": "apple-academic-lisa-os-3.1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-apple-academic-lisa-os-3.1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -1728,7 +1824,7 @@
   },
   {
     "license_key": "aptana-1.0",
-    "category": "Copyleft Limited",
+    "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-aptana-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -1752,7 +1848,7 @@
   },
   {
     "license_key": "arachni-psl-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-arachni-psl-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -1773,6 +1869,18 @@
     "yaml": "aravindan-premkumar.yml",
     "html": "aravindan-premkumar.html",
     "license": "aravindan-premkumar.LICENSE"
+  },
+  {
+    "license_key": "arcinstitute-state-nc-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-arcinstitute-state-nc-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "arcinstitute-state-nc-2025.json",
+    "yaml": "arcinstitute-state-nc-2025.yml",
+    "html": "arcinstitute-state-nc-2025.html",
+    "license": "arcinstitute-state-nc-2025.LICENSE"
   },
   {
     "license_key": "argouml",
@@ -2294,7 +2402,7 @@
   },
   {
     "license_key": "autosar-proprietary",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-autosar-proprietary",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -2363,6 +2471,30 @@
     "yaml": "aws-ip-2021.yml",
     "html": "aws-ip-2021.html",
     "license": "aws-ip-2021.LICENSE"
+  },
+  {
+    "license_key": "axoniq-osla-1.0",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-axoniq-osla-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "axoniq-osla-1.0.json",
+    "yaml": "axoniq-osla-1.0.yml",
+    "html": "axoniq-osla-1.0.html",
+    "license": "axoniq-osla-1.0.LICENSE"
+  },
+  {
+    "license_key": "aydinnyunus-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-aydinnyunus-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "aydinnyunus-2025.json",
+    "yaml": "aydinnyunus-2025.yml",
+    "html": "aydinnyunus-2025.html",
+    "license": "aydinnyunus-2025.LICENSE"
   },
   {
     "license_key": "bacula-exception",
@@ -2782,7 +2914,7 @@
   },
   {
     "license_key": "bittorrent-eula",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-bittorrent-eula",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -2794,7 +2926,7 @@
   },
   {
     "license_key": "bitwarden-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-bitwarden-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -2915,8 +3047,10 @@
   {
     "license_key": "bola11",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-bola11",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "BOLA-1.1",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-bola11"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "bola11.json",
@@ -2973,6 +3107,18 @@
     "license": "borceux.LICENSE"
   },
   {
+    "license_key": "bosch-sensortec-2023",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-bosch-sensortec-2023",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "bosch-sensortec-2023.json",
+    "yaml": "bosch-sensortec-2023.yml",
+    "html": "bosch-sensortec-2023.html",
+    "license": "bosch-sensortec-2023.LICENSE"
+  },
+  {
     "license_key": "boutell-libgd-2021",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-boutell-libgd-2021",
@@ -3010,7 +3156,7 @@
   },
   {
     "license_key": "brad-martinez-vb-32",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-brad-martinez-vb-32",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -3019,6 +3165,18 @@
     "yaml": "brad-martinez-vb-32.yml",
     "html": "brad-martinez-vb-32.html",
     "license": "brad-martinez-vb-32.LICENSE"
+  },
+  {
+    "license_key": "brakeman-public-use",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-brakeman-public-use",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "brakeman-public-use.json",
+    "yaml": "brakeman-public-use.yml",
+    "html": "brakeman-public-use.html",
+    "license": "brakeman-public-use.LICENSE"
   },
   {
     "license_key": "brankas-open-license-1.0",
@@ -3547,6 +3705,18 @@
     "license": "bsd-3-clause-sun.LICENSE"
   },
   {
+    "license_key": "bsd-3-clause-tso",
+    "category": "Permissive",
+    "spdx_license_key": "BSD-3-Clause-Tso",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "bsd-3-clause-tso.json",
+    "yaml": "bsd-3-clause-tso.yml",
+    "html": "bsd-3-clause-tso.html",
+    "license": "bsd-3-clause-tso.LICENSE"
+  },
+  {
     "license_key": "bsd-4-clause-shortened",
     "category": "Permissive",
     "spdx_license_key": "BSD-4-Clause-Shortened",
@@ -3737,6 +3907,18 @@
     "yaml": "bsd-intel.yml",
     "html": "bsd-intel.html",
     "license": "bsd-intel.LICENSE"
+  },
+  {
+    "license_key": "bsd-mark-modifications",
+    "category": "Permissive",
+    "spdx_license_key": "BSD-Mark-Modifications",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "bsd-mark-modifications.json",
+    "yaml": "bsd-mark-modifications.yml",
+    "html": "bsd-mark-modifications.html",
+    "license": "bsd-mark-modifications.LICENSE"
   },
   {
     "license_key": "bsd-mylex",
@@ -4174,6 +4356,30 @@
     "license": "bsla-no-advert.LICENSE"
   },
   {
+    "license_key": "buddy",
+    "category": "Permissive",
+    "spdx_license_key": "Buddy",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "buddy.json",
+    "yaml": "buddy.yml",
+    "html": "buddy.html",
+    "license": "buddy.LICENSE"
+  },
+  {
+    "license_key": "budibase-sqs-2023",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-budibase-sqs-2023",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "budibase-sqs-2023.json",
+    "yaml": "budibase-sqs-2023.yml",
+    "html": "budibase-sqs-2023.html",
+    "license": "budibase-sqs-2023.LICENSE"
+  },
+  {
     "license_key": "bugsense-sdk",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-bugsense-sdk",
@@ -4196,6 +4402,18 @@
     "yaml": "bytemark.yml",
     "html": "bytemark.html",
     "license": "bytemark.LICENSE"
+  },
+  {
+    "license_key": "bzip2-libbzip-1.0.4",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-bzip2-libbzip-1.0.4",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "bzip2-libbzip-1.0.4.json",
+    "yaml": "bzip2-libbzip-1.0.4.yml",
+    "html": "bzip2-libbzip-1.0.4.html",
+    "license": "bzip2-libbzip-1.0.4.LICENSE"
   },
   {
     "license_key": "bzip2-libbzip-1.0.5",
@@ -4454,8 +4672,10 @@
   {
     "license_key": "capec-tou",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-capec-tou",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "CAPEC-tou",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-capec-tou"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "capec-tou.json",
@@ -4721,7 +4941,7 @@
   },
   {
     "license_key": "cc-by-nc-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4733,7 +4953,7 @@
   },
   {
     "license_key": "cc-by-nc-2.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4745,7 +4965,7 @@
   },
   {
     "license_key": "cc-by-nc-2.5",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-2.5",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4757,7 +4977,7 @@
   },
   {
     "license_key": "cc-by-nc-3.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4769,7 +4989,7 @@
   },
   {
     "license_key": "cc-by-nc-3.0-de",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-3.0-DE",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4781,7 +5001,7 @@
   },
   {
     "license_key": "cc-by-nc-4.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-4.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4793,7 +5013,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-ND-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4805,7 +5025,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-2.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-ND-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4817,7 +5037,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-2.0-at",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-cc-by-nc-nd-2.0-at",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4829,7 +5049,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-2.0-au",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-cc-by-nc-nd-2.0-au",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4841,7 +5061,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-2.5",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-ND-2.5",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4853,7 +5073,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-3.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-ND-3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4865,7 +5085,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-3.0-de",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-ND-3.0-DE",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4877,7 +5097,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-3.0-igo",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-ND-3.0-IGO",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4889,7 +5109,7 @@
   },
   {
     "license_key": "cc-by-nc-nd-4.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-ND-4.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4901,7 +5121,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4913,7 +5133,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-2.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4925,7 +5145,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-2.0-de",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-2.0-DE",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4937,7 +5157,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-2.0-fr",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-2.0-FR",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4949,7 +5169,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-2.0-uk",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-2.0-UK",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4961,7 +5181,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-2.5",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-2.5",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4973,7 +5193,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-3.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4985,7 +5205,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-3.0-de",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-3.0-DE",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -4997,7 +5217,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-3.0-igo",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-3.0-IGO",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5009,7 +5229,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-3.0-us",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-cc-by-nc-sa-3.0-us",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5021,7 +5241,7 @@
   },
   {
     "license_key": "cc-by-nc-sa-4.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "CC-BY-NC-SA-4.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5261,7 +5481,7 @@
   },
   {
     "license_key": "cc-nc-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-cc-nc-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5273,7 +5493,7 @@
   },
   {
     "license_key": "cc-nc-sampling-plus-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-cc-nc-sampling-plus-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5373,7 +5593,7 @@
   },
   {
     "license_key": "ccg-research-academic",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ccg-research-academic",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5382,6 +5602,18 @@
     "yaml": "ccg-research-academic.yml",
     "html": "ccg-research-academic.html",
     "license": "ccg-research-academic.LICENSE"
+  },
+  {
+    "license_key": "ccl-2026",
+    "category": "Commercial",
+    "spdx_license_key": "LicenseRef-scancode-ccl-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ccl-2026.json",
+    "yaml": "ccl-2026.yml",
+    "html": "ccl-2026.html",
+    "license": "ccl-2026.LICENSE"
   },
   {
     "license_key": "cclrc",
@@ -5721,7 +5953,7 @@
   },
   {
     "license_key": "chameleon-research-2024",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-chameleon-research-2024",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5733,7 +5965,7 @@
   },
   {
     "license_key": "charmpp-2019",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-charmpp-2019",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5745,7 +5977,7 @@
   },
   {
     "license_key": "charmpp-converse-2017",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-charmpp-converse-2017",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5757,7 +5989,7 @@
   },
   {
     "license_key": "chartdirector-6.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-chartdirector-6.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5853,7 +6085,7 @@
   },
   {
     "license_key": "christopher-velazquez",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-christopher-velazquez",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -5862,6 +6094,18 @@
     "yaml": "christopher-velazquez.yml",
     "html": "christopher-velazquez.html",
     "license": "christopher-velazquez.LICENSE"
+  },
+  {
+    "license_key": "circlestone-labs-nc-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-circlestone-labs-nc-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "circlestone-labs-nc-1.0.json",
+    "yaml": "circlestone-labs-nc-1.0.yml",
+    "html": "circlestone-labs-nc-1.0.html",
+    "license": "circlestone-labs-nc-1.0.LICENSE"
   },
   {
     "license_key": "cisco-avch264-patent",
@@ -6221,7 +6465,7 @@
   },
   {
     "license_key": "cockroachdb-2024-10-01",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-cockroachdb-2024-10-01",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -6344,6 +6588,18 @@
     "license": "cognitive-web-osl-1.1.LICENSE"
   },
   {
+    "license_key": "cogvideox-2024",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-cogvideox-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "cogvideox-2024.json",
+    "yaml": "cogvideox-2024.yml",
+    "html": "cogvideox-2024.html",
+    "license": "cogvideox-2024.LICENSE"
+  },
+  {
     "license_key": "coil-1.0",
     "category": "Permissive",
     "spdx_license_key": "COIL-1.0",
@@ -6428,6 +6684,18 @@
     "yaml": "commons-clause.yml",
     "html": "commons-clause.html",
     "license": "commons-clause.LICENSE"
+  },
+  {
+    "license_key": "comodo-available-source-sal",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-comodo-available-source-sal",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "comodo-available-source-sal.json",
+    "yaml": "comodo-available-source-sal.yml",
+    "html": "comodo-available-source-sal.html",
+    "license": "comodo-available-source-sal.LICENSE"
   },
   {
     "license_key": "compass",
@@ -6649,7 +6917,7 @@
   },
   {
     "license_key": "couchbase-enterprise",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-couchbase-enterprise",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -6952,6 +7220,18 @@
     "license": "cubiware-software-1.0.LICENSE"
   },
   {
+    "license_key": "cuffs-dataset-2024",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-cuffs-dataset-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "cuffs-dataset-2024.json",
+    "yaml": "cuffs-dataset-2024.yml",
+    "html": "cuffs-dataset-2024.html",
+    "license": "cuffs-dataset-2024.LICENSE"
+  },
+  {
     "license_key": "cups",
     "category": "Copyleft",
     "spdx_license_key": "LicenseRef-scancode-cups",
@@ -7194,6 +7474,18 @@
     "yaml": "databricks-dbx-2021.yml",
     "html": "databricks-dbx-2021.html",
     "license": "databricks-dbx-2021.LICENSE"
+  },
+  {
+    "license_key": "datajuggler-2019",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-datajuggler-2019",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "datajuggler-2019.json",
+    "yaml": "datajuggler-2019.yml",
+    "html": "datajuggler-2019.html",
+    "license": "datajuggler-2019.LICENSE"
   },
   {
     "license_key": "datamekanix-license",
@@ -7484,6 +7776,18 @@
     "license": "diffmark.LICENSE"
   },
   {
+    "license_key": "dify-exception-apache-2.0",
+    "category": "Commercial",
+    "spdx_license_key": "LicenseRef-scancode-dify-exception-apache-2.0",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "dify-exception-apache-2.0.json",
+    "yaml": "dify-exception-apache-2.0.yml",
+    "html": "dify-exception-apache-2.0.html",
+    "license": "dify-exception-apache-2.0.LICENSE"
+  },
+  {
     "license_key": "digia-qt-commercial",
     "category": "Commercial",
     "spdx_license_key": "LicenseRef-scancode-digia-qt-commercial",
@@ -7532,8 +7836,20 @@
     "license": "digirule-foss-exception.LICENSE"
   },
   {
+    "license_key": "directus-bsl-1.1",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-directus-bsl-1.1",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "directus-bsl-1.1.json",
+    "yaml": "directus-bsl-1.1.yml",
+    "html": "directus-bsl-1.1.html",
+    "license": "directus-bsl-1.1.LICENSE"
+  },
+  {
     "license_key": "divx-open-1.0",
-    "category": "Copyleft Limited",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-divx-open-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -7619,7 +7935,7 @@
   },
   {
     "license_key": "dl-de-by-nc-1-0-de",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-dl-de-by-nc-1-0-de",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -7631,7 +7947,7 @@
   },
   {
     "license_key": "dl-de-by-nc-1-0-en",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-dl-de-by-nc-1-0-en",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -7740,6 +8056,18 @@
     "license": "docbook-stylesheet.LICENSE"
   },
   {
+    "license_key": "dokploy-dsal-1.0",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-dokploy-dsal-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "dokploy-dsal-1.0.json",
+    "yaml": "dokploy-dsal-1.0.yml",
+    "html": "dokploy-dsal-1.0.html",
+    "license": "dokploy-dsal-1.0.LICENSE"
+  },
+  {
     "license_key": "dom4j",
     "category": "Permissive",
     "spdx_license_key": "Plexus",
@@ -7765,7 +8093,7 @@
   },
   {
     "license_key": "dosa-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-dosa-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -7774,6 +8102,18 @@
     "yaml": "dosa-1.0.yml",
     "html": "dosa-1.0.html",
     "license": "dosa-1.0.LICENSE"
+  },
+  {
+    "license_key": "dotcms-aug-2025",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-dotcms-aug-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "dotcms-aug-2025.json",
+    "yaml": "dotcms-aug-2025.yml",
+    "html": "dotcms-aug-2025.html",
+    "license": "dotcms-aug-2025.LICENSE"
   },
   {
     "license_key": "dotseqn",
@@ -8043,7 +8383,7 @@
   },
   {
     "license_key": "dynarch-linkware",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-dynarch-linkware",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -8091,7 +8431,7 @@
   },
   {
     "license_key": "ecl-gcl-2019",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ecl-gcl-2019",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -8551,7 +8891,7 @@
   },
   {
     "license_key": "embedthis-evaluation",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-embedthis-evaluation",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -8598,6 +8938,18 @@
     "license": "emit.LICENSE"
   },
   {
+    "license_key": "emq-use-grant-for-bsl-1.1",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-emq-use-grant-for-bsl-1.1",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "emq-use-grant-for-bsl-1.1.json",
+    "yaml": "emq-use-grant-for-bsl-1.1.yml",
+    "html": "emq-use-grant-for-bsl-1.1.html",
+    "license": "emq-use-grant-for-bsl-1.1.LICENSE"
+  },
+  {
     "license_key": "emx-library",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-emx-library",
@@ -8634,6 +8986,18 @@
     "license": "energyplus-bsd.LICENSE"
   },
   {
+    "license_key": "engram-quest-plugin-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-engram-quest-plugin-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "engram-quest-plugin-1.0.json",
+    "yaml": "engram-quest-plugin-1.0.yml",
+    "html": "engram-quest-plugin-1.0.html",
+    "license": "engram-quest-plugin-1.0.LICENSE"
+  },
+  {
     "license_key": "enhydra-1.1",
     "category": "Copyleft Limited",
     "spdx_license_key": "LicenseRef-scancode-enhydra-1.1",
@@ -8644,6 +9008,18 @@
     "yaml": "enhydra-1.1.yml",
     "html": "enhydra-1.1.html",
     "license": "enhydra-1.1.LICENSE"
+  },
+  {
+    "license_key": "enisa-legal-notice-2025",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-enisa-legal-notice-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "enisa-legal-notice-2025.json",
+    "yaml": "enisa-legal-notice-2025.yml",
+    "html": "enisa-legal-notice-2025.html",
+    "license": "enisa-legal-notice-2025.LICENSE"
   },
   {
     "license_key": "enlightenment",
@@ -8826,6 +9202,42 @@
     "license": "errbot-exception.LICENSE"
   },
   {
+    "license_key": "esa-pl-permissive-2.4",
+    "category": "Permissive",
+    "spdx_license_key": "ESA-PL-permissive-2.4",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "esa-pl-permissive-2.4.json",
+    "yaml": "esa-pl-permissive-2.4.yml",
+    "html": "esa-pl-permissive-2.4.html",
+    "license": "esa-pl-permissive-2.4.LICENSE"
+  },
+  {
+    "license_key": "esa-pl-strong-copyleft-2.4",
+    "category": "Permissive",
+    "spdx_license_key": "ESA-PL-strong-copyleft-2.4",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "esa-pl-strong-copyleft-2.4.json",
+    "yaml": "esa-pl-strong-copyleft-2.4.yml",
+    "html": "esa-pl-strong-copyleft-2.4.html",
+    "license": "esa-pl-strong-copyleft-2.4.LICENSE"
+  },
+  {
+    "license_key": "esa-pl-weak-copyleft-2.4",
+    "category": "Permissive",
+    "spdx_license_key": "ESA-PL-weak-copyleft-2.4",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "esa-pl-weak-copyleft-2.4.json",
+    "yaml": "esa-pl-weak-copyleft-2.4.yml",
+    "html": "esa-pl-weak-copyleft-2.4.html",
+    "license": "esa-pl-weak-copyleft-2.4.LICENSE"
+  },
+  {
     "license_key": "esri",
     "category": "Commercial",
     "spdx_license_key": "LicenseRef-scancode-esri",
@@ -8950,7 +9362,7 @@
   },
   {
     "license_key": "examdiff",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-examdiff",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -8962,7 +9374,7 @@
   },
   {
     "license_key": "exaone-ai-model-1.1-nc",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-exaone-ai-model-1.1-nc",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -8971,6 +9383,18 @@
     "yaml": "exaone-ai-model-1.1-nc.yml",
     "html": "exaone-ai-model-1.1-nc.html",
     "license": "exaone-ai-model-1.1-nc.LICENSE"
+  },
+  {
+    "license_key": "exaone-ai-model-1.2-nc",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-exaone-ai-model-1.2-nc",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "exaone-ai-model-1.2-nc.json",
+    "yaml": "exaone-ai-model-1.2-nc.yml",
+    "html": "exaone-ai-model-1.2-nc.html",
+    "license": "exaone-ai-model-1.2-nc.LICENSE"
   },
   {
     "license_key": "excelsior-jet-runtime",
@@ -9081,6 +9505,18 @@
     "license": "fair-ai-public-1.0-sd.LICENSE"
   },
   {
+    "license_key": "fair-chemistry-v1",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-fair-chemistry-v1",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "fair-chemistry-v1.json",
+    "yaml": "fair-chemistry-v1.yml",
+    "html": "fair-chemistry-v1.html",
+    "license": "fair-chemistry-v1.LICENSE"
+  },
+  {
     "license_key": "fair-source-0.9",
     "category": "Source-available",
     "spdx_license_key": "LicenseRef-scancode-fair-source-0.9",
@@ -9106,7 +9542,7 @@
   },
   {
     "license_key": "fancyzoom",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-fancyzoom",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9190,7 +9626,7 @@
   },
   {
     "license_key": "fcl-1.0-apache-2.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-fcl-1.0-apache-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9202,7 +9638,7 @@
   },
   {
     "license_key": "fcl-1.0-mit",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-fcl-1.0-mit",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9299,6 +9735,18 @@
     "license": "first-works-appreciative-1.2.LICENSE"
   },
   {
+    "license_key": "fish-audio-research-2026-03-07",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-fish-audio-research-2026-03-07",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "fish-audio-research-2026-03-07.json",
+    "yaml": "fish-audio-research-2026-03-07.yml",
+    "html": "fish-audio-research-2026-03-07.html",
+    "license": "fish-audio-research-2026-03-07.LICENSE"
+  },
+  {
     "license_key": "flex-2.5",
     "category": "Permissive",
     "spdx_license_key": "BSD-3-Clause-flex",
@@ -9323,6 +9771,18 @@
     "yaml": "flex2sdk.yml",
     "html": "flex2sdk.html",
     "license": "flex2sdk.LICENSE"
+  },
+  {
+    "license_key": "flexbyte",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-flexbyte",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "flexbyte.json",
+    "yaml": "flexbyte.yml",
+    "html": "flexbyte.html",
+    "license": "flexbyte.LICENSE"
   },
   {
     "license_key": "flora-1.1",
@@ -9398,7 +9858,7 @@
   },
   {
     "license_key": "flux-1-nc",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-flux-1-nc",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9814,7 +10274,7 @@
   },
   {
     "license_key": "fsl-1.0-apache-2.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-fsl-1.0-apache-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9826,7 +10286,7 @@
   },
   {
     "license_key": "fsl-1.0-mit",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-fsl-1.0-mit",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9838,7 +10298,7 @@
   },
   {
     "license_key": "fsl-1.1-apache-2.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "FSL-1.1-ALv2",
     "other_spdx_license_keys": [
       "LicenseRef-scancode-fsl-1.1-apache-2.0"
@@ -9852,7 +10312,7 @@
   },
   {
     "license_key": "fsl-1.1-mit",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "FSL-1.1-MIT",
     "other_spdx_license_keys": [
       "LicenseRef-scancode-fsl-1.1-mit"
@@ -9914,7 +10374,7 @@
   },
   {
     "license_key": "futo-sfl-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-futo-sfl-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9926,7 +10386,7 @@
   },
   {
     "license_key": "futo-sfl-1.1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-futo-sfl-1.1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -9938,7 +10398,7 @@
   },
   {
     "license_key": "futo-sfl-1.1-kb",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-futo-sfl-1.1-kb",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -10010,7 +10470,7 @@
   },
   {
     "license_key": "gaussian-splatting-2024",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-gaussian-splatting-2024",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -10084,7 +10544,7 @@
   },
   {
     "license_key": "gcel-2022",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-gcel-2022",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -10096,7 +10556,7 @@
   },
   {
     "license_key": "gco-v3.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-gco-v3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -10204,7 +10664,7 @@
   },
   {
     "license_key": "generic-amiwm",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-generic-amiwm",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -10338,7 +10798,7 @@
   },
   {
     "license_key": "geogebra-ncla-2022",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-geogebra-ncla-2022",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -10709,6 +11169,18 @@
     "yaml": "glide.yml",
     "html": "glide.html",
     "license": "glide.LICENSE"
+  },
+  {
+    "license_key": "glm-130b",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-glm-130b",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "glm-130b.json",
+    "yaml": "glm-130b.yml",
+    "html": "glm-130b.html",
+    "license": "glm-130b.LICENSE"
   },
   {
     "license_key": "glulxe",
@@ -12478,6 +12950,18 @@
     "license": "hdparm.LICENSE"
   },
   {
+    "license_key": "health-ai-developer-tou-2024",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-health-ai-developer-tou-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "health-ai-developer-tou-2024.json",
+    "yaml": "health-ai-developer-tou-2024.yml",
+    "html": "health-ai-developer-tou-2024.html",
+    "license": "health-ai-developer-tou-2024.LICENSE"
+  },
+  {
     "license_key": "helios-eula",
     "category": "Commercial",
     "spdx_license_key": "LicenseRef-scancode-helios-eula",
@@ -12491,7 +12975,7 @@
   },
   {
     "license_key": "helix",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-helix",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -12723,7 +13207,7 @@
   },
   {
     "license_key": "hp",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-hp",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -12759,7 +13243,7 @@
   },
   {
     "license_key": "hp-netperf",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-hp-netperf",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -12962,6 +13446,18 @@
     "license": "hpnd-sell-regexpr.LICENSE"
   },
   {
+    "license_key": "hpnd-sell-variant-critical-systems",
+    "category": "Permissive",
+    "spdx_license_key": "HPND-sell-variant-critical-systems",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "hpnd-sell-variant-critical-systems.json",
+    "yaml": "hpnd-sell-variant-critical-systems.yml",
+    "html": "hpnd-sell-variant-critical-systems.html",
+    "license": "hpnd-sell-variant-critical-systems.LICENSE"
+  },
+  {
     "license_key": "hpnd-sell-variant-mit-disclaimer",
     "category": "Permissive",
     "spdx_license_key": "HPND-sell-variant-MIT-disclaimer",
@@ -12984,6 +13480,18 @@
     "yaml": "hpnd-sell-variant-mit-disclaimer-rev.yml",
     "html": "hpnd-sell-variant-mit-disclaimer-rev.html",
     "license": "hpnd-sell-variant-mit-disclaimer-rev.LICENSE"
+  },
+  {
+    "license_key": "hpnd-smc",
+    "category": "Permissive",
+    "spdx_license_key": "HPND-SMC",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "hpnd-smc.json",
+    "yaml": "hpnd-smc.yml",
+    "html": "hpnd-smc.html",
+    "license": "hpnd-smc.LICENSE"
   },
   {
     "license_key": "hpnd-uc",
@@ -13104,6 +13612,18 @@
     "yaml": "hyperclova-x-seed-2025.yml",
     "html": "hyperclova-x-seed-2025.html",
     "license": "hyperclova-x-seed-2025.LICENSE"
+  },
+  {
+    "license_key": "hyphen-bulgarian",
+    "category": "Permissive",
+    "spdx_license_key": "hyphen-bulgarian",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "hyphen-bulgarian.json",
+    "yaml": "hyphen-bulgarian.yml",
+    "html": "hyphen-bulgarian.html",
+    "license": "hyphen-bulgarian.LICENSE"
   },
   {
     "license_key": "i2p-gpl-java-exception",
@@ -13481,7 +14001,7 @@
   },
   {
     "license_key": "imagen",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-imagen",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -13502,6 +14022,18 @@
     "yaml": "imlib2.yml",
     "html": "imlib2.html",
     "license": "imlib2.LICENSE"
+  },
+  {
+    "license_key": "inbox-zero-exception-3.0",
+    "category": "Copyleft",
+    "spdx_license_key": "LicenseRef-scancode-inbox-zero-exception-3.0",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "inbox-zero-exception-3.0.json",
+    "yaml": "inbox-zero-exception-3.0.yml",
+    "html": "inbox-zero-exception-3.0.html",
+    "license": "inbox-zero-exception-3.0.LICENSE"
   },
   {
     "license_key": "independent-module-linking-exception",
@@ -13716,7 +14248,7 @@
   },
   {
     "license_key": "inria-compcert",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-inria-compcert",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -13728,7 +14260,7 @@
   },
   {
     "license_key": "inria-icesl",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-inria-icesl",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -13754,7 +14286,7 @@
   },
   {
     "license_key": "inria-zelus",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-inria-zelus",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -13961,6 +14493,18 @@
     "license": "intel-osl-1993.LICENSE"
   },
   {
+    "license_key": "intel-research-use-2024",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-intel-research-use-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "intel-research-use-2024.json",
+    "yaml": "intel-research-use-2024.yml",
+    "html": "intel-research-use-2024.html",
+    "license": "intel-research-use-2024.LICENSE"
+  },
+  {
     "license_key": "intel-royalty-free",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-intel-royalty-free",
@@ -14109,8 +14653,10 @@
   {
     "license_key": "iso-8879",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-iso-8879",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "ISO-permission",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-iso-8879"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "iso-8879.json",
@@ -14129,6 +14675,18 @@
     "yaml": "iso-recorder.yml",
     "html": "iso-recorder.html",
     "license": "iso-recorder.LICENSE"
+  },
+  {
+    "license_key": "iso-schematron-19757-3",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-iso-schematron-19757-3",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "iso-schematron-19757-3.json",
+    "yaml": "iso-schematron-19757-3.yml",
+    "html": "iso-schematron-19757-3.html",
+    "license": "iso-schematron-19757-3.LICENSE"
   },
   {
     "license_key": "isotope-cla",
@@ -14338,7 +14896,7 @@
   },
   {
     "license_key": "java-research-1.5",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-java-research-1.5",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -14350,7 +14908,7 @@
   },
   {
     "license_key": "java-research-1.6",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-java-research-1.6",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -14434,7 +14992,7 @@
   },
   {
     "license_key": "jetbrains-toolbox-open-source-3",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-jetbrains-toolbox-oss-3",
     "other_spdx_license_keys": [
       "LicenseRef-scancode-jetbrains-toolbox-open-source-3"
@@ -14520,7 +15078,7 @@
   },
   {
     "license_key": "jmagnetic",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-jmagnetic",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -14544,7 +15102,7 @@
   },
   {
     "license_key": "joplin-server-personal-v1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-joplin-server-personal-v1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -14795,6 +15353,18 @@
     "license": "kalle-kaukonen.LICENSE"
   },
   {
+    "license_key": "kapivara-sal-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-kapivara-sal-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "kapivara-sal-1.0.json",
+    "yaml": "kapivara-sal-1.0.yml",
+    "html": "kapivara-sal-1.0.html",
+    "license": "kapivara-sal-1.0.LICENSE"
+  },
+  {
     "license_key": "karl-peterson",
     "category": "Free Restricted",
     "spdx_license_key": "LicenseRef-scancode-karl-peterson",
@@ -14841,6 +15411,18 @@
     "yaml": "katharos-0.2.0.yml",
     "html": "katharos-0.2.0.html",
     "license": "katharos-0.2.0.LICENSE"
+  },
+  {
+    "license_key": "katlang-patents-exception-mit",
+    "category": "Patent License",
+    "spdx_license_key": "LicenseRef-scancode-katlang-patents-exception-mit",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "katlang-patents-exception-mit.json",
+    "yaml": "katlang-patents-exception-mit.yml",
+    "html": "katlang-patents-exception-mit.html",
+    "license": "katlang-patents-exception-mit.LICENSE"
   },
   {
     "license_key": "kazlib",
@@ -14945,6 +15527,18 @@
     "license": "kevlin-henney.LICENSE"
   },
   {
+    "license_key": "keychron-sal-2024",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-keychron-sal-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "keychron-sal-2024.json",
+    "yaml": "keychron-sal-2024.yml",
+    "html": "keychron-sal-2024.html",
+    "license": "keychron-sal-2024.LICENSE"
+  },
+  {
     "license_key": "keypirinha",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-keypirinha",
@@ -15046,7 +15640,7 @@
   },
   {
     "license_key": "kubesphere-osl-2024",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-kubesphere-osl-2024",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -15067,6 +15661,18 @@
     "yaml": "kumar-robotics.yml",
     "html": "kumar-robotics.html",
     "license": "kumar-robotics.LICENSE"
+  },
+  {
+    "license_key": "kvirc-openssl-exception",
+    "category": "Copyleft Limited",
+    "spdx_license_key": "kvirc-openssl-exception",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "kvirc-openssl-exception.json",
+    "yaml": "kvirc-openssl-exception.yml",
+    "html": "kvirc-openssl-exception.html",
+    "license": "kvirc-openssl-exception.LICENSE"
   },
   {
     "license_key": "la-opt-nxp-v51-2023",
@@ -15343,6 +15949,18 @@
     "yaml": "leptonica.yml",
     "html": "leptonica.html",
     "license": "leptonica.LICENSE"
+  },
+  {
+    "license_key": "lfm-open-1.0",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-lfm-open-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "lfm-open-1.0.json",
+    "yaml": "lfm-open-1.0.yml",
+    "html": "lfm-open-1.0.html",
+    "license": "lfm-open-1.0.LICENSE"
   },
   {
     "license_key": "lgpl-2.0",
@@ -15812,6 +16430,18 @@
     "license": "librato-exception.LICENSE"
   },
   {
+    "license_key": "libroxml-exception-lgpl-2.1",
+    "category": "Copyleft Limited",
+    "spdx_license_key": "LicenseRef-scancode-libroxml-exception-lgpl-2.1",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "libroxml-exception-lgpl-2.1.json",
+    "yaml": "libroxml-exception-lgpl-2.1.yml",
+    "html": "libroxml-exception-lgpl-2.1.html",
+    "license": "libroxml-exception-lgpl-2.1.LICENSE"
+  },
+  {
     "license_key": "libselinux-pd",
     "category": "Public Domain",
     "spdx_license_key": "LicenseRef-scancode-libselinux-pd",
@@ -15968,6 +16598,18 @@
     "license": "liferay-marketplace-tos.LICENSE"
   },
   {
+    "license_key": "lightbend-use-grant-bsl-1.1",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-lightbend-use-grant-bsl-1.1",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "lightbend-use-grant-bsl-1.1.json",
+    "yaml": "lightbend-use-grant-bsl-1.1.yml",
+    "html": "lightbend-use-grant-bsl-1.1.html",
+    "license": "lightbend-use-grant-bsl-1.1.LICENSE"
+  },
+  {
     "license_key": "lil-1",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-lil-1",
@@ -16068,9 +16710,10 @@
   {
     "license_key": "linking-exception-lgpl-2.0-plus",
     "category": "Copyleft Limited",
-    "spdx_license_key": "LicenseRef-scancode-linking-exception-lgpl-2.0plus",
+    "spdx_license_key": "Classpath-exception-2.0-short",
     "other_spdx_license_keys": [
-      "LicenseRef-scancode-linking-exception-lgpl-2.0-plus"
+      "LicenseRef-scancode-linking-exception-lgpl-2.0-plus",
+      "LicenseRef-scancode-linking-exception-lgpl-2.0plus"
     ],
     "is_exception": true,
     "is_deprecated": false,
@@ -16212,6 +16855,18 @@
     "license": "linuxhowtos.LICENSE"
   },
   {
+    "license_key": "livekit-model-2024",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-livekit-model-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "livekit-model-2024.json",
+    "yaml": "livekit-model-2024.yml",
+    "html": "livekit-model-2024.html",
+    "license": "livekit-model-2024.LICENSE"
+  },
+  {
     "license_key": "llama-2-license-2023",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-llama-2-license-2023",
@@ -16285,7 +16940,7 @@
   },
   {
     "license_key": "llama-license-2023",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-llama-license-2023",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -16476,6 +17131,18 @@
     "yaml": "lsi-proprietary-eula.yml",
     "html": "lsi-proprietary-eula.html",
     "license": "lsi-proprietary-eula.LICENSE"
+  },
+  {
+    "license_key": "ltx-2-cla-2026",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-ltx-2-cla-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ltx-2-cla-2026.json",
+    "yaml": "ltx-2-cla-2026.yml",
+    "html": "ltx-2-cla-2026.html",
+    "license": "ltx-2-cla-2026.LICENSE"
   },
   {
     "license_key": "ltxv-owl-2025-04-17",
@@ -16769,7 +17436,7 @@
   },
   {
     "license_key": "mame",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-mame",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -17025,7 +17692,7 @@
   },
   {
     "license_key": "mcrae-pl-4-r53",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-mcrae-pl-4-r53",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -17037,7 +17704,7 @@
   },
   {
     "license_key": "mdl-2021",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-mdl-2021",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -17145,7 +17812,7 @@
   },
   {
     "license_key": "melange",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-melange",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -17169,7 +17836,7 @@
   },
   {
     "license_key": "menuet64-2024",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-menuet64-2024",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -17178,6 +17845,18 @@
     "yaml": "menuet64-2024.yml",
     "html": "menuet64-2024.html",
     "license": "menuet64-2024.LICENSE"
+  },
+  {
+    "license_key": "meralion-pl-2025",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-meralion-pl-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "meralion-pl-2025.json",
+    "yaml": "meralion-pl-2025.yml",
+    "html": "meralion-pl-2025.html",
+    "license": "meralion-pl-2025.LICENSE"
   },
   {
     "license_key": "merit-network-derivative",
@@ -17193,7 +17872,7 @@
   },
   {
     "license_key": "metageek-inssider-eula",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-metageek-inssider-eula",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -17238,6 +17917,18 @@
     "yaml": "mgb-1.0.yml",
     "html": "mgb-1.0.html",
     "license": "mgb-1.0.LICENSE"
+  },
+  {
+    "license_key": "mgb-brainiac-nc-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-mgb-brainiac-nc-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "mgb-brainiac-nc-2026.json",
+    "yaml": "mgb-brainiac-nc-2026.yml",
+    "html": "mgb-brainiac-nc-2026.html",
+    "license": "mgb-brainiac-nc-2026.LICENSE"
   },
   {
     "license_key": "mgopen-font-license",
@@ -17363,7 +18054,7 @@
   },
   {
     "license_key": "mike95",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-mike95",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -17376,8 +18067,10 @@
   {
     "license_key": "minecraft-mod",
     "category": "Proprietary Free",
-    "spdx_license_key": "LicenseRef-scancode-minecraft-mod",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "MMPL-1.0.1",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-minecraft-mod"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "minecraft-mod.json",
@@ -17408,6 +18101,42 @@
     "yaml": "mini-xml-exception-lgpl-2.0.yml",
     "html": "mini-xml-exception-lgpl-2.0.html",
     "license": "mini-xml-exception-lgpl-2.0.LICENSE"
+  },
+  {
+    "license_key": "minimax-mit-variant-2025",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-minimax-mit-variant-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "minimax-mit-variant-2025.json",
+    "yaml": "minimax-mit-variant-2025.yml",
+    "html": "minimax-mit-variant-2025.html",
+    "license": "minimax-mit-variant-2025.LICENSE"
+  },
+  {
+    "license_key": "minimax-model-m2.5",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-minimax-model-m2.5",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "minimax-model-m2.5.json",
+    "yaml": "minimax-model-m2.5.yml",
+    "html": "minimax-model-m2.5.html",
+    "license": "minimax-model-m2.5.LICENSE"
+  },
+  {
+    "license_key": "minimax-non-commercial-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-minimax-non-commercial-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "minimax-non-commercial-2026.json",
+    "yaml": "minimax-non-commercial-2026.yml",
+    "html": "minimax-non-commercial-2026.html",
+    "license": "minimax-non-commercial-2026.LICENSE"
   },
   {
     "license_key": "minpack",
@@ -17631,8 +18360,10 @@
   {
     "license_key": "mit-old-style",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-mit-old-style",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "Advanced-Cryptics-Dictionary",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-mit-old-style"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "mit-old-style.json",
@@ -17828,6 +18559,18 @@
     "yaml": "moderne-sala-2024.yml",
     "html": "moderne-sala-2024.html",
     "license": "moderne-sala-2024.LICENSE"
+  },
+  {
+    "license_key": "moe-speech",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-moe-speech",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "moe-speech.json",
+    "yaml": "moe-speech.yml",
+    "html": "moe-speech.html",
+    "license": "moe-speech.LICENSE"
   },
   {
     "license_key": "monetdb-1.1",
@@ -18531,7 +19274,7 @@
   },
   {
     "license_key": "ms-invisible-eula-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ms-invisible-eula-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -18931,7 +19674,7 @@
   },
   {
     "license_key": "ms-research-license-terms",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ms-research-license-terms",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -18943,7 +19686,7 @@
   },
   {
     "license_key": "ms-research-shared-source",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ms-research-shared-source",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -19666,6 +20409,18 @@
     "license": "mut-license.LICENSE"
   },
   {
+    "license_key": "mux0-sal-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-mux0-sal-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "mux0-sal-2026.json",
+    "yaml": "mux0-sal-2026.yml",
+    "html": "mux0-sal-2026.html",
+    "license": "mux0-sal-2026.LICENSE"
+  },
+  {
     "license_key": "mvt-1.1",
     "category": "Free Restricted",
     "spdx_license_key": "LicenseRef-scancode-mvt-1.1",
@@ -19691,7 +20446,7 @@
   },
   {
     "license_key": "mxparser-dual-2024-05-19",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-mxparser-dual-2024-05-19",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -19767,7 +20522,7 @@
   },
   {
     "license_key": "nanoporetech-public-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-nanoporetech-public-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -19838,6 +20593,30 @@
     "license": "nbpl-1.0.LICENSE"
   },
   {
+    "license_key": "nc-gov-public-sector-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-nc-gov-public-sector-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nc-gov-public-sector-1.0.json",
+    "yaml": "nc-gov-public-sector-1.0.yml",
+    "html": "nc-gov-public-sector-1.0.html",
+    "license": "nc-gov-public-sector-1.0.LICENSE"
+  },
+  {
+    "license_key": "nc-gov-public-sector-2.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-nc-gov-public-sector-2.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nc-gov-public-sector-2.0.json",
+    "yaml": "nc-gov-public-sector-2.0.yml",
+    "html": "nc-gov-public-sector-2.0.html",
+    "license": "nc-gov-public-sector-2.0.LICENSE"
+  },
+  {
     "license_key": "ncbi",
     "category": "Public Domain",
     "spdx_license_key": "NCBI-PD",
@@ -19853,7 +20632,7 @@
   },
   {
     "license_key": "ncgl-uk-2.0",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "NCGL-UK-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -19874,6 +20653,30 @@
     "yaml": "ncsa-httpd-1995.yml",
     "html": "ncsa-httpd-1995.html",
     "license": "ncsa-httpd-1995.LICENSE"
+  },
+  {
+    "license_key": "ncsc-nl-disclaimer",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-ncsc-nl-disclaimer",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ncsc-nl-disclaimer.json",
+    "yaml": "ncsc-nl-disclaimer.yml",
+    "html": "ncsc-nl-disclaimer.html",
+    "license": "ncsc-nl-disclaimer.LICENSE"
+  },
+  {
+    "license_key": "nemotron-open-model-2025-12-15",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-nemotron-open-model-2025-12-15",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nemotron-open-model-2025-12-15.json",
+    "yaml": "nemotron-open-model-2025-12-15.yml",
+    "html": "nemotron-open-model-2025-12-15.html",
+    "license": "nemotron-open-model-2025-12-15.LICENSE"
   },
   {
     "license_key": "nero-eula",
@@ -20070,6 +20873,18 @@
     "license": "newton-king-cla.LICENSE"
   },
   {
+    "license_key": "nexar-dataset-2025",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-nexar-dataset-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nexar-dataset-2025.json",
+    "yaml": "nexar-dataset-2025.yml",
+    "html": "nexar-dataset-2025.html",
+    "license": "nexar-dataset-2025.LICENSE"
+  },
+  {
     "license_key": "nexb-eula-saas-1.1.0",
     "category": "Commercial",
     "spdx_license_key": "LicenseRef-scancode-nexb-eula-saas-1.1.0",
@@ -20214,6 +21029,18 @@
     "yaml": "nist-pd-fallback.yml",
     "html": "nist-pd-fallback.html",
     "license": "nist-pd-fallback.LICENSE"
+  },
+  {
+    "license_key": "nist-pd-tnt",
+    "category": "Public Domain",
+    "spdx_license_key": "NIST-PD-TNT",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nist-pd-tnt.json",
+    "yaml": "nist-pd-tnt.yml",
+    "html": "nist-pd-tnt.html",
+    "license": "nist-pd-tnt.LICENSE"
   },
   {
     "license_key": "nist-software",
@@ -20614,6 +21441,18 @@
     "license": "ntpl-origin.LICENSE"
   },
   {
+    "license_key": "ntuitive-la-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-ntuitive-la-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ntuitive-la-2025.json",
+    "yaml": "ntuitive-la-2025.yml",
+    "html": "ntuitive-la-2025.html",
+    "license": "ntuitive-la-2025.LICENSE"
+  },
+  {
     "license_key": "nucleusicons-eula",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-nucleusicons-eula",
@@ -20660,6 +21499,30 @@
     "yaml": "nvidia.yml",
     "html": "nvidia.html",
     "license": "nvidia.LICENSE"
+  },
+  {
+    "license_key": "nvidia-1-way-commercial",
+    "category": "Commercial",
+    "spdx_license_key": "LicenseRef-scancode-nvidia-1-way-commercial",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nvidia-1-way-commercial.json",
+    "yaml": "nvidia-1-way-commercial.yml",
+    "html": "nvidia-1-way-commercial.html",
+    "license": "nvidia-1-way-commercial.LICENSE"
+  },
+  {
+    "license_key": "nvidia-1-way-noncommercial",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-nvidia-1-way-noncommercial",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nvidia-1-way-noncommercial.json",
+    "yaml": "nvidia-1-way-noncommercial.yml",
+    "html": "nvidia-1-way-noncommercial.html",
+    "license": "nvidia-1-way-noncommercial.LICENSE"
   },
   {
     "license_key": "nvidia-2002",
@@ -20736,6 +21599,18 @@
     "license": "nvidia-isaac-eula-2019.1.LICENSE"
   },
   {
+    "license_key": "nvidia-isaac-ros-2021",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-nvidia-isaac-ros-2021",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nvidia-isaac-ros-2021.json",
+    "yaml": "nvidia-isaac-ros-2021.yml",
+    "html": "nvidia-isaac-ros-2021.html",
+    "license": "nvidia-isaac-ros-2021.LICENSE"
+  },
+  {
     "license_key": "nvidia-model-training-2025",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-nvidia-model-training-2025",
@@ -20770,6 +21645,18 @@
     "yaml": "nvidia-ngx-eula-2019.yml",
     "html": "nvidia-ngx-eula-2019.html",
     "license": "nvidia-ngx-eula-2019.LICENSE"
+  },
+  {
+    "license_key": "nvidia-open-model-2025",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-nvidia-open-model-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nvidia-open-model-2025.json",
+    "yaml": "nvidia-open-model-2025.yml",
+    "html": "nvidia-open-model-2025.html",
+    "license": "nvidia-open-model-2025.LICENSE"
   },
   {
     "license_key": "nvidia-open-model-2025-04-28",
@@ -20808,6 +21695,18 @@
     "license": "nvidia-sdk-eula-v0.11.LICENSE"
   },
   {
+    "license_key": "nvidia-source-code-nc-2024",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-nvidia-source-code-nc-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nvidia-source-code-nc-2024.json",
+    "yaml": "nvidia-source-code-nc-2024.yml",
+    "html": "nvidia-source-code-nc-2024.html",
+    "license": "nvidia-source-code-nc-2024.LICENSE"
+  },
+  {
     "license_key": "nvidia-video-codec-agreement",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-nvidia-video-codec-agreement",
@@ -20842,6 +21741,18 @@
     "yaml": "nxlog-public-license-1.0.yml",
     "html": "nxlog-public-license-1.0.html",
     "license": "nxlog-public-license-1.0.LICENSE"
+  },
+  {
+    "license_key": "nxml-pokemon-legends-za-nc-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-nxml-pokemon-legends-za-nc-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "nxml-pokemon-legends-za-nc-1.0.json",
+    "yaml": "nxml-pokemon-legends-za-nc-1.0.yml",
+    "html": "nxml-pokemon-legends-za-nc-1.0.html",
+    "license": "nxml-pokemon-legends-za-nc-1.0.LICENSE"
   },
   {
     "license_key": "nxp-firmware-patent",
@@ -21029,7 +21940,7 @@
   },
   {
     "license_key": "ocamlpro-nc-v1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ocamlpro-nc-v1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -21098,6 +22009,18 @@
     "yaml": "occt-pl.yml",
     "html": "occt-pl.html",
     "license": "occt-pl.LICENSE"
+  },
+  {
+    "license_key": "ocl-v1",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-ocl-v1",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ocl-v1.json",
+    "yaml": "ocl-v1.yml",
+    "html": "ocl-v1.html",
+    "license": "ocl-v1.LICENSE"
   },
   {
     "license_key": "oclc-1.0",
@@ -21184,6 +22107,18 @@
     "license": "oculus-sdk-3.5.LICENSE"
   },
   {
+    "license_key": "ocvsal-1.0",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-ocvsal-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ocvsal-1.0.json",
+    "yaml": "ocvsal-1.0.yml",
+    "html": "ocvsal-1.0.html",
+    "license": "ocvsal-1.0.LICENSE"
+  },
+  {
     "license_key": "odb-cpl",
     "category": "Commercial",
     "spdx_license_key": "LicenseRef-scancode-odb-cpl",
@@ -21194,6 +22129,18 @@
     "yaml": "odb-cpl.yml",
     "html": "odb-cpl.html",
     "license": "odb-cpl.LICENSE"
+  },
+  {
+    "license_key": "odb-floss-exception-2.0",
+    "category": "Copyleft",
+    "spdx_license_key": "LicenseRef-scancode-odb-floss-exception-2.0",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "odb-floss-exception-2.0.json",
+    "yaml": "odb-floss-exception-2.0.yml",
+    "html": "odb-floss-exception-2.0.html",
+    "license": "odb-floss-exception-2.0.LICENSE"
   },
   {
     "license_key": "odb-fpl",
@@ -21209,7 +22156,7 @@
   },
   {
     "license_key": "odb-ncuel",
-    "category": "Copyleft",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-odb-ncuel",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -21403,7 +22350,7 @@
   },
   {
     "license_key": "ofrak-community-1.0",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ofrak-community-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -21415,7 +22362,7 @@
   },
   {
     "license_key": "ofrak-community-1.1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ofrak-community-1.1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -21679,7 +22626,7 @@
   },
   {
     "license_key": "onezoom-np-sal-v1",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-onezoom-np-sal-v1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -21703,7 +22650,7 @@
   },
   {
     "license_key": "open-aleph-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-open-aleph-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -21811,7 +22758,7 @@
   },
   {
     "license_key": "opencarp-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-opencarp-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -22116,8 +23063,10 @@
   {
     "license_key": "openmdw-1.0",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-openmdw-1.0",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "OpenMDW-1.0",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-openmdw-1.0"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "openmdw-1.0.json",
@@ -22175,7 +23124,7 @@
   },
   {
     "license_key": "openpbs-2.3",
-    "category": "Copyleft Limited",
+    "category": "Non-Commercial",
     "spdx_license_key": "OpenPBS-2.3",
     "other_spdx_license_keys": [
       "LicenseRef-scancode-openpbs-2.3"
@@ -22554,6 +23503,18 @@
     "license": "opnl-2.0.LICENSE"
   },
   {
+    "license_key": "opt-175b-2022",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-opt-175b-2022",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "opt-175b-2022.json",
+    "yaml": "opt-175b-2022.yml",
+    "html": "opt-175b-2022.html",
+    "license": "opt-175b-2022.LICENSE"
+  },
+  {
     "license_key": "oracle-bcl-javaee",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-oracle-bcl-javaee",
@@ -22591,7 +23552,7 @@
   },
   {
     "license_key": "oracle-bcl-javase-platform-javafx-2013",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-oracle-bcl-java-platform-2013",
     "other_spdx_license_keys": [
       "LicenseRef-scancode-oracle-bcl-javase-platform-javafx-2013"
@@ -22702,6 +23663,18 @@
     "yaml": "oracle-free-2018.yml",
     "html": "oracle-free-2018.html",
     "license": "oracle-free-2018.LICENSE"
+  },
+  {
+    "license_key": "oracle-free-2021",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-oracle-free-2021",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "oracle-free-2021.json",
+    "yaml": "oracle-free-2021.yml",
+    "html": "oracle-free-2021.html",
+    "license": "oracle-free-2021.LICENSE"
   },
   {
     "license_key": "oracle-gftc-2023-06-12",
@@ -22817,7 +23790,7 @@
   },
   {
     "license_key": "oracle-web-sites-tou",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-oracle-web-sites-tou",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -22862,6 +23835,30 @@
     "yaml": "os4d-1.1-apache-2.0.yml",
     "html": "os4d-1.1-apache-2.0.html",
     "license": "os4d-1.1-apache-2.0.LICENSE"
+  },
+  {
+    "license_key": "osassy-2025",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-osassy-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "osassy-2025.json",
+    "yaml": "osassy-2025.yml",
+    "html": "osassy-2025.html",
+    "license": "osassy-2025.LICENSE"
+  },
+  {
+    "license_key": "osc-1.0",
+    "category": "Permissive",
+    "spdx_license_key": "OSC-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "osc-1.0.json",
+    "yaml": "osc-1.0.yml",
+    "html": "osc-1.0.html",
+    "license": "osc-1.0.LICENSE"
   },
   {
     "license_key": "oset-pl-2.1",
@@ -22975,7 +23972,7 @@
   },
   {
     "license_key": "ossn-3.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-ossn-3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -22986,8 +23983,20 @@
     "license": "ossn-3.0.LICENSE"
   },
   {
+    "license_key": "ossp",
+    "category": "Permissive",
+    "spdx_license_key": "OSSP",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ossp.json",
+    "yaml": "ossp.yml",
+    "html": "ossp.html",
+    "license": "ossp.LICENSE"
+  },
+  {
     "license_key": "osvdb",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-osvdb",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23049,7 +24058,7 @@
   },
   {
     "license_key": "otn-dev-dist-2009",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-otn-dev-dist-2009",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23085,7 +24094,7 @@
   },
   {
     "license_key": "otn-early-adopter-2018",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-otn-early-adopter-2018",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23097,7 +24106,7 @@
   },
   {
     "license_key": "otn-early-adopter-development",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-otn-early-adopter-development",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23312,6 +24321,18 @@
     "license": "paolo-messina-2000.LICENSE"
   },
   {
+    "license_key": "paratype-free-font-1.3",
+    "category": "Permissive",
+    "spdx_license_key": "ParaType-Free-Font-1.3",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "paratype-free-font-1.3.json",
+    "yaml": "paratype-free-font-1.3.yml",
+    "html": "paratype-free-font-1.3.html",
+    "license": "paratype-free-font-1.3.LICENSE"
+  },
+  {
     "license_key": "paraview-1.2",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-paraview-1.2",
@@ -23349,7 +24370,7 @@
   },
   {
     "license_key": "passive-aggressive",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-passive-aggressive",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23482,6 +24503,18 @@
     "yaml": "pbl-1.0.yml",
     "html": "pbl-1.0.html",
     "license": "pbl-1.0.LICENSE"
+  },
+  {
+    "license_key": "pcgexelementszonegraph-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-pcgexelementszonegraph-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "pcgexelementszonegraph-2026.json",
+    "yaml": "pcgexelementszonegraph-2026.yml",
+    "html": "pcgexelementszonegraph-2026.html",
+    "license": "pcgexelementszonegraph-2026.LICENSE"
   },
   {
     "license_key": "pcre",
@@ -23619,7 +24652,7 @@
   },
   {
     "license_key": "pftus-1.1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-pftus-1.1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23631,7 +24664,7 @@
   },
   {
     "license_key": "phaser-academic",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-phaser-academic",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23764,6 +24797,18 @@
     "license": "php-3.01.LICENSE"
   },
   {
+    "license_key": "pi-lab-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-pi-lab-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "pi-lab-1.0.json",
+    "yaml": "pi-lab-1.0.yml",
+    "html": "pi-lab-1.0.html",
+    "license": "pi-lab-1.0.LICENSE"
+  },
+  {
     "license_key": "pine",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-pine",
@@ -23777,7 +24822,7 @@
   },
   {
     "license_key": "pipedream-sal-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-pipedream-sal-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -23822,6 +24867,18 @@
     "yaml": "pixar.yml",
     "html": "pixar.html",
     "license": "pixar.LICENSE"
+  },
+  {
+    "license_key": "plamo-cla-2024",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-plamo-cla-2024",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "plamo-cla-2024.json",
+    "yaml": "plamo-cla-2024.yml",
+    "html": "plamo-cla-2024.html",
+    "license": "plamo-cla-2024.LICENSE"
   },
   {
     "license_key": "planet-source-code",
@@ -23908,6 +24965,18 @@
     "license": "pnmstitch.LICENSE"
   },
   {
+    "license_key": "poke-wiggle-proprietary-2026",
+    "category": "Commercial",
+    "spdx_license_key": "LicenseRef-scancode-poke-wiggle-proprietary-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "poke-wiggle-proprietary-2026.json",
+    "yaml": "poke-wiggle-proprietary-2026.yml",
+    "html": "poke-wiggle-proprietary-2026.html",
+    "license": "poke-wiggle-proprietary-2026.LICENSE"
+  },
+  {
     "license_key": "politepix-pl-1.0",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-politepix-pl-1.0",
@@ -23957,7 +25026,7 @@
   },
   {
     "license_key": "polyform-noncommercial-1.0.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "PolyForm-Noncommercial-1.0.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -24007,7 +25076,7 @@
   },
   {
     "license_key": "polyform-strict-1.0.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-polyform-strict-1.0.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -24154,7 +25223,7 @@
   },
   {
     "license_key": "prosperity-1.0.1",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-prosperity-1.0.1",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -24178,7 +25247,7 @@
   },
   {
     "license_key": "prosperity-3.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-prosperity-3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -24691,7 +25760,7 @@
   },
   {
     "license_key": "quadratic-sal-2024",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-quadratic-sal-2024",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -24738,6 +25807,18 @@
     "license": "quickfix-1.0.LICENSE"
   },
   {
+    "license_key": "quicknet-document-1999",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-quicknet-document-1999",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "quicknet-document-1999.json",
+    "yaml": "quicknet-document-1999.yml",
+    "html": "quicknet-document-1999.html",
+    "license": "quicknet-document-1999.LICENSE"
+  },
+  {
     "license_key": "quicktime",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-quicktime",
@@ -24751,7 +25832,7 @@
   },
   {
     "license_key": "quin-street",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-quin-street",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -24897,7 +25978,7 @@
   },
   {
     "license_key": "rcsl-2.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-rcsl-2.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -24909,7 +25990,7 @@
   },
   {
     "license_key": "rcsl-3.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-rcsl-3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -25081,7 +26162,7 @@
   },
   {
     "license_key": "research-disclaimer",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-research-disclaimer",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -25116,6 +26197,18 @@
     "license": "responsible-ai-source-1.1.LICENSE"
   },
   {
+    "license_key": "resume-summarization-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-resume-summarization-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "resume-summarization-2025.json",
+    "yaml": "resume-summarization-2025.yml",
+    "html": "resume-summarization-2025.html",
+    "license": "resume-summarization-2025.LICENSE"
+  },
+  {
     "license_key": "retentioneering-2023",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-retentioneering-2023",
@@ -25138,6 +26231,18 @@
     "yaml": "retype-3.7.0.yml",
     "html": "retype-3.7.0.html",
     "license": "retype-3.7.0.LICENSE"
+  },
+  {
+    "license_key": "rexgradient-nc",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-rexgradient-nc",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "rexgradient-nc.json",
+    "yaml": "rexgradient-nc.yml",
+    "html": "rexgradient-nc.html",
+    "license": "rexgradient-nc.LICENSE"
   },
   {
     "license_key": "rh-eula",
@@ -25344,6 +26449,18 @@
     "license": "rogue-wave.LICENSE"
   },
   {
+    "license_key": "roofsuit-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-roofsuit-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "roofsuit-2025.json",
+    "yaml": "roofsuit-2025.yml",
+    "html": "roofsuit-2025.html",
+    "license": "roofsuit-2025.LICENSE"
+  },
+  {
     "license_key": "root-cert-3.0",
     "category": "Proprietary Free",
     "spdx_license_key": "LicenseRef-scancode-root-cert-3.0",
@@ -25354,6 +26471,18 @@
     "yaml": "root-cert-3.0.yml",
     "html": "root-cert-3.0.html",
     "license": "root-cert-3.0.LICENSE"
+  },
+  {
+    "license_key": "rosetta-software-nc-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-rosetta-software-nc-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "rosetta-software-nc-2026.json",
+    "yaml": "rosetta-software-nc-2026.yml",
+    "html": "rosetta-software-nc-2026.html",
+    "license": "rosetta-software-nc-2026.LICENSE"
   },
   {
     "license_key": "rpl-1.1",
@@ -25443,7 +26572,7 @@
   },
   {
     "license_key": "rsa-md2",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-rsa-md2",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -25491,7 +26620,7 @@
   },
   {
     "license_key": "rsalv2",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-rsalv2",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -25500,6 +26629,18 @@
     "yaml": "rsalv2.yml",
     "html": "rsalv2.html",
     "license": "rsalv2.LICENSE"
+  },
+  {
+    "license_key": "rsync-linking-exception",
+    "category": "Copyleft Limited",
+    "spdx_license_key": "rsync-linking-exception",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "rsync-linking-exception.json",
+    "yaml": "rsync-linking-exception.yml",
+    "html": "rsync-linking-exception.html",
+    "license": "rsync-linking-exception.LICENSE"
   },
   {
     "license_key": "rtems-exception-2.0",
@@ -25587,7 +26728,7 @@
   },
   {
     "license_key": "rwth-returnn-2024",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-rwth-returnn-2024",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -25623,7 +26764,7 @@
   },
   {
     "license_key": "s-lab-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-s-lab-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -25683,7 +26824,7 @@
   },
   {
     "license_key": "salesforce-ai-ethics-2025",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-salesforce-ai-ethics-2025",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -25716,6 +26857,18 @@
     "yaml": "salesforcesans-font.yml",
     "html": "salesforcesans-font.html",
     "license": "salesforcesans-font.LICENSE"
+  },
+  {
+    "license_key": "sam-2025-11-19",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-sam-2025-11-19",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "sam-2025-11-19.json",
+    "yaml": "sam-2025-11-19.yml",
+    "html": "sam-2025-11-19.html",
+    "license": "sam-2025-11-19.LICENSE"
   },
   {
     "license_key": "samba-dc-1.0",
@@ -25780,6 +26933,18 @@
     "license": "sash.LICENSE"
   },
   {
+    "license_key": "sat-uk-choral-ai-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-sat-uk-choral-ai-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "sat-uk-choral-ai-1.0.json",
+    "yaml": "sat-uk-choral-ai-1.0.yml",
+    "html": "sat-uk-choral-ai-1.0.html",
+    "license": "sat-uk-choral-ai-1.0.LICENSE"
+  },
+  {
     "license_key": "sata",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-sata",
@@ -25838,6 +27003,18 @@
     "yaml": "saxpath.yml",
     "html": "saxpath.html",
     "license": "saxpath.LICENSE"
+  },
+  {
+    "license_key": "saxs-synthetic-commercial-1.0",
+    "category": "Commercial",
+    "spdx_license_key": "LicenseRef-scancode-saxs-synthetic-commercial-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "saxs-synthetic-commercial-1.0.json",
+    "yaml": "saxs-synthetic-commercial-1.0.yml",
+    "html": "saxs-synthetic-commercial-1.0.html",
+    "license": "saxs-synthetic-commercial-1.0.LICENSE"
   },
   {
     "license_key": "sbia-b",
@@ -25913,7 +27090,7 @@
   },
   {
     "license_key": "scilab-en-2005",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-scilab-en",
     "other_spdx_license_keys": [
       "LicenseRef-scancode-scilba-en"
@@ -25927,7 +27104,7 @@
   },
   {
     "license_key": "scilab-fr",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-scilab-fr",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26023,7 +27200,7 @@
   },
   {
     "license_key": "scsl-2.8",
-    "category": "Copyleft Limited",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-scsl-2.8",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26035,7 +27212,7 @@
   },
   {
     "license_key": "scsl-3.0",
-    "category": "Copyleft Limited",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-scsl-3.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26056,6 +27233,18 @@
     "yaml": "scylladb-sla-1.0.yml",
     "html": "scylladb-sla-1.0.html",
     "license": "scylladb-sla-1.0.LICENSE"
+  },
+  {
+    "license_key": "seamless-2023",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-seamless-2023",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "seamless-2023.json",
+    "yaml": "seamless-2023.yml",
+    "html": "seamless-2023.html",
+    "license": "seamless-2023.LICENSE"
   },
   {
     "license_key": "secret-labs-2011",
@@ -26336,8 +27525,10 @@
   {
     "license_key": "sgmlug",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-sgmlug",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "SGMLUG-PM",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-sgmlug"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "sgmlug.json",
@@ -26455,7 +27646,7 @@
   },
   {
     "license_key": "siesta-academic-individuals",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-siesta-academic-individuals",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26467,7 +27658,7 @@
   },
   {
     "license_key": "siesta-computer-centres",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-siesta-computer-centres",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26526,6 +27717,18 @@
     "license": "simpl-2.0.LICENSE"
   },
   {
+    "license_key": "simple-library-usage-exception",
+    "category": "Copyleft Limited",
+    "spdx_license_key": "Simple-Library-Usage-exception",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "simple-library-usage-exception.json",
+    "yaml": "simple-library-usage-exception.yml",
+    "html": "simple-library-usage-exception.html",
+    "license": "simple-library-usage-exception.LICENSE"
+  },
+  {
     "license_key": "six-labors-split-1.0",
     "category": "Free Restricted",
     "spdx_license_key": "LicenseRef-scancode-six-labors-split-1.0",
@@ -26548,6 +27751,18 @@
     "yaml": "skip-2014.yml",
     "html": "skip-2014.html",
     "license": "skip-2014.LICENSE"
+  },
+  {
+    "license_key": "skunkworks-varuna-stt",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-skunkworks-varuna-stt",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "skunkworks-varuna-stt.json",
+    "yaml": "skunkworks-varuna-stt.yml",
+    "html": "skunkworks-varuna-stt.html",
+    "license": "skunkworks-varuna-stt.LICENSE"
   },
   {
     "license_key": "sl",
@@ -26622,6 +27837,18 @@
     "license": "slint-royalty-free-1.0.LICENSE"
   },
   {
+    "license_key": "slipnet-sal-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-slipnet-sal-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "slipnet-sal-2026.json",
+    "yaml": "slipnet-sal-2026.yml",
+    "html": "slipnet-sal-2026.html",
+    "license": "slipnet-sal-2026.LICENSE"
+  },
+  {
     "license_key": "slysoft-eula",
     "category": "Commercial",
     "spdx_license_key": "LicenseRef-scancode-slysoft-eula",
@@ -26673,7 +27900,7 @@
   },
   {
     "license_key": "smsc-non-commercial-2012",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-smsc-non-commercial-2012",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26682,6 +27909,18 @@
     "yaml": "smsc-non-commercial-2012.yml",
     "html": "smsc-non-commercial-2012.html",
     "license": "smsc-non-commercial-2012.LICENSE"
+  },
+  {
+    "license_key": "snap-nc-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-snap-nc-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "snap-nc-2025.json",
+    "yaml": "snap-nc-2025.yml",
+    "html": "snap-nc-2025.html",
+    "license": "snap-nc-2025.LICENSE"
   },
   {
     "license_key": "snapeda-design-exception-1.0",
@@ -26718,6 +27957,18 @@
     "yaml": "snmp4j-smi.yml",
     "html": "snmp4j-smi.html",
     "license": "snmp4j-smi.LICENSE"
+  },
+  {
+    "license_key": "snofs-1.1",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-snofs-1.1",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "snofs-1.1.json",
+    "yaml": "snofs-1.1.yml",
+    "html": "snofs-1.1.html",
+    "license": "snofs-1.1.LICENSE"
   },
   {
     "license_key": "snort-subscriber-rules-3.1",
@@ -26757,7 +28008,7 @@
   },
   {
     "license_key": "snowplow-person-academic-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-snowplow-person-academic-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26780,6 +28031,18 @@
     "yaml": "snprintf.yml",
     "html": "snprintf.html",
     "license": "snprintf.LICENSE"
+  },
+  {
+    "license_key": "socigy-nc-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-socigy-nc-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "socigy-nc-2026.json",
+    "yaml": "socigy-nc-2026.yml",
+    "html": "socigy-nc-2026.html",
+    "license": "socigy-nc-2026.LICENSE"
   },
   {
     "license_key": "socketxx-2003",
@@ -26869,7 +28132,7 @@
   },
   {
     "license_key": "solace-software-eula-2020",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-solace-software-eula-2020",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -26902,6 +28165,18 @@
     "yaml": "sonar-sal-1.0.yml",
     "html": "sonar-sal-1.0.html",
     "license": "sonar-sal-1.0.LICENSE"
+  },
+  {
+    "license_key": "sonar-sal-1.0.1",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-sonar-sal-1.0.1",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "sonar-sal-1.0.1.json",
+    "yaml": "sonar-sal-1.0.1.yml",
+    "html": "sonar-sal-1.0.1.html",
+    "license": "sonar-sal-1.0.1.LICENSE"
   },
   {
     "license_key": "soundex",
@@ -27028,6 +28303,18 @@
     "license": "splunk-sla.LICENSE"
   },
   {
+    "license_key": "sqlitestudio-openssl-exception",
+    "category": "Copyleft Limited",
+    "spdx_license_key": "sqlitestudio-OpenSSL-exception",
+    "other_spdx_license_keys": [],
+    "is_exception": true,
+    "is_deprecated": false,
+    "json": "sqlitestudio-openssl-exception.json",
+    "yaml": "sqlitestudio-openssl-exception.yml",
+    "html": "sqlitestudio-openssl-exception.html",
+    "license": "sqlitestudio-openssl-exception.LICENSE"
+  },
+  {
     "license_key": "square-cla",
     "category": "CLA",
     "spdx_license_key": "LicenseRef-scancode-square-cla",
@@ -27127,7 +28414,7 @@
   },
   {
     "license_key": "stability-ai-community-2024",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-stability-ai-community-2024",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -27139,7 +28426,7 @@
   },
   {
     "license_key": "stability-ai-nc-2023-12-06",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-stability-ai-nc-2023-12-06",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -27857,7 +29144,7 @@
   },
   {
     "license_key": "sun-prop-non-commercial",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-sun-prop-non-commercial",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -28003,7 +29290,7 @@
   },
   {
     "license_key": "sustainable-use-1.0",
-    "category": "Free Restricted",
+    "category": "Non-Commercial",
     "spdx_license_key": "SUL-1.0",
     "other_spdx_license_keys": [
       "LicenseRef-scancode-sustainable-use-1.0"
@@ -28150,8 +29437,10 @@
   {
     "license_key": "synthesis-toolkit",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-synthesis-toolkit",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "MIT-STK",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-synthesis-toolkit"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "synthesis-toolkit.json",
@@ -28278,6 +29567,18 @@
     "yaml": "t-license-tkse.yml",
     "html": "t-license-tkse.html",
     "license": "t-license-tkse.LICENSE"
+  },
+  {
+    "license_key": "tabpfn-2.6-v1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-tabpfn-2.6-v1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "tabpfn-2.6-v1.0.json",
+    "yaml": "tabpfn-2.6-v1.0.yml",
+    "html": "tabpfn-2.6-v1.0.html",
+    "license": "tabpfn-2.6-v1.0.LICENSE"
   },
   {
     "license_key": "takao-abe",
@@ -28462,8 +29763,10 @@
   {
     "license_key": "tekhvc",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-tekhvc",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "TekHVC",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-tekhvc"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "tekhvc.json",
@@ -28497,7 +29800,7 @@
   },
   {
     "license_key": "tenable-nessus",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-tenable-nessus",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -28518,6 +29821,18 @@
     "yaml": "tencent-hunyuan-3d-2.0-cla.yml",
     "html": "tencent-hunyuan-3d-2.0-cla.html",
     "license": "tencent-hunyuan-3d-2.0-cla.LICENSE"
+  },
+  {
+    "license_key": "tencent-hunyuan-image-3.0-cla",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-tencent-hunyuan-image-3.0-cla",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "tencent-hunyuan-image-3.0-cla.json",
+    "yaml": "tencent-hunyuan-image-3.0-cla.yml",
+    "html": "tencent-hunyuan-image-3.0-cla.html",
+    "license": "tencent-hunyuan-image-3.0-cla.LICENSE"
   },
   {
     "license_key": "term-readkey",
@@ -28720,6 +30035,18 @@
     "license": "ti-restricted.LICENSE"
   },
   {
+    "license_key": "ti-text-file",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-ti-text-file",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "ti-text-file.json",
+    "yaml": "ti-text-file.yml",
+    "html": "ti-text-file.html",
+    "license": "ti-text-file.LICENSE"
+  },
+  {
     "license_key": "tidy",
     "category": "Permissive",
     "spdx_license_key": "HTMLTIDY",
@@ -28742,6 +30069,18 @@
     "yaml": "tiger-crypto.yml",
     "html": "tiger-crypto.html",
     "license": "tiger-crypto.LICENSE"
+  },
+  {
+    "license_key": "tigerdataset-nc-2025",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-tigerdataset-nc-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "tigerdataset-nc-2025.json",
+    "yaml": "tigerdataset-nc-2025.yml",
+    "html": "tigerdataset-nc-2025.html",
+    "license": "tigerdataset-nc-2025.LICENSE"
   },
   {
     "license_key": "tigra-calendar-3.2",
@@ -29021,7 +30360,7 @@
   },
   {
     "license_key": "triptracker",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-triptracker",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -29105,7 +30444,7 @@
   },
   {
     "license_key": "tsl-2018",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-tsl-2018",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -29671,8 +31010,10 @@
   {
     "license_key": "unrar",
     "category": "Source-available",
-    "spdx_license_key": "LicenseRef-scancode-unrar",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "UnRAR",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-unrar"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "unrar.json",
@@ -29718,7 +31059,7 @@
   },
   {
     "license_key": "uofu-rfpl",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-uofu-rfpl",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -29751,6 +31092,18 @@
     "yaml": "upl-1.0.yml",
     "html": "upl-1.0.html",
     "license": "upl-1.0.LICENSE"
+  },
+  {
+    "license_key": "upstage-solar-2026-01-16",
+    "category": "Permissive",
+    "spdx_license_key": "LicenseRef-scancode-upstage-solar-2026-01-16",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "upstage-solar-2026-01-16.json",
+    "yaml": "upstage-solar-2026-01-16.yml",
+    "html": "upstage-solar-2026-01-16.html",
+    "license": "upstage-solar-2026-01-16.LICENSE"
   },
   {
     "license_key": "upx-exception-2.0-plus",
@@ -29862,7 +31215,7 @@
   },
   {
     "license_key": "vanderbilt-sla-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-vanderbilt-sla-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -29898,7 +31251,7 @@
   },
   {
     "license_key": "vcvrack-exception-to-gpl-3.0",
-    "category": "Copyleft Limited",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-vcvrack-exception-to-gpl-3.0",
     "other_spdx_license_keys": [],
     "is_exception": true,
@@ -30058,8 +31411,10 @@
   {
     "license_key": "vixie-cron",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-vixie-cron",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "Vixie-Cron",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-vixie-cron"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "vixie-cron.json",
@@ -30093,7 +31448,7 @@
   },
   {
     "license_key": "volla-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-volla-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -30189,7 +31544,7 @@
   },
   {
     "license_key": "vvvvvv-scl-1.0",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-vvvvvv-scl-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -30404,6 +31759,30 @@
     "license": "waterfall-feed-parser.LICENSE"
   },
   {
+    "license_key": "weinbach-non-commercial-1.0",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-weinbach-non-commercial-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "weinbach-non-commercial-1.0.json",
+    "yaml": "weinbach-non-commercial-1.0.yml",
+    "html": "weinbach-non-commercial-1.0.html",
+    "license": "weinbach-non-commercial-1.0.LICENSE"
+  },
+  {
+    "license_key": "wender-media-sal-1.0",
+    "category": "Source-available",
+    "spdx_license_key": "LicenseRef-scancode-wender-media-sal-1.0",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "wender-media-sal-1.0.json",
+    "yaml": "wender-media-sal-1.0.yml",
+    "html": "wender-media-sal-1.0.html",
+    "license": "wender-media-sal-1.0.LICENSE"
+  },
+  {
     "license_key": "westhawk",
     "category": "Permissive",
     "spdx_license_key": "LicenseRef-scancode-westhawk",
@@ -30438,6 +31817,18 @@
     "yaml": "whitecat.yml",
     "html": "whitecat.html",
     "license": "whitecat.LICENSE"
+  },
+  {
+    "license_key": "whitedns-sal-nc-2026",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-whitedns-sal-nc-2026",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "whitedns-sal-nc-2026.json",
+    "yaml": "whitedns-sal-nc-2026.yml",
+    "html": "whitedns-sal-nc-2026.html",
+    "license": "whitedns-sal-nc-2026.LICENSE"
   },
   {
     "license_key": "whosonfirst-license",
@@ -30610,14 +32001,28 @@
   {
     "license_key": "wordnet",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-wordnet",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "WordNet",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-wordnet"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "wordnet.json",
     "yaml": "wordnet.yml",
     "html": "wordnet.html",
     "license": "wordnet.LICENSE"
+  },
+  {
+    "license_key": "writer-open-model-2024-05-31",
+    "category": "Non-Commercial",
+    "spdx_license_key": "LicenseRef-scancode-writer-open-model-2024-05-31",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "writer-open-model-2024-05-31.json",
+    "yaml": "writer-open-model-2024-05-31.yml",
+    "html": "writer-open-model-2024-05-31.html",
+    "license": "writer-open-model-2024-05-31.LICENSE"
   },
   {
     "license_key": "wrox",
@@ -30694,8 +32099,10 @@
   {
     "license_key": "wtfnmfpl-1.0",
     "category": "Permissive",
-    "spdx_license_key": "LicenseRef-scancode-wtfnmfpl-1.0",
-    "other_spdx_license_keys": [],
+    "spdx_license_key": "WTFNMFPL",
+    "other_spdx_license_keys": [
+      "LicenseRef-scancode-wtfnmfpl-1.0"
+    ],
     "is_exception": false,
     "is_deprecated": false,
     "json": "wtfnmfpl-1.0.json",
@@ -31014,6 +32421,18 @@
     "license": "x11-lucent-variant.LICENSE"
   },
   {
+    "license_key": "x11-no-permit-persons",
+    "category": "Permissive",
+    "spdx_license_key": "X11-no-permit-persons",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "x11-no-permit-persons.json",
+    "yaml": "x11-no-permit-persons.yml",
+    "html": "x11-no-permit-persons.html",
+    "license": "x11-no-permit-persons.LICENSE"
+  },
+  {
     "license_key": "x11-oar",
     "category": "Permissive",
     "spdx_license_key": "OAR",
@@ -31214,8 +32633,20 @@
     "license": "x11r5-authors.LICENSE"
   },
   {
-    "license_key": "xceed-community-2021",
+    "license_key": "xai-cla-2025",
     "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-xai-cla-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "xai-cla-2025.json",
+    "yaml": "xai-cla-2025.yml",
+    "html": "xai-cla-2025.html",
+    "license": "xai-cla-2025.LICENSE"
+  },
+  {
+    "license_key": "xceed-community-2021",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-xceed-community-2021",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -31419,7 +32850,7 @@
   },
   {
     "license_key": "yahoo-browserplus-eula",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-yahoo-browserplus-eula",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -31431,7 +32862,7 @@
   },
   {
     "license_key": "yahoo-messenger-eula",
-    "category": "Proprietary Free",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-yahoo-messenger-eula",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -31452,6 +32883,18 @@
     "yaml": "yale-cas.yml",
     "html": "yale-cas.html",
     "license": "yale-cas.LICENSE"
+  },
+  {
+    "license_key": "yandexgpt-5-lite-8b-2025",
+    "category": "Proprietary Free",
+    "spdx_license_key": "LicenseRef-scancode-yandexgpt-5-lite-8b-2025",
+    "other_spdx_license_keys": [],
+    "is_exception": false,
+    "is_deprecated": false,
+    "json": "yandexgpt-5-lite-8b-2025.json",
+    "yaml": "yandexgpt-5-lite-8b-2025.yml",
+    "html": "yandexgpt-5-lite-8b-2025.html",
+    "license": "yandexgpt-5-lite-8b-2025.LICENSE"
   },
   {
     "license_key": "yensdesign",
@@ -31539,7 +32982,7 @@
   },
   {
     "license_key": "zeebe-community-1.0",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-zeebe-community-1.0",
     "other_spdx_license_keys": [],
     "is_exception": false,
@@ -31551,7 +32994,7 @@
   },
   {
     "license_key": "zeebe-community-1.1",
-    "category": "Source-available",
+    "category": "Non-Commercial",
     "spdx_license_key": "LicenseRef-scancode-zeebe-community-1.1",
     "other_spdx_license_keys": [],
     "is_exception": false,

--- a/pkg/licenses/files/licenses_spdx.json
+++ b/pkg/licenses/files/licenses_spdx.json
@@ -1,16 +1,16 @@
 {
-  "licenseListVersion": "2e6a0e5",
+  "licenseListVersion": "e4c1f27",
   "licenses": [
     {
       "reference": "https://spdx.org/licenses/0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/0BSD.json",
-      "referenceNumber": 415,
+      "referenceNumber": 627,
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
         "http://landley.net/toybox/license.html",
-        "https://opensource.org/licenses/0BSD"
+        "https://opensource.org/license/0BSD"
       ],
       "isOsiApproved": true
     },
@@ -18,7 +18,7 @@
       "reference": "https://spdx.org/licenses/3D-Slicer-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/3D-Slicer-1.0.json",
-      "referenceNumber": 131,
+      "referenceNumber": 314,
       "name": "3D Slicer License v1.0",
       "licenseId": "3D-Slicer-1.0",
       "seeAlso": [
@@ -31,11 +31,11 @@
       "reference": "https://spdx.org/licenses/AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AAL.json",
-      "referenceNumber": 87,
+      "referenceNumber": 23,
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
-        "https://opensource.org/licenses/attribution"
+        "https://opensource.org/license/AAL"
       ],
       "isOsiApproved": true
     },
@@ -43,7 +43,7 @@
       "reference": "https://spdx.org/licenses/Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": 15,
+      "referenceNumber": 585,
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -55,7 +55,7 @@
       "reference": "https://spdx.org/licenses/AdaCore-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AdaCore-doc.json",
-      "referenceNumber": 288,
+      "referenceNumber": 342,
       "name": "AdaCore Doc License",
       "licenseId": "AdaCore-doc",
       "seeAlso": [
@@ -69,7 +69,7 @@
       "reference": "https://spdx.org/licenses/Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": 367,
+      "referenceNumber": 506,
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -81,7 +81,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Display-PostScript.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Display-PostScript.json",
-      "referenceNumber": 143,
+      "referenceNumber": 175,
       "name": "Adobe Display PostScript License",
       "licenseId": "Adobe-Display-PostScript",
       "seeAlso": [
@@ -93,7 +93,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": 338,
+      "referenceNumber": 376,
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -105,7 +105,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Utopia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Utopia.json",
-      "referenceNumber": 118,
+      "referenceNumber": 140,
       "name": "Adobe Utopia Font License",
       "licenseId": "Adobe-Utopia",
       "seeAlso": [
@@ -117,7 +117,7 @@
       "reference": "https://spdx.org/licenses/ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ADSL.json",
-      "referenceNumber": 250,
+      "referenceNumber": 320,
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -129,7 +129,7 @@
       "reference": "https://spdx.org/licenses/Advanced-Cryptics-Dictionary.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Advanced-Cryptics-Dictionary.json",
-      "referenceNumber": 498,
+      "referenceNumber": 136,
       "name": "Advanced Cryptics Dictionary License",
       "licenseId": "Advanced-Cryptics-Dictionary",
       "seeAlso": [
@@ -141,7 +141,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": 121,
+      "referenceNumber": 730,
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -155,7 +155,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": 489,
+      "referenceNumber": 92,
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -169,7 +169,7 @@
       "reference": "https://spdx.org/licenses/AFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": 480,
+      "referenceNumber": 281,
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -182,11 +182,13 @@
       "reference": "https://spdx.org/licenses/AFL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": 450,
+      "referenceNumber": 477,
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
+        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt",
+        "https://web.archive.org/web/20061013013632/http://opensource.linux-mirror.org/licenses/afl-2.1.txt",
+        "https://gitlab.freedesktop.org/dbus/dbus/-/blob/789d97ad53044f94351a958e785c2923643b346a/COPYING#L11-207"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -195,12 +197,12 @@
       "reference": "https://spdx.org/licenses/AFL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": 472,
+      "referenceNumber": 634,
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
         "http://www.rosenlaw.com/AFL3.0.htm",
-        "https://opensource.org/licenses/afl-3.0"
+        "https://opensource.org/license/AFL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -209,7 +211,7 @@
       "reference": "https://spdx.org/licenses/Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": 554,
+      "referenceNumber": 75,
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -221,7 +223,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": 629,
+      "referenceNumber": 142,
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -234,7 +236,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": 659,
+      "referenceNumber": 273,
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -246,7 +248,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": 13,
+      "referenceNumber": 30,
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -258,12 +260,12 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": 82,
+      "referenceNumber": 699,
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
         "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
+        "https://opensource.org/license/AGPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -272,12 +274,12 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": 668,
+      "referenceNumber": 514,
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
+        "https://opensource.org/license/AGPL-3.0-only"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -286,12 +288,12 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": 389,
+      "referenceNumber": 455,
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
+        "https://opensource.org/license/AGPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -300,7 +302,7 @@
       "reference": "https://spdx.org/licenses/Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": 696,
+      "referenceNumber": 434,
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -310,10 +312,20 @@
       "isFsfLibre": false
     },
     {
+      "reference": "https://spdx.org/licenses/ALGLIB-Documentation.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ALGLIB-Documentation.json",
+      "referenceNumber": 68,
+      "name": "ALGLIB Documentation License",
+      "licenseId": "ALGLIB-Documentation",
+      "seeAlso": [],
+      "isOsiApproved": true
+    },
+    {
       "reference": "https://spdx.org/licenses/AMD-newlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMD-newlib.json",
-      "referenceNumber": 434,
+      "referenceNumber": 524,
       "name": "AMD newlib License",
       "licenseId": "AMD-newlib",
       "seeAlso": [
@@ -325,7 +337,7 @@
       "reference": "https://spdx.org/licenses/AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": 630,
+      "referenceNumber": 151,
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -337,7 +349,7 @@
       "reference": "https://spdx.org/licenses/AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML.json",
-      "referenceNumber": 598,
+      "referenceNumber": 517,
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -349,7 +361,7 @@
       "reference": "https://spdx.org/licenses/AML-glslang.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML-glslang.json",
-      "referenceNumber": 80,
+      "referenceNumber": 288,
       "name": "AML glslang variant License",
       "licenseId": "AML-glslang",
       "seeAlso": [
@@ -362,7 +374,7 @@
       "reference": "https://spdx.org/licenses/AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": 261,
+      "referenceNumber": 338,
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -374,7 +386,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": 373,
+      "referenceNumber": 245,
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -386,7 +398,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
-      "referenceNumber": 75,
+      "referenceNumber": 485,
       "name": "ANTLR Software Rights Notice with license fallback",
       "licenseId": "ANTLR-PD-fallback",
       "seeAlso": [
@@ -398,7 +410,7 @@
       "reference": "https://spdx.org/licenses/any-OSI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/any-OSI.json",
-      "referenceNumber": 348,
+      "referenceNumber": 205,
       "name": "Any OSI License",
       "licenseId": "any-OSI",
       "seeAlso": [
@@ -410,7 +422,7 @@
       "reference": "https://spdx.org/licenses/any-OSI-perl-modules.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/any-OSI-perl-modules.json",
-      "referenceNumber": 399,
+      "referenceNumber": 554,
       "name": "Any OSI License - Perl Modules",
       "licenseId": "any-OSI-perl-modules",
       "seeAlso": [
@@ -424,7 +436,7 @@
       "reference": "https://spdx.org/licenses/Apache-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": 680,
+      "referenceNumber": 409,
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -437,12 +449,12 @@
       "reference": "https://spdx.org/licenses/Apache-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": 218,
+      "referenceNumber": 624,
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
         "http://apache.org/licenses/LICENSE-1.1",
-        "https://opensource.org/licenses/Apache-1.1"
+        "https://opensource.org/license/apache-1.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -451,13 +463,12 @@
       "reference": "https://spdx.org/licenses/Apache-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": 101,
+      "referenceNumber": 505,
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
         "https://www.apache.org/licenses/LICENSE-2.0",
-        "https://opensource.org/licenses/Apache-2.0",
-        "https://opensource.org/license/apache-2-0"
+        "https://opensource.org/license/apache-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -466,7 +477,7 @@
       "reference": "https://spdx.org/licenses/APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APAFML.json",
-      "referenceNumber": 130,
+      "referenceNumber": 90,
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -478,11 +489,11 @@
       "reference": "https://spdx.org/licenses/APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": 154,
+      "referenceNumber": 623,
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/APL-1.0"
+        "https://opensource.org/license/APL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -490,7 +501,7 @@
       "reference": "https://spdx.org/licenses/App-s2p.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
-      "referenceNumber": 416,
+      "referenceNumber": 430,
       "name": "App::s2p License",
       "licenseId": "App-s2p",
       "seeAlso": [
@@ -502,7 +513,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": 684,
+      "referenceNumber": 301,
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -515,7 +526,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": 573,
+      "referenceNumber": 15,
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -539,7 +550,7 @@
       "reference": "https://spdx.org/licenses/APSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": 352,
+      "referenceNumber": 471,
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -552,7 +563,7 @@
       "reference": "https://spdx.org/licenses/Arphic-1999.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
-      "referenceNumber": 268,
+      "referenceNumber": 128,
       "name": "Arphic Public License",
       "licenseId": "Arphic-1999",
       "seeAlso": [
@@ -564,11 +575,11 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": 372,
+      "referenceNumber": 510,
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Artistic-1.0"
+        "https://opensource.org/license/Artistic-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": false
@@ -577,11 +588,11 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": 478,
+      "referenceNumber": 315,
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
-        "https://opensource.org/licenses/Artistic-1.0"
+        "https://opensource.org/license/Artistic-1.0"
       ],
       "isOsiApproved": true
     },
@@ -589,7 +600,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": 403,
+      "referenceNumber": 134,
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -601,13 +612,13 @@
       "reference": "https://spdx.org/licenses/Artistic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": 619,
+      "referenceNumber": 332,
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
         "http://www.perlfoundation.org/artistic_license_2_0",
         "https://www.perlfoundation.org/artistic-license-20.html",
-        "https://opensource.org/licenses/artistic-license-2.0"
+        "https://opensource.org/license/Artistic-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -616,7 +627,7 @@
       "reference": "https://spdx.org/licenses/Artistic-dist.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-dist.json",
-      "referenceNumber": 600,
+      "referenceNumber": 475,
       "name": "Artistic License 1.0 (dist)",
       "licenseId": "Artistic-dist",
       "seeAlso": [
@@ -628,7 +639,7 @@
       "reference": "https://spdx.org/licenses/Aspell-RU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Aspell-RU.json",
-      "referenceNumber": 356,
+      "referenceNumber": 43,
       "name": "Aspell Russian License",
       "licenseId": "Aspell-RU",
       "seeAlso": [
@@ -640,7 +651,7 @@
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.json",
-      "referenceNumber": 182,
+      "referenceNumber": 192,
       "name": "ASWF Digital Assets License version 1.0",
       "licenseId": "ASWF-Digital-Assets-1.0",
       "seeAlso": [
@@ -652,7 +663,7 @@
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.json",
-      "referenceNumber": 602,
+      "referenceNumber": 345,
       "name": "ASWF Digital Assets License 1.1",
       "licenseId": "ASWF-Digital-Assets-1.1",
       "seeAlso": [
@@ -661,10 +672,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/atc-game.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/atc-game.json",
+      "referenceNumber": 528,
+      "name": "atc Game License",
+      "licenseId": "atc-game",
+      "seeAlso": [
+        "https://github.com/vattam/BSDGames/blob/master/atc/extern.c#L36"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Baekmuk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
-      "referenceNumber": 559,
+      "referenceNumber": 328,
       "name": "Baekmuk License",
       "licenseId": "Baekmuk",
       "seeAlso": [
@@ -676,7 +699,7 @@
       "reference": "https://spdx.org/licenses/Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": 513,
+      "referenceNumber": 45,
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -688,7 +711,7 @@
       "reference": "https://spdx.org/licenses/Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Barr.json",
-      "referenceNumber": 529,
+      "referenceNumber": 731,
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -700,7 +723,7 @@
       "reference": "https://spdx.org/licenses/bcrypt-Solar-Designer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bcrypt-Solar-Designer.json",
-      "referenceNumber": 492,
+      "referenceNumber": 466,
       "name": "bcrypt Solar Designer License",
       "licenseId": "bcrypt-Solar-Designer",
       "seeAlso": [
@@ -712,7 +735,7 @@
       "reference": "https://spdx.org/licenses/Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Beerware.json",
-      "referenceNumber": 429,
+      "referenceNumber": 226,
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -725,7 +748,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Charter.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Charter.json",
-      "referenceNumber": 216,
+      "referenceNumber": 660,
       "name": "Bitstream Charter Font License",
       "licenseId": "Bitstream-Charter",
       "seeAlso": [
@@ -738,7 +761,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
-      "referenceNumber": 671,
+      "referenceNumber": 365,
       "name": "Bitstream Vera Font License",
       "licenseId": "Bitstream-Vera",
       "seeAlso": [
@@ -751,7 +774,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": 222,
+      "referenceNumber": 74,
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -763,7 +786,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": 369,
+      "referenceNumber": 217,
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -776,7 +799,7 @@
       "reference": "https://spdx.org/licenses/blessing.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/blessing.json",
-      "referenceNumber": 604,
+      "referenceNumber": 190,
       "name": "SQLite Blessing",
       "licenseId": "blessing",
       "seeAlso": [
@@ -789,7 +812,7 @@
       "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
-      "referenceNumber": 510,
+      "referenceNumber": 41,
       "name": "Blue Oak Model License 1.0.0",
       "licenseId": "BlueOak-1.0.0",
       "seeAlso": [
@@ -801,7 +824,7 @@
       "reference": "https://spdx.org/licenses/Boehm-GC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Boehm-GC.json",
-      "referenceNumber": 238,
+      "referenceNumber": 121,
       "name": "Boehm-Demers-Weiser GC License",
       "licenseId": "Boehm-GC",
       "seeAlso": [
@@ -815,7 +838,7 @@
       "reference": "https://spdx.org/licenses/Boehm-GC-without-fee.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Boehm-GC-without-fee.json",
-      "referenceNumber": 572,
+      "referenceNumber": 501,
       "name": "Boehm-Demers-Weiser GC License (without fee)",
       "licenseId": "Boehm-GC-without-fee",
       "seeAlso": [
@@ -824,10 +847,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/BOLA-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BOLA-1.1.json",
+      "referenceNumber": 116,
+      "name": "Buena Onda License Agreement v1.1",
+      "licenseId": "BOLA-1.1",
+      "seeAlso": [
+        "https://blitiri.com.ar/p/bola/"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Borceux.json",
-      "referenceNumber": 65,
+      "referenceNumber": 352,
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -839,7 +874,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-2-Clause.json",
-      "referenceNumber": 522,
+      "referenceNumber": 67,
       "name": "Brian Gladman 2-Clause License",
       "licenseId": "Brian-Gladman-2-Clause",
       "seeAlso": [
@@ -852,7 +887,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause.json",
-      "referenceNumber": 473,
+      "referenceNumber": 726,
       "name": "Brian Gladman 3-Clause License",
       "licenseId": "Brian-Gladman-3-Clause",
       "seeAlso": [
@@ -861,10 +896,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause-no-conversion.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause-no-conversion.json",
+      "referenceNumber": 679,
+      "name": "Brian Gladman 3-Clause License (no conversion clause)",
+      "licenseId": "Brian-Gladman-3-Clause-no-conversion",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/kfw-4.0.1-beta1/src/lib/crypto/builtin/aes/aesopt.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": 709,
+      "referenceNumber": 268,
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -876,11 +923,11 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": 427,
+      "referenceNumber": 143,
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
-        "https://opensource.org/licenses/BSD-2-Clause"
+        "https://opensource.org/license/BSD-2-Clause"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -889,7 +936,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Darwin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Darwin.json",
-      "referenceNumber": 251,
+      "referenceNumber": 117,
       "name": "BSD 2-Clause - Ian Darwin variant",
       "licenseId": "BSD-2-Clause-Darwin",
       "seeAlso": [
@@ -901,7 +948,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-first-lines.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-first-lines.json",
-      "referenceNumber": 516,
+      "referenceNumber": 575,
       "name": "BSD 2-Clause - first lines requirement",
       "licenseId": "BSD-2-Clause-first-lines",
       "seeAlso": [
@@ -914,7 +961,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": 535,
+      "referenceNumber": 335,
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -927,7 +974,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": 694,
+      "referenceNumber": 56,
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -940,11 +987,11 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": 302,
+      "referenceNumber": 394,
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
-        "https://opensource.org/licenses/BSDplusPatent"
+        "https://opensource.org/license/BSD-2-Clause-Patent"
       ],
       "isOsiApproved": true
     },
@@ -952,7 +999,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.json",
-      "referenceNumber": 31,
+      "referenceNumber": 448,
       "name": "BSD 2-Clause pkgconf disclaimer variant",
       "licenseId": "BSD-2-Clause-pkgconf-disclaimer",
       "seeAlso": [
@@ -965,7 +1012,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
-      "referenceNumber": 322,
+      "referenceNumber": 27,
       "name": "BSD 2-Clause with views sentence",
       "licenseId": "BSD-2-Clause-Views",
       "seeAlso": [
@@ -979,11 +1026,11 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": 289,
+      "referenceNumber": 665,
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
-        "https://opensource.org/licenses/BSD-3-Clause",
+        "https://opensource.org/license/BSD-3-Clause",
         "https://www.eclipse.org/org/documents/edl-v10.php"
       ],
       "isOsiApproved": true,
@@ -993,7 +1040,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-acpica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-acpica.json",
-      "referenceNumber": 16,
+      "referenceNumber": 476,
       "name": "BSD 3-Clause acpica variant",
       "licenseId": "BSD-3-Clause-acpica",
       "seeAlso": [
@@ -1005,7 +1052,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": 564,
+      "referenceNumber": 137,
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -1017,7 +1064,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": 650,
+      "referenceNumber": 344,
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -1030,7 +1077,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-flex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-flex.json",
-      "referenceNumber": 316,
+      "referenceNumber": 266,
       "name": "BSD 3-Clause Flex variant",
       "licenseId": "BSD-3-Clause-flex",
       "seeAlso": [
@@ -1042,7 +1089,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-HP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-HP.json",
-      "referenceNumber": 314,
+      "referenceNumber": 187,
       "name": "Hewlett-Packard BSD variant license",
       "licenseId": "BSD-3-Clause-HP",
       "seeAlso": [
@@ -1054,7 +1101,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": 55,
+      "referenceNumber": 26,
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -1066,7 +1113,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
-      "referenceNumber": 406,
+      "referenceNumber": 637,
       "name": "BSD 3-Clause Modification",
       "licenseId": "BSD-3-Clause-Modification",
       "seeAlso": [
@@ -1078,7 +1125,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
-      "referenceNumber": 202,
+      "referenceNumber": 523,
       "name": "BSD 3-Clause No Military License",
       "licenseId": "BSD-3-Clause-No-Military-License",
       "seeAlso": [
@@ -1091,7 +1138,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": 397,
+      "referenceNumber": 613,
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -1103,7 +1150,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": 445,
+      "referenceNumber": 497,
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -1115,7 +1162,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": 601,
+      "referenceNumber": 700,
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -1127,7 +1174,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-      "referenceNumber": 490,
+      "referenceNumber": 66,
       "name": "BSD 3-Clause Open MPI variant",
       "licenseId": "BSD-3-Clause-Open-MPI",
       "seeAlso": [
@@ -1140,7 +1187,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Sun.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Sun.json",
-      "referenceNumber": 334,
+      "referenceNumber": 543,
       "name": "BSD 3-Clause Sun Microsystems",
       "licenseId": "BSD-3-Clause-Sun",
       "seeAlso": [
@@ -1152,7 +1199,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Tso.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Tso.json",
-      "referenceNumber": 645,
+      "referenceNumber": 556,
       "name": "BSD 3-Clause Tso variant",
       "licenseId": "BSD-3-Clause-Tso",
       "seeAlso": [
@@ -1164,7 +1211,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": 297,
+      "referenceNumber": 574,
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -1178,7 +1225,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
-      "referenceNumber": 209,
+      "referenceNumber": 231,
       "name": "BSD 4 Clause Shortened",
       "licenseId": "BSD-4-Clause-Shortened",
       "seeAlso": [
@@ -1190,7 +1237,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": 336,
+      "referenceNumber": 6,
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -1202,7 +1249,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3RENO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3RENO.json",
-      "referenceNumber": 231,
+      "referenceNumber": 219,
       "name": "BSD 4.3 RENO License",
       "licenseId": "BSD-4.3RENO",
       "seeAlso": [
@@ -1215,7 +1262,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3TAHOE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3TAHOE.json",
-      "referenceNumber": 471,
+      "referenceNumber": 64,
       "name": "BSD 4.3 TAHOE License",
       "licenseId": "BSD-4.3TAHOE",
       "seeAlso": [
@@ -1228,7 +1275,7 @@
       "reference": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.json",
-      "referenceNumber": 152,
+      "referenceNumber": 7,
       "name": "BSD Advertising Acknowledgement License",
       "licenseId": "BSD-Advertising-Acknowledgement",
       "seeAlso": [
@@ -1240,7 +1287,7 @@
       "reference": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.json",
-      "referenceNumber": 526,
+      "referenceNumber": 695,
       "name": "BSD with Attribution and HPND disclaimer",
       "licenseId": "BSD-Attribution-HPND-disclaimer",
       "seeAlso": [
@@ -1252,7 +1299,7 @@
       "reference": "https://spdx.org/licenses/BSD-Inferno-Nettverk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Inferno-Nettverk.json",
-      "referenceNumber": 561,
+      "referenceNumber": 135,
       "name": "BSD-Inferno-Nettverk",
       "licenseId": "BSD-Inferno-Nettverk",
       "seeAlso": [
@@ -1264,7 +1311,7 @@
       "reference": "https://spdx.org/licenses/BSD-Mark-Modifications.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Mark-Modifications.json",
-      "referenceNumber": 139,
+      "referenceNumber": 195,
       "name": "BSD Mark Modifications License",
       "licenseId": "BSD-Mark-Modifications",
       "seeAlso": [
@@ -1276,7 +1323,7 @@
       "reference": "https://spdx.org/licenses/BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": 335,
+      "referenceNumber": 343,
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -1288,7 +1335,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-beginning-file.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-beginning-file.json",
-      "referenceNumber": 705,
+      "referenceNumber": 722,
       "name": "BSD Source Code Attribution - beginning of file variant",
       "licenseId": "BSD-Source-beginning-file",
       "seeAlso": [
@@ -1300,7 +1347,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": 91,
+      "referenceNumber": 408,
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -1312,7 +1359,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics.json",
-      "referenceNumber": 435,
+      "referenceNumber": 59,
       "name": "Systemics BSD variant license",
       "licenseId": "BSD-Systemics",
       "seeAlso": [
@@ -1324,7 +1371,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics-W3Works.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics-W3Works.json",
-      "referenceNumber": 441,
+      "referenceNumber": 542,
       "name": "Systemics W3Works BSD variant license",
       "licenseId": "BSD-Systemics-W3Works",
       "seeAlso": [
@@ -1336,12 +1383,12 @@
       "reference": "https://spdx.org/licenses/BSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": 589,
+      "referenceNumber": 361,
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
         "http://www.boost.org/LICENSE_1_0.txt",
-        "https://opensource.org/licenses/BSL-1.0"
+        "https://opensource.org/license/BSL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -1350,7 +1397,7 @@
       "reference": "https://spdx.org/licenses/Buddy.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Buddy.json",
-      "referenceNumber": 353,
+      "referenceNumber": 181,
       "name": "Buddy License",
       "licenseId": "Buddy",
       "seeAlso": [
@@ -1359,10 +1406,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Bugroff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bugroff.json",
+      "referenceNumber": 472,
+      "name": "Bugroff License",
+      "licenseId": "Bugroff",
+      "seeAlso": [
+        "https://tunes.org/legalese/bugroff.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/BUSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
-      "referenceNumber": 325,
+      "referenceNumber": 35,
       "name": "Business Source License 1.1",
       "licenseId": "BUSL-1.1",
       "seeAlso": [
@@ -1374,7 +1433,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": 586,
+      "referenceNumber": 642,
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -1387,7 +1446,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": 579,
+      "referenceNumber": 317,
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -1401,7 +1460,7 @@
       "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
-      "referenceNumber": 381,
+      "referenceNumber": 306,
       "name": "Computational Use of Data Agreement v1.0",
       "licenseId": "C-UDA-1.0",
       "seeAlso": [
@@ -1414,12 +1473,12 @@
       "reference": "https://spdx.org/licenses/CAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
-      "referenceNumber": 23,
+      "referenceNumber": 705,
       "name": "Cryptographic Autonomy License 1.0",
       "licenseId": "CAL-1.0",
       "seeAlso": [
         "http://cryptographicautonomylicense.com/license-text.html",
-        "https://opensource.org/licenses/CAL-1.0"
+        "https://opensource.org/license/CAL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1427,12 +1486,12 @@
       "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
-      "referenceNumber": 347,
+      "referenceNumber": 229,
       "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
       "licenseId": "CAL-1.0-Combined-Work-Exception",
       "seeAlso": [
         "http://cryptographicautonomylicense.com/license-text.html",
-        "https://opensource.org/licenses/CAL-1.0"
+        "https://opensource.org/license/CAL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1440,7 +1499,7 @@
       "reference": "https://spdx.org/licenses/Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera.json",
-      "referenceNumber": 207,
+      "referenceNumber": 516,
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1452,7 +1511,7 @@
       "reference": "https://spdx.org/licenses/Caldera-no-preamble.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera-no-preamble.json",
-      "referenceNumber": 422,
+      "referenceNumber": 104,
       "name": "Caldera License (without preamble)",
       "licenseId": "Caldera-no-preamble",
       "seeAlso": [
@@ -1461,10 +1520,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/CAPEC-tou.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CAPEC-tou.json",
+      "referenceNumber": 386,
+      "name": "Common Attack    Pattern Enumeration and Classification License",
+      "licenseId": "CAPEC-tou",
+      "seeAlso": [
+        "https://capec.mitre.org/about/termsofuse.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Catharon.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Catharon.json",
-      "referenceNumber": 17,
+      "referenceNumber": 463,
       "name": "Catharon License",
       "licenseId": "Catharon",
       "seeAlso": [
@@ -1476,11 +1547,11 @@
       "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": 77,
+      "referenceNumber": 235,
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
-        "https://opensource.org/licenses/CATOSL-1.1"
+        "https://opensource.org/license/CATOSL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -1488,7 +1559,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": 384,
+      "referenceNumber": 553,
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -1500,7 +1571,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": 686,
+      "referenceNumber": 570,
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -1512,7 +1583,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": 11,
+      "referenceNumber": 354,
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -1524,7 +1595,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
-      "referenceNumber": 240,
+      "referenceNumber": 444,
       "name": "Creative Commons Attribution 2.5 Australia",
       "licenseId": "CC-BY-2.5-AU",
       "seeAlso": [
@@ -1536,7 +1607,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": 33,
+      "referenceNumber": 460,
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -1548,7 +1619,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
-      "referenceNumber": 533,
+      "referenceNumber": 108,
       "name": "Creative Commons Attribution 3.0 Austria",
       "licenseId": "CC-BY-3.0-AT",
       "seeAlso": [
@@ -1560,7 +1631,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AU.json",
-      "referenceNumber": 412,
+      "referenceNumber": 193,
       "name": "Creative Commons Attribution 3.0 Australia",
       "licenseId": "CC-BY-3.0-AU",
       "seeAlso": [
@@ -1572,7 +1643,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
-      "referenceNumber": 6,
+      "referenceNumber": 534,
       "name": "Creative Commons Attribution 3.0 Germany",
       "licenseId": "CC-BY-3.0-DE",
       "seeAlso": [
@@ -1584,7 +1655,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
-      "referenceNumber": 28,
+      "referenceNumber": 684,
       "name": "Creative Commons Attribution 3.0 IGO",
       "licenseId": "CC-BY-3.0-IGO",
       "seeAlso": [
@@ -1596,7 +1667,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
-      "referenceNumber": 161,
+      "referenceNumber": 130,
       "name": "Creative Commons Attribution 3.0 Netherlands",
       "licenseId": "CC-BY-3.0-NL",
       "seeAlso": [
@@ -1608,7 +1679,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
-      "referenceNumber": 699,
+      "referenceNumber": 223,
       "name": "Creative Commons Attribution 3.0 United States",
       "licenseId": "CC-BY-3.0-US",
       "seeAlso": [
@@ -1620,7 +1691,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": 628,
+      "referenceNumber": 479,
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
@@ -1633,7 +1704,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": 695,
+      "referenceNumber": 666,
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
@@ -1646,7 +1717,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": 155,
+      "referenceNumber": 504,
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
@@ -1659,7 +1730,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": 317,
+      "referenceNumber": 253,
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
@@ -1672,7 +1743,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": 587,
+      "referenceNumber": 633,
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
@@ -1685,7 +1756,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
-      "referenceNumber": 491,
+      "referenceNumber": 511,
       "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
       "licenseId": "CC-BY-NC-3.0-DE",
       "seeAlso": [
@@ -1694,10 +1765,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-IGO.json",
+      "referenceNumber": 626,
+      "name": "Creative Commons Attribution Non Commercial 3.0 IGO",
+      "licenseId": "CC-BY-NC-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": 408,
+      "referenceNumber": 110,
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
@@ -1710,7 +1793,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": 499,
+      "referenceNumber": 11,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -1722,7 +1805,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": 626,
+      "referenceNumber": 583,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -1734,7 +1817,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": 475,
+      "referenceNumber": 413,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -1746,7 +1829,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": 590,
+      "referenceNumber": 247,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -1758,7 +1841,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
-      "referenceNumber": 534,
+      "referenceNumber": 305,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-NC-ND-3.0-DE",
       "seeAlso": [
@@ -1770,7 +1853,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
-      "referenceNumber": 394,
+      "referenceNumber": 675,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
       "licenseId": "CC-BY-NC-ND-3.0-IGO",
       "seeAlso": [
@@ -1782,7 +1865,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": 544,
+      "referenceNumber": 683,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -1794,7 +1877,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": 170,
+      "referenceNumber": 132,
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -1806,7 +1889,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": 541,
+      "referenceNumber": 440,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -1818,7 +1901,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.json",
-      "referenceNumber": 203,
+      "referenceNumber": 0,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
       "licenseId": "CC-BY-NC-SA-2.0-DE",
       "seeAlso": [
@@ -1830,7 +1913,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
-      "referenceNumber": 245,
+      "referenceNumber": 644,
       "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
       "licenseId": "CC-BY-NC-SA-2.0-FR",
       "seeAlso": [
@@ -1842,7 +1925,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
-      "referenceNumber": 208,
+      "referenceNumber": 390,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-NC-SA-2.0-UK",
       "seeAlso": [
@@ -1854,7 +1937,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": 113,
+      "referenceNumber": 293,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -1866,7 +1949,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": 254,
+      "referenceNumber": 464,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
@@ -1878,7 +1961,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
-      "referenceNumber": 211,
+      "referenceNumber": 248,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
       "licenseId": "CC-BY-NC-SA-3.0-DE",
       "seeAlso": [
@@ -1890,7 +1973,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
-      "referenceNumber": 234,
+      "referenceNumber": 216,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
       "licenseId": "CC-BY-NC-SA-3.0-IGO",
       "seeAlso": [
@@ -1902,7 +1985,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": 285,
+      "referenceNumber": 178,
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -1914,7 +1997,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": 123,
+      "referenceNumber": 662,
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -1927,7 +2010,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": 14,
+      "referenceNumber": 651,
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1940,7 +2023,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": 249,
+      "referenceNumber": 405,
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
@@ -1953,7 +2036,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": 248,
+      "referenceNumber": 661,
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
@@ -1966,7 +2049,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
-      "referenceNumber": 566,
+      "referenceNumber": 73,
       "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-ND-3.0-DE",
       "seeAlso": [
@@ -1978,7 +2061,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": 484,
+      "referenceNumber": 374,
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
@@ -1991,7 +2074,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": 556,
+      "referenceNumber": 573,
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -2003,7 +2086,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": 607,
+      "referenceNumber": 631,
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -2015,7 +2098,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
-      "referenceNumber": 41,
+      "referenceNumber": 296,
       "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-SA-2.0-UK",
       "seeAlso": [
@@ -2027,7 +2110,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
-      "referenceNumber": 224,
+      "referenceNumber": 103,
       "name": "Creative Commons Attribution Share Alike 2.1 Japan",
       "licenseId": "CC-BY-SA-2.1-JP",
       "seeAlso": [
@@ -2039,7 +2122,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": 97,
+      "referenceNumber": 25,
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -2051,7 +2134,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": 451,
+      "referenceNumber": 227,
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -2063,7 +2146,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
-      "referenceNumber": 95,
+      "referenceNumber": 709,
       "name": "Creative Commons Attribution Share Alike 3.0 Austria",
       "licenseId": "CC-BY-SA-3.0-AT",
       "seeAlso": [
@@ -2075,7 +2158,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
-      "referenceNumber": 177,
+      "referenceNumber": 552,
       "name": "Creative Commons Attribution Share Alike 3.0 Germany",
       "licenseId": "CC-BY-SA-3.0-DE",
       "seeAlso": [
@@ -2087,7 +2170,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.json",
-      "referenceNumber": 342,
+      "referenceNumber": 254,
       "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
       "licenseId": "CC-BY-SA-3.0-IGO",
       "seeAlso": [
@@ -2099,7 +2182,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": 93,
+      "referenceNumber": 373,
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
@@ -2112,7 +2195,7 @@
       "reference": "https://spdx.org/licenses/CC-PDDC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
-      "referenceNumber": 568,
+      "referenceNumber": 174,
       "name": "Creative Commons Public Domain Dedication and Certification",
       "licenseId": "CC-PDDC",
       "seeAlso": [
@@ -2124,7 +2207,7 @@
       "reference": "https://spdx.org/licenses/CC-PDM-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-PDM-1.0.json",
-      "referenceNumber": 24,
+      "referenceNumber": 93,
       "name": "Creative    Commons Public Domain Mark 1.0 Universal",
       "licenseId": "CC-PDM-1.0",
       "seeAlso": [
@@ -2137,7 +2220,7 @@
       "reference": "https://spdx.org/licenses/CC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-SA-1.0.json",
-      "referenceNumber": 678,
+      "referenceNumber": 327,
       "name": "Creative Commons Share Alike 1.0 Generic",
       "licenseId": "CC-SA-1.0",
       "seeAlso": [
@@ -2149,7 +2232,7 @@
       "reference": "https://spdx.org/licenses/CC0-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": 206,
+      "referenceNumber": 655,
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -2162,11 +2245,11 @@
       "reference": "https://spdx.org/licenses/CDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": 63,
+      "referenceNumber": 262,
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/cddl1"
+        "https://opensource.org/license/CDDL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -2175,20 +2258,20 @@
       "reference": "https://spdx.org/licenses/CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": 676,
+      "referenceNumber": 204,
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
         "http://glassfish.java.net/public/CDDL+GPL_1_1.html",
         "https://javaee.github.io/glassfish/LICENSE"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "https://spdx.org/licenses/CDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
-      "referenceNumber": 89,
+      "referenceNumber": 494,
       "name": "Common Documentation License 1.0",
       "licenseId": "CDL-1.0",
       "seeAlso": [
@@ -2202,7 +2285,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": 27,
+      "referenceNumber": 109,
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -2214,7 +2297,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
-      "referenceNumber": 341,
+      "referenceNumber": 264,
       "name": "Community Data License Agreement Permissive 2.0",
       "licenseId": "CDLA-Permissive-2.0",
       "seeAlso": [
@@ -2226,7 +2309,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": 537,
+      "referenceNumber": 311,
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -2238,7 +2321,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": 210,
+      "referenceNumber": 14,
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -2250,7 +2333,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": 244,
+      "referenceNumber": 80,
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -2262,7 +2345,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": 700,
+      "referenceNumber": 112,
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -2275,7 +2358,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": 150,
+      "referenceNumber": 208,
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -2287,7 +2370,7 @@
       "reference": "https://spdx.org/licenses/CECILL-B.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": 176,
+      "referenceNumber": 418,
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -2300,7 +2383,7 @@
       "reference": "https://spdx.org/licenses/CECILL-C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": 189,
+      "referenceNumber": 49,
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -2313,7 +2396,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": 160,
+      "referenceNumber": 183,
       "name": "CERN Open Hardware Licence v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -2325,7 +2408,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
-      "referenceNumber": 446,
+      "referenceNumber": 198,
       "name": "CERN Open Hardware Licence v1.2",
       "licenseId": "CERN-OHL-1.2",
       "seeAlso": [
@@ -2337,7 +2420,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
-      "referenceNumber": 636,
+      "referenceNumber": 297,
       "name": "CERN Open Hardware Licence Version 2 - Permissive",
       "licenseId": "CERN-OHL-P-2.0",
       "seeAlso": [
@@ -2349,7 +2432,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
-      "referenceNumber": 615,
+      "referenceNumber": 33,
       "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
       "licenseId": "CERN-OHL-S-2.0",
       "seeAlso": [
@@ -2361,7 +2444,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
-      "referenceNumber": 549,
+      "referenceNumber": 465,
       "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
       "licenseId": "CERN-OHL-W-2.0",
       "seeAlso": [
@@ -2373,7 +2456,7 @@
       "reference": "https://spdx.org/licenses/CFITSIO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CFITSIO.json",
-      "referenceNumber": 679,
+      "referenceNumber": 653,
       "name": "CFITSIO License",
       "licenseId": "CFITSIO",
       "seeAlso": [
@@ -2386,7 +2469,7 @@
       "reference": "https://spdx.org/licenses/check-cvs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/check-cvs.json",
-      "referenceNumber": 62,
+      "referenceNumber": 85,
       "name": "check-cvs License",
       "licenseId": "check-cvs",
       "seeAlso": [
@@ -2398,7 +2481,7 @@
       "reference": "https://spdx.org/licenses/checkmk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/checkmk.json",
-      "referenceNumber": 411,
+      "referenceNumber": 60,
       "name": "Checkmk License",
       "licenseId": "checkmk",
       "seeAlso": [
@@ -2410,7 +2493,7 @@
       "reference": "https://spdx.org/licenses/ClArtistic.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": 495,
+      "referenceNumber": 384,
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -2424,7 +2507,7 @@
       "reference": "https://spdx.org/licenses/Clips.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Clips.json",
-      "referenceNumber": 212,
+      "referenceNumber": 316,
       "name": "Clips License",
       "licenseId": "Clips",
       "seeAlso": [
@@ -2436,7 +2519,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach.json",
-      "referenceNumber": 42,
+      "referenceNumber": 115,
       "name": "CMU Mach License",
       "licenseId": "CMU-Mach",
       "seeAlso": [
@@ -2448,7 +2531,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach-nodoc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach-nodoc.json",
-      "referenceNumber": 22,
+      "referenceNumber": 483,
       "name": "CMU    Mach - no notices-in-documentation variant",
       "licenseId": "CMU-Mach-nodoc",
       "seeAlso": [
@@ -2461,7 +2544,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": 386,
+      "referenceNumber": 715,
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -2473,11 +2556,11 @@
       "reference": "https://spdx.org/licenses/CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": 235,
+      "referenceNumber": 446,
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
-        "https://opensource.org/licenses/CNRI-Python"
+        "https://opensource.org/license/CNRI-Python"
       ],
       "isOsiApproved": true
     },
@@ -2485,7 +2568,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": 71,
+      "referenceNumber": 708,
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -2497,7 +2580,7 @@
       "reference": "https://spdx.org/licenses/COIL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
-      "referenceNumber": 379,
+      "referenceNumber": 206,
       "name": "Copyfree Open Innovation License",
       "licenseId": "COIL-1.0",
       "seeAlso": [
@@ -2509,7 +2592,7 @@
       "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
-      "referenceNumber": 393,
+      "referenceNumber": 442,
       "name": "Community Specification License 1.0",
       "licenseId": "Community-Spec-1.0",
       "seeAlso": [
@@ -2521,7 +2604,7 @@
       "reference": "https://spdx.org/licenses/Condor-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": 555,
+      "referenceNumber": 654,
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -2535,7 +2618,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": 463,
+      "referenceNumber": 701,
       "name": "copyleft-next 0.3.0",
       "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
@@ -2547,7 +2630,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": 3,
+      "referenceNumber": 308,
       "name": "copyleft-next 0.3.1",
       "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
@@ -2559,7 +2642,7 @@
       "reference": "https://spdx.org/licenses/Cornell-Lossless-JPEG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cornell-Lossless-JPEG.json",
-      "referenceNumber": 375,
+      "referenceNumber": 509,
       "name": "Cornell Lossless JPEG License",
       "licenseId": "Cornell-Lossless-JPEG",
       "seeAlso": [
@@ -2573,11 +2656,11 @@
       "reference": "https://spdx.org/licenses/CPAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": 354,
+      "referenceNumber": 621,
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/CPAL-1.0"
+        "https://opensource.org/license/CPAL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -2586,11 +2669,11 @@
       "reference": "https://spdx.org/licenses/CPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": 575,
+      "referenceNumber": 411,
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/CPL-1.0"
+        "https://opensource.org/license/CPL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -2599,7 +2682,7 @@
       "reference": "https://spdx.org/licenses/CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": 588,
+      "referenceNumber": 96,
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -2612,7 +2695,7 @@
       "reference": "https://spdx.org/licenses/Cronyx.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cronyx.json",
-      "referenceNumber": 190,
+      "referenceNumber": 641,
       "name": "Cronyx License",
       "licenseId": "Cronyx",
       "seeAlso": [
@@ -2627,7 +2710,7 @@
       "reference": "https://spdx.org/licenses/Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Crossword.json",
-      "referenceNumber": 702,
+      "referenceNumber": 244,
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -2639,7 +2722,7 @@
       "reference": "https://spdx.org/licenses/CryptoSwift.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CryptoSwift.json",
-      "referenceNumber": 690,
+      "referenceNumber": 355,
       "name": "CryptoSwift License",
       "licenseId": "CryptoSwift",
       "seeAlso": [
@@ -2651,7 +2734,7 @@
       "reference": "https://spdx.org/licenses/CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": 459,
+      "referenceNumber": 153,
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -2663,11 +2746,11 @@
       "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": 612,
+      "referenceNumber": 689,
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/CUA-OPL-1.0"
+        "https://opensource.org/license/CUA-OPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2675,7 +2758,7 @@
       "reference": "https://spdx.org/licenses/Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cube.json",
-      "referenceNumber": 346,
+      "referenceNumber": 398,
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -2687,7 +2770,7 @@
       "reference": "https://spdx.org/licenses/curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/curl.json",
-      "referenceNumber": 223,
+      "referenceNumber": 396,
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -2699,7 +2782,7 @@
       "reference": "https://spdx.org/licenses/cve-tou.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/cve-tou.json",
-      "referenceNumber": 596,
+      "referenceNumber": 218,
       "name": "Common Vulnerability Enumeration ToU License",
       "licenseId": "cve-tou",
       "seeAlso": [
@@ -2711,7 +2794,7 @@
       "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": 183,
+      "referenceNumber": 239,
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -2730,7 +2813,7 @@
       "reference": "https://spdx.org/licenses/DEC-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DEC-3-Clause.json",
-      "referenceNumber": 140,
+      "referenceNumber": 599,
       "name": "DEC 3-Clause License",
       "licenseId": "DEC-3-Clause",
       "seeAlso": [
@@ -2742,7 +2825,7 @@
       "reference": "https://spdx.org/licenses/diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/diffmark.json",
-      "referenceNumber": 456,
+      "referenceNumber": 561,
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -2754,7 +2837,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
-      "referenceNumber": 252,
+      "referenceNumber": 53,
       "name": "Data licence Germany – attribution – version 2.0",
       "licenseId": "DL-DE-BY-2.0",
       "seeAlso": [
@@ -2766,7 +2849,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-ZERO-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-ZERO-2.0.json",
-      "referenceNumber": 35,
+      "referenceNumber": 564,
       "name": "Data licence Germany – zero – version 2.0",
       "licenseId": "DL-DE-ZERO-2.0",
       "seeAlso": [
@@ -2778,7 +2861,7 @@
       "reference": "https://spdx.org/licenses/DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DOC.json",
-      "referenceNumber": 553,
+      "referenceNumber": 677,
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -2791,7 +2874,7 @@
       "reference": "https://spdx.org/licenses/DocBook-DTD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-DTD.json",
-      "referenceNumber": 64,
+      "referenceNumber": 636,
       "name": "DocBook DTD License",
       "licenseId": "DocBook-DTD",
       "seeAlso": [
@@ -2803,7 +2886,7 @@
       "reference": "https://spdx.org/licenses/DocBook-Schema.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-Schema.json",
-      "referenceNumber": 685,
+      "referenceNumber": 52,
       "name": "DocBook Schema License",
       "licenseId": "DocBook-Schema",
       "seeAlso": [
@@ -2815,7 +2898,7 @@
       "reference": "https://spdx.org/licenses/DocBook-Stylesheet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-Stylesheet.json",
-      "referenceNumber": 627,
+      "referenceNumber": 589,
       "name": "DocBook Stylesheet License",
       "licenseId": "DocBook-Stylesheet",
       "seeAlso": [
@@ -2827,7 +2910,7 @@
       "reference": "https://spdx.org/licenses/DocBook-XML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-XML.json",
-      "referenceNumber": 557,
+      "referenceNumber": 375,
       "name": "DocBook XML License",
       "licenseId": "DocBook-XML",
       "seeAlso": [
@@ -2839,7 +2922,7 @@
       "reference": "https://spdx.org/licenses/Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": 571,
+      "referenceNumber": 213,
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -2851,7 +2934,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
-      "referenceNumber": 569,
+      "referenceNumber": 257,
       "name": "Detection Rule License 1.0",
       "licenseId": "DRL-1.0",
       "seeAlso": [
@@ -2863,7 +2946,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.1.json",
-      "referenceNumber": 692,
+      "referenceNumber": 63,
       "name": "Detection Rule License 1.1",
       "licenseId": "DRL-1.1",
       "seeAlso": [
@@ -2875,7 +2958,7 @@
       "reference": "https://spdx.org/licenses/DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DSDP.json",
-      "referenceNumber": 497,
+      "referenceNumber": 286,
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -2887,7 +2970,7 @@
       "reference": "https://spdx.org/licenses/dtoa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dtoa.json",
-      "referenceNumber": 482,
+      "referenceNumber": 438,
       "name": "David M. Gay dtoa License",
       "licenseId": "dtoa",
       "seeAlso": [
@@ -2900,7 +2983,7 @@
       "reference": "https://spdx.org/licenses/dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": 545,
+      "referenceNumber": 295,
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -2912,11 +2995,11 @@
       "reference": "https://spdx.org/licenses/ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": 128,
+      "referenceNumber": 42,
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/ECL-1.0"
+        "https://opensource.org/license/ECL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2924,11 +3007,11 @@
       "reference": "https://spdx.org/licenses/ECL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": 117,
+      "referenceNumber": 8,
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
-        "https://opensource.org/licenses/ECL-2.0"
+        "https://opensource.org/license/ECL-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -2937,7 +3020,7 @@
       "reference": "https://spdx.org/licenses/eCos-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": 136,
+      "referenceNumber": 158,
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -2950,12 +3033,12 @@
       "reference": "https://spdx.org/licenses/EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": 45,
+      "referenceNumber": 133,
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
         "http://www.eiffel-nice.org/license/forum.txt",
-        "https://opensource.org/licenses/EFL-1.0"
+        "https://opensource.org/license/EFL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2963,12 +3046,12 @@
       "reference": "https://spdx.org/licenses/EFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": 280,
+      "referenceNumber": 549,
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
         "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
-        "https://opensource.org/licenses/EFL-2.0"
+        "https://opensource.org/license/EFL-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -2977,7 +3060,7 @@
       "reference": "https://spdx.org/licenses/eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/eGenix.json",
-      "referenceNumber": 681,
+      "referenceNumber": 182,
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -2990,7 +3073,7 @@
       "reference": "https://spdx.org/licenses/Elastic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
-      "referenceNumber": 167,
+      "referenceNumber": 4,
       "name": "Elastic License 2.0",
       "licenseId": "Elastic-2.0",
       "seeAlso": [
@@ -3003,11 +3086,11 @@
       "reference": "https://spdx.org/licenses/Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Entessa.json",
-      "referenceNumber": 122,
+      "referenceNumber": 336,
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
-        "https://opensource.org/licenses/Entessa"
+        "https://opensource.org/license/Entessa"
       ],
       "isOsiApproved": true
     },
@@ -3015,7 +3098,7 @@
       "reference": "https://spdx.org/licenses/EPICS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPICS.json",
-      "referenceNumber": 315,
+      "referenceNumber": 215,
       "name": "EPICS Open License",
       "licenseId": "EPICS",
       "seeAlso": [
@@ -3027,12 +3110,12 @@
       "reference": "https://spdx.org/licenses/EPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": 105,
+      "referenceNumber": 638,
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
         "http://www.eclipse.org/legal/epl-v10.html",
-        "https://opensource.org/licenses/EPL-1.0"
+        "https://opensource.org/license/EPL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3041,12 +3124,12 @@
       "reference": "https://spdx.org/licenses/EPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": 503,
+      "referenceNumber": 724,
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
         "https://www.eclipse.org/legal/epl-2.0",
-        "https://www.opensource.org/licenses/EPL-2.0",
+        "https://www.opensource.org/license/EPL-2.0",
         "https://www.eclipse.org/legal/epl-v20.html",
         "https://projects.eclipse.org/license/epl-2.0"
       ],
@@ -3057,7 +3140,7 @@
       "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": 669,
+      "referenceNumber": 547,
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -3069,7 +3152,7 @@
       "reference": "https://spdx.org/licenses/ESA-PL-permissive-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ESA-PL-permissive-2.4.json",
-      "referenceNumber": 432,
+      "referenceNumber": 489,
       "name": "European Space Agency Public License – v2.4 – Permissive (Type 3)",
       "licenseId": "ESA-PL-permissive-2.4",
       "seeAlso": [
@@ -3081,7 +3164,7 @@
       "reference": "https://spdx.org/licenses/ESA-PL-strong-copyleft-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ESA-PL-strong-copyleft-2.4.json",
-      "referenceNumber": 487,
+      "referenceNumber": 565,
       "name": "European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1)",
       "licenseId": "ESA-PL-strong-copyleft-2.4",
       "seeAlso": [
@@ -3093,7 +3176,7 @@
       "reference": "https://spdx.org/licenses/ESA-PL-weak-copyleft-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ESA-PL-weak-copyleft-2.4.json",
-      "referenceNumber": 312,
+      "referenceNumber": 188,
       "name": "European Space Agency Public License – v2.4 – Weak Copyleft (Type 2)",
       "licenseId": "ESA-PL-weak-copyleft-2.4",
       "seeAlso": [
@@ -3105,7 +3188,7 @@
       "reference": "https://spdx.org/licenses/etalab-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
-      "referenceNumber": 214,
+      "referenceNumber": 250,
       "name": "Etalab Open License 2.0",
       "licenseId": "etalab-2.0",
       "seeAlso": [
@@ -3118,12 +3201,12 @@
       "reference": "https://spdx.org/licenses/EUDatagrid.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": 562,
+      "referenceNumber": 544,
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
         "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
-        "https://opensource.org/licenses/EUDatagrid"
+        "https://opensource.org/license/EUDatagrid"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3132,7 +3215,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": 281,
+      "referenceNumber": 55,
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -3145,13 +3228,13 @@
       "reference": "https://spdx.org/licenses/EUPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": 609,
+      "referenceNumber": 519,
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
         "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
-        "https://opensource.org/licenses/EUPL-1.1"
+        "https://opensource.org/license/EUPL-1.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3160,7 +3243,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": 168,
+      "referenceNumber": 275,
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -3169,7 +3252,8 @@
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt",
         "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
         "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
-        "https://opensource.org/licenses/EUPL-1.2"
+        "https://opensource.org/license/EUPL-1.2",
+        "https://interoperable-europe.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3178,7 +3262,7 @@
       "reference": "https://spdx.org/licenses/Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": 84,
+      "referenceNumber": 579,
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -3190,12 +3274,12 @@
       "reference": "https://spdx.org/licenses/Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Fair.json",
-      "referenceNumber": 5,
+      "referenceNumber": 718,
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
         "https://web.archive.org/web/20150926120323/http://fairlicense.org/",
-        "https://opensource.org/licenses/Fair"
+        "https://opensource.org/license/Fair"
       ],
       "isOsiApproved": true
     },
@@ -3203,7 +3287,7 @@
       "reference": "https://spdx.org/licenses/FBM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FBM.json",
-      "referenceNumber": 400,
+      "referenceNumber": 484,
       "name": "Fuzzy Bitmap License",
       "licenseId": "FBM",
       "seeAlso": [
@@ -3215,7 +3299,7 @@
       "reference": "https://spdx.org/licenses/FDK-AAC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
-      "referenceNumber": 638,
+      "referenceNumber": 452,
       "name": "Fraunhofer FDK AAC Codec Library",
       "licenseId": "FDK-AAC",
       "seeAlso": [
@@ -3228,7 +3312,7 @@
       "reference": "https://spdx.org/licenses/Ferguson-Twofish.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ferguson-Twofish.json",
-      "referenceNumber": 502,
+      "referenceNumber": 369,
       "name": "Ferguson Twofish License",
       "licenseId": "Ferguson-Twofish",
       "seeAlso": [
@@ -3240,11 +3324,11 @@
       "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": 392,
+      "referenceNumber": 615,
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Frameworx-1.0"
+        "https://opensource.org/license/Frameworx-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3252,7 +3336,7 @@
       "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
-      "referenceNumber": 371,
+      "referenceNumber": 587,
       "name": "FreeBSD Documentation License",
       "licenseId": "FreeBSD-DOC",
       "seeAlso": [
@@ -3264,7 +3348,7 @@
       "reference": "https://spdx.org/licenses/FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": 308,
+      "referenceNumber": 535,
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -3276,7 +3360,7 @@
       "reference": "https://spdx.org/licenses/FSFAP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": 90,
+      "referenceNumber": 246,
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -3289,7 +3373,7 @@
       "reference": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.json",
-      "referenceNumber": 241,
+      "referenceNumber": 333,
       "name": "FSF All Permissive License (without Warranty)",
       "licenseId": "FSFAP-no-warranty-disclaimer",
       "seeAlso": [
@@ -3301,7 +3385,7 @@
       "reference": "https://spdx.org/licenses/FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": 135,
+      "referenceNumber": 95,
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -3313,7 +3397,7 @@
       "reference": "https://spdx.org/licenses/FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": 198,
+      "referenceNumber": 22,
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -3325,7 +3409,7 @@
       "reference": "https://spdx.org/licenses/FSFULLRSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLRSD.json",
-      "referenceNumber": 296,
+      "referenceNumber": 697,
       "name": "FSF Unlimited License (with License Retention and Short Disclaimer)",
       "licenseId": "FSFULLRSD",
       "seeAlso": [
@@ -3337,7 +3421,7 @@
       "reference": "https://spdx.org/licenses/FSFULLRWD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLRWD.json",
-      "referenceNumber": 323,
+      "referenceNumber": 242,
       "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
       "licenseId": "FSFULLRWD",
       "seeAlso": [
@@ -3349,7 +3433,7 @@
       "reference": "https://spdx.org/licenses/FSL-1.1-ALv2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSL-1.1-ALv2.json",
-      "referenceNumber": 423,
+      "referenceNumber": 272,
       "name": "Functional Source License, Version 1.1, ALv2 Future License",
       "licenseId": "FSL-1.1-ALv2",
       "seeAlso": [
@@ -3361,7 +3445,7 @@
       "reference": "https://spdx.org/licenses/FSL-1.1-MIT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSL-1.1-MIT.json",
-      "referenceNumber": 0,
+      "referenceNumber": 503,
       "name": "Functional Source License, Version 1.1, MIT Future License",
       "licenseId": "FSL-1.1-MIT",
       "seeAlso": [
@@ -3373,7 +3457,7 @@
       "reference": "https://spdx.org/licenses/FTL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FTL.json",
-      "referenceNumber": 378,
+      "referenceNumber": 269,
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -3388,7 +3472,7 @@
       "reference": "https://spdx.org/licenses/Furuseth.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Furuseth.json",
-      "referenceNumber": 691,
+      "referenceNumber": 1,
       "name": "Furuseth License",
       "licenseId": "Furuseth",
       "seeAlso": [
@@ -3400,7 +3484,7 @@
       "reference": "https://spdx.org/licenses/fwlw.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/fwlw.json",
-      "referenceNumber": 243,
+      "referenceNumber": 410,
       "name": "fwlw License",
       "licenseId": "fwlw",
       "seeAlso": [
@@ -3412,7 +3496,7 @@
       "reference": "https://spdx.org/licenses/Game-Programming-Gems.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Game-Programming-Gems.json",
-      "referenceNumber": 275,
+      "referenceNumber": 98,
       "name": "Game Programming Gems License",
       "licenseId": "Game-Programming-Gems",
       "seeAlso": [
@@ -3424,7 +3508,7 @@
       "reference": "https://spdx.org/licenses/GCR-docs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GCR-docs.json",
-      "referenceNumber": 196,
+      "referenceNumber": 443,
       "name": "Gnome GCR Documentation License",
       "licenseId": "GCR-docs",
       "seeAlso": [
@@ -3436,7 +3520,7 @@
       "reference": "https://spdx.org/licenses/GD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GD.json",
-      "referenceNumber": 546,
+      "referenceNumber": 530,
       "name": "GD License",
       "licenseId": "GD",
       "seeAlso": [
@@ -3448,7 +3532,7 @@
       "reference": "https://spdx.org/licenses/generic-xts.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/generic-xts.json",
-      "referenceNumber": 134,
+      "referenceNumber": 167,
       "name": "Generic XTS License",
       "licenseId": "generic-xts",
       "seeAlso": [
@@ -3460,7 +3544,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": 469,
+      "referenceNumber": 702,
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
@@ -3473,7 +3557,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
-      "referenceNumber": 639,
+      "referenceNumber": 274,
       "name": "GNU Free Documentation License v1.1 only - invariants",
       "licenseId": "GFDL-1.1-invariants-only",
       "seeAlso": [
@@ -3485,7 +3569,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
-      "referenceNumber": 374,
+      "referenceNumber": 203,
       "name": "GNU Free Documentation License v1.1 or later - invariants",
       "licenseId": "GFDL-1.1-invariants-or-later",
       "seeAlso": [
@@ -3497,7 +3581,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
-      "referenceNumber": 582,
+      "referenceNumber": 536,
       "name": "GNU Free Documentation License v1.1 only - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-only",
       "seeAlso": [
@@ -3509,7 +3593,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
-      "referenceNumber": 641,
+      "referenceNumber": 610,
       "name": "GNU Free Documentation License v1.1 or later - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-or-later",
       "seeAlso": [
@@ -3521,7 +3605,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": 331,
+      "referenceNumber": 91,
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -3534,7 +3618,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": 449,
+      "referenceNumber": 347,
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -3547,7 +3631,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": 34,
+      "referenceNumber": 77,
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
@@ -3560,7 +3644,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
-      "referenceNumber": 37,
+      "referenceNumber": 540,
       "name": "GNU Free Documentation License v1.2 only - invariants",
       "licenseId": "GFDL-1.2-invariants-only",
       "seeAlso": [
@@ -3572,7 +3656,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
-      "referenceNumber": 440,
+      "referenceNumber": 401,
       "name": "GNU Free Documentation License v1.2 or later - invariants",
       "licenseId": "GFDL-1.2-invariants-or-later",
       "seeAlso": [
@@ -3584,7 +3668,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
-      "referenceNumber": 69,
+      "referenceNumber": 207,
       "name": "GNU Free Documentation License v1.2 only - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-only",
       "seeAlso": [
@@ -3596,7 +3680,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
-      "referenceNumber": 88,
+      "referenceNumber": 341,
       "name": "GNU Free Documentation License v1.2 or later - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-or-later",
       "seeAlso": [
@@ -3608,7 +3692,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": 185,
+      "referenceNumber": 101,
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -3621,7 +3705,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": 637,
+      "referenceNumber": 541,
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -3634,7 +3718,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": 501,
+      "referenceNumber": 403,
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
@@ -3647,7 +3731,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
-      "referenceNumber": 232,
+      "referenceNumber": 608,
       "name": "GNU Free Documentation License v1.3 only - invariants",
       "licenseId": "GFDL-1.3-invariants-only",
       "seeAlso": [
@@ -3659,7 +3743,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
-      "referenceNumber": 205,
+      "referenceNumber": 271,
       "name": "GNU Free Documentation License v1.3 or later - invariants",
       "licenseId": "GFDL-1.3-invariants-or-later",
       "seeAlso": [
@@ -3671,7 +3755,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
-      "referenceNumber": 642,
+      "referenceNumber": 480,
       "name": "GNU Free Documentation License v1.3 only - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-only",
       "seeAlso": [
@@ -3683,7 +3767,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
-      "referenceNumber": 376,
+      "referenceNumber": 124,
       "name": "GNU Free Documentation License v1.3 or later - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-or-later",
       "seeAlso": [
@@ -3695,7 +3779,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": 181,
+      "referenceNumber": 358,
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -3708,7 +3792,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": 72,
+      "referenceNumber": 202,
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
@@ -3721,7 +3805,7 @@
       "reference": "https://spdx.org/licenses/Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Giftware.json",
-      "referenceNumber": 420,
+      "referenceNumber": 349,
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -3733,7 +3817,7 @@
       "reference": "https://spdx.org/licenses/GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": 274,
+      "referenceNumber": 719,
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -3745,7 +3829,7 @@
       "reference": "https://spdx.org/licenses/Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glide.json",
-      "referenceNumber": 715,
+      "referenceNumber": 450,
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -3757,7 +3841,7 @@
       "reference": "https://spdx.org/licenses/Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": 36,
+      "referenceNumber": 691,
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -3769,7 +3853,7 @@
       "reference": "https://spdx.org/licenses/GLWTPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
-      "referenceNumber": 563,
+      "referenceNumber": 58,
       "name": "Good Luck With That Public License",
       "licenseId": "GLWTPL",
       "seeAlso": [
@@ -3781,7 +3865,7 @@
       "reference": "https://spdx.org/licenses/gnuplot.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": 277,
+      "referenceNumber": 126,
       "name": "gnuplot License",
       "licenseId": "gnuplot",
       "seeAlso": [
@@ -3794,7 +3878,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": 714,
+      "referenceNumber": 616,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
@@ -3806,7 +3890,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": 448,
+      "referenceNumber": 474,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
@@ -3818,7 +3902,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": 355,
+      "referenceNumber": 163,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
@@ -3830,7 +3914,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": 517,
+      "referenceNumber": 454,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -3842,12 +3926,12 @@
       "reference": "https://spdx.org/licenses/GPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": 329,
+      "referenceNumber": 457,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
+        "https://opensource.org/license/GPL-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3856,12 +3940,12 @@
       "reference": "https://spdx.org/licenses/GPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": 38,
+      "referenceNumber": 351,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
+        "https://opensource.org/license/GPL-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3870,13 +3954,13 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": 301,
+      "referenceNumber": 560,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt",
-        "https://opensource.org/licenses/GPL-2.0",
+        "https://opensource.org/license/GPL-2.0-only",
         "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
       ],
       "isOsiApproved": true,
@@ -3886,12 +3970,12 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": 467,
+      "referenceNumber": 618,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0",
+        "https://opensource.org/license/GPL-2.0",
         "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
       ],
       "isOsiApproved": true,
@@ -3901,7 +3985,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": 697,
+      "referenceNumber": 407,
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -3913,7 +3997,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": 46,
+      "referenceNumber": 232,
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -3925,7 +4009,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": 343,
+      "referenceNumber": 399,
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -3937,7 +4021,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": 293,
+      "referenceNumber": 609,
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
@@ -3949,7 +4033,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": 259,
+      "referenceNumber": 576,
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -3961,12 +4045,12 @@
       "reference": "https://spdx.org/licenses/GPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": 145,
+      "referenceNumber": 79,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
         "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
+        "https://opensource.org/license/GPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3975,12 +4059,12 @@
       "reference": "https://spdx.org/licenses/GPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": 83,
+      "referenceNumber": 129,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
         "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
+        "https://opensource.org/license/GPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -3989,12 +4073,12 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": 443,
+      "referenceNumber": 162,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
+        "https://opensource.org/license/GPL-3.0-only"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4003,12 +4087,12 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": 142,
+      "referenceNumber": 537,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
+        "https://opensource.org/license/GPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4017,7 +4101,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": 670,
+      "referenceNumber": 283,
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -4029,7 +4113,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": 595,
+      "referenceNumber": 107,
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
@@ -4041,7 +4125,7 @@
       "reference": "https://spdx.org/licenses/Graphics-Gems.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Graphics-Gems.json",
-      "referenceNumber": 667,
+      "referenceNumber": 364,
       "name": "Graphics Gems License",
       "licenseId": "Graphics-Gems",
       "seeAlso": [
@@ -4053,7 +4137,7 @@
       "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": 511,
+      "referenceNumber": 712,
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -4065,7 +4149,7 @@
       "reference": "https://spdx.org/licenses/gtkbook.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gtkbook.json",
-      "referenceNumber": 103,
+      "referenceNumber": 606,
       "name": "gtkbook License",
       "licenseId": "gtkbook",
       "seeAlso": [
@@ -4078,7 +4162,7 @@
       "reference": "https://spdx.org/licenses/Gutmann.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Gutmann.json",
-      "referenceNumber": 610,
+      "referenceNumber": 567,
       "name": "Gutmann License",
       "licenseId": "Gutmann",
       "seeAlso": [
@@ -4090,7 +4174,7 @@
       "reference": "https://spdx.org/licenses/HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": 550,
+      "referenceNumber": 359,
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -4102,7 +4186,7 @@
       "reference": "https://spdx.org/licenses/HDF5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HDF5.json",
-      "referenceNumber": 52,
+      "referenceNumber": 197,
       "name": "HDF5 License",
       "licenseId": "HDF5",
       "seeAlso": [
@@ -4114,7 +4198,7 @@
       "reference": "https://spdx.org/licenses/hdparm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/hdparm.json",
-      "referenceNumber": 258,
+      "referenceNumber": 114,
       "name": "hdparm License",
       "licenseId": "hdparm",
       "seeAlso": [
@@ -4126,7 +4210,7 @@
       "reference": "https://spdx.org/licenses/HIDAPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HIDAPI.json",
-      "referenceNumber": 178,
+      "referenceNumber": 578,
       "name": "HIDAPI License",
       "licenseId": "HIDAPI",
       "seeAlso": [
@@ -4138,7 +4222,7 @@
       "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
-      "referenceNumber": 246,
+      "referenceNumber": 682,
       "name": "Hippocratic License 2.1",
       "licenseId": "Hippocratic-2.1",
       "seeAlso": [
@@ -4151,7 +4235,7 @@
       "reference": "https://spdx.org/licenses/HP-1986.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1986.json",
-      "referenceNumber": 577,
+      "referenceNumber": 230,
       "name": "Hewlett-Packard 1986 License",
       "licenseId": "HP-1986",
       "seeAlso": [
@@ -4163,7 +4247,7 @@
       "reference": "https://spdx.org/licenses/HP-1989.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1989.json",
-      "referenceNumber": 380,
+      "referenceNumber": 325,
       "name": "Hewlett-Packard 1989 License",
       "licenseId": "HP-1989",
       "seeAlso": [
@@ -4175,11 +4259,11 @@
       "reference": "https://spdx.org/licenses/HPND.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND.json",
-      "referenceNumber": 300,
+      "referenceNumber": 156,
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
-        "https://opensource.org/licenses/HPND",
+        "https://opensource.org/license/HPND",
         "http://lists.opensource.org/pipermail/license-discuss_lists.opensource.org/2002-November/006304.html"
       ],
       "isOsiApproved": true,
@@ -4189,7 +4273,7 @@
       "reference": "https://spdx.org/licenses/HPND-DEC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-DEC.json",
-      "referenceNumber": 199,
+      "referenceNumber": 590,
       "name": "Historical Permission Notice and Disclaimer - DEC variant",
       "licenseId": "HPND-DEC",
       "seeAlso": [
@@ -4201,7 +4285,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc.json",
-      "referenceNumber": 217,
+      "referenceNumber": 559,
       "name": "Historical Permission Notice and Disclaimer - documentation variant",
       "licenseId": "HPND-doc",
       "seeAlso": [
@@ -4214,7 +4298,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc-sell.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc-sell.json",
-      "referenceNumber": 137,
+      "referenceNumber": 568,
       "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
       "licenseId": "HPND-doc-sell",
       "seeAlso": [
@@ -4227,7 +4311,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US.json",
-      "referenceNumber": 707,
+      "referenceNumber": 622,
       "name": "HPND with US Government export control warning",
       "licenseId": "HPND-export-US",
       "seeAlso": [
@@ -4239,7 +4323,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US-acknowledgement.json",
-      "referenceNumber": 493,
+      "referenceNumber": 507,
       "name": "HPND with US Government export control warning and acknowledgment",
       "licenseId": "HPND-export-US-acknowledgement",
       "seeAlso": [
@@ -4252,7 +4336,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US-modify.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US-modify.json",
-      "referenceNumber": 395,
+      "referenceNumber": 596,
       "name": "HPND with US Government export control warning and modification rqmt",
       "licenseId": "HPND-export-US-modify",
       "seeAlso": [
@@ -4265,7 +4349,7 @@
       "reference": "https://spdx.org/licenses/HPND-export2-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export2-US.json",
-      "referenceNumber": 151,
+      "referenceNumber": 688,
       "name": "HPND with US Government export control and 2 disclaimers",
       "licenseId": "HPND-export2-US",
       "seeAlso": [
@@ -4278,7 +4362,7 @@
       "reference": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.json",
-      "referenceNumber": 524,
+      "referenceNumber": 324,
       "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
       "licenseId": "HPND-Fenneberg-Livingston",
       "seeAlso": [
@@ -4291,7 +4375,7 @@
       "reference": "https://spdx.org/licenses/HPND-INRIA-IMAG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-INRIA-IMAG.json",
-      "referenceNumber": 188,
+      "referenceNumber": 106,
       "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
       "licenseId": "HPND-INRIA-IMAG",
       "seeAlso": [
@@ -4303,7 +4387,7 @@
       "reference": "https://spdx.org/licenses/HPND-Intel.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Intel.json",
-      "referenceNumber": 461,
+      "referenceNumber": 625,
       "name": "Historical Permission Notice and Disclaimer - Intel variant",
       "licenseId": "HPND-Intel",
       "seeAlso": [
@@ -4315,7 +4399,7 @@
       "reference": "https://spdx.org/licenses/HPND-Kevlin-Henney.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Kevlin-Henney.json",
-      "referenceNumber": 221,
+      "referenceNumber": 427,
       "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
       "licenseId": "HPND-Kevlin-Henney",
       "seeAlso": [
@@ -4327,7 +4411,7 @@
       "reference": "https://spdx.org/licenses/HPND-Markus-Kuhn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Markus-Kuhn.json",
-      "referenceNumber": 361,
+      "referenceNumber": 676,
       "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
       "licenseId": "HPND-Markus-Kuhn",
       "seeAlso": [
@@ -4340,7 +4424,7 @@
       "reference": "https://spdx.org/licenses/HPND-merchantability-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-merchantability-variant.json",
-      "referenceNumber": 701,
+      "referenceNumber": 539,
       "name": "Historical Permission Notice and Disclaimer - merchantability variant",
       "licenseId": "HPND-merchantability-variant",
       "seeAlso": [
@@ -4352,7 +4436,7 @@
       "reference": "https://spdx.org/licenses/HPND-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-MIT-disclaimer.json",
-      "referenceNumber": 257,
+      "referenceNumber": 551,
       "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
       "licenseId": "HPND-MIT-disclaimer",
       "seeAlso": [
@@ -4364,7 +4448,7 @@
       "reference": "https://spdx.org/licenses/HPND-Netrek.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Netrek.json",
-      "referenceNumber": 110,
+      "referenceNumber": 154,
       "name": "Historical Permission Notice and Disclaimer - Netrek variant",
       "licenseId": "HPND-Netrek",
       "seeAlso": [],
@@ -4374,7 +4458,7 @@
       "reference": "https://spdx.org/licenses/HPND-Pbmplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Pbmplus.json",
-      "referenceNumber": 640,
+      "referenceNumber": 348,
       "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
       "licenseId": "HPND-Pbmplus",
       "seeAlso": [
@@ -4386,7 +4470,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.json",
-      "referenceNumber": 303,
+      "referenceNumber": 210,
       "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
       "licenseId": "HPND-sell-MIT-disclaimer-xserver",
       "seeAlso": [
@@ -4398,7 +4482,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-regexpr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-regexpr.json",
-      "referenceNumber": 653,
+      "referenceNumber": 237,
       "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
       "licenseId": "HPND-sell-regexpr",
       "seeAlso": [
@@ -4410,7 +4494,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": 213,
+      "referenceNumber": 291,
       "name": "Historical Permission Notice and Disclaimer - sell variant",
       "licenseId": "HPND-sell-variant",
       "seeAlso": [
@@ -4420,10 +4504,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant-critical-systems.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-critical-systems.json",
+      "referenceNumber": 224,
+      "name": "HPND - sell variant with safety critical systems clause",
+      "licenseId": "HPND-sell-variant-critical-systems",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/driver/xf86-video-voodoo/-/blob/68a5b6d98ae34749cca889f4373b4043d00bfe6a/src/voodoo_dga.c#L12-33"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.json",
-      "referenceNumber": 536,
+      "referenceNumber": 635,
       "name": "HPND sell variant with MIT disclaimer",
       "licenseId": "HPND-sell-variant-MIT-disclaimer",
       "seeAlso": [
@@ -4435,7 +4531,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.json",
-      "referenceNumber": 442,
+      "referenceNumber": 179,
       "name": "HPND sell variant with MIT disclaimer - reverse",
       "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
       "seeAlso": [
@@ -4447,7 +4543,7 @@
       "reference": "https://spdx.org/licenses/HPND-SMC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-SMC.json",
-      "referenceNumber": 477,
+      "referenceNumber": 392,
       "name": "Historical Permission Notice and Disclaimer - SMC variant",
       "licenseId": "HPND-SMC",
       "seeAlso": [
@@ -4459,7 +4555,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC.json",
-      "referenceNumber": 682,
+      "referenceNumber": 334,
       "name": "Historical Permission Notice and Disclaimer - University of California variant",
       "licenseId": "HPND-UC",
       "seeAlso": [
@@ -4471,7 +4567,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC-export-US.json",
-      "referenceNumber": 523,
+      "referenceNumber": 339,
       "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
       "licenseId": "HPND-UC-export-US",
       "seeAlso": [
@@ -4483,7 +4579,7 @@
       "reference": "https://spdx.org/licenses/HTMLTIDY.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
-      "referenceNumber": 193,
+      "referenceNumber": 176,
       "name": "HTML Tidy License",
       "licenseId": "HTMLTIDY",
       "seeAlso": [
@@ -4495,7 +4591,7 @@
       "reference": "https://spdx.org/licenses/hyphen-bulgarian.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/hyphen-bulgarian.json",
-      "referenceNumber": 470,
+      "referenceNumber": 629,
       "name": "hyphen-bulgarian License",
       "licenseId": "hyphen-bulgarian",
       "seeAlso": [
@@ -4508,7 +4604,7 @@
       "reference": "https://spdx.org/licenses/IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": 67,
+      "referenceNumber": 404,
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -4520,7 +4616,7 @@
       "reference": "https://spdx.org/licenses/ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ICU.json",
-      "referenceNumber": 271,
+      "referenceNumber": 521,
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -4532,7 +4628,7 @@
       "reference": "https://spdx.org/licenses/IEC-Code-Components-EULA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IEC-Code-Components-EULA.json",
-      "referenceNumber": 194,
+      "referenceNumber": 189,
       "name": "IEC    Code Components End-user licence agreement",
       "licenseId": "IEC-Code-Components-EULA",
       "seeAlso": [
@@ -4546,7 +4642,7 @@
       "reference": "https://spdx.org/licenses/IJG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG.json",
-      "referenceNumber": 96,
+      "referenceNumber": 21,
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -4561,7 +4657,7 @@
       "reference": "https://spdx.org/licenses/IJG-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG-short.json",
-      "referenceNumber": 633,
+      "referenceNumber": 284,
       "name": "Independent JPEG Group License - short",
       "licenseId": "IJG-short",
       "seeAlso": [
@@ -4573,7 +4669,7 @@
       "reference": "https://spdx.org/licenses/ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": 358,
+      "referenceNumber": 111,
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -4585,7 +4681,7 @@
       "reference": "https://spdx.org/licenses/iMatix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/iMatix.json",
-      "referenceNumber": 466,
+      "referenceNumber": 605,
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -4598,7 +4694,7 @@
       "reference": "https://spdx.org/licenses/Imlib2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": 634,
+      "referenceNumber": 299,
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -4612,7 +4708,7 @@
       "reference": "https://spdx.org/licenses/Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": 327,
+      "referenceNumber": 378,
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -4621,10 +4717,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/Informatica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Informatica.json",
+      "referenceNumber": 420,
+      "name": "Informatica License",
+      "licenseId": "Informatica",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/landtuna/open-mtools/6c04c2882eca7c4313ec267766ea53ac9bfe129b/msend.c",
+        "https://raw.githubusercontent.com/landtuna/open-mtools/6c04c2882eca7c4313ec267766ea53ac9bfe129b/mdump.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Inner-Net-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Inner-Net-2.0.json",
-      "referenceNumber": 284,
+      "referenceNumber": 577,
       "name": "Inner Net License v2.0",
       "licenseId": "Inner-Net-2.0",
       "seeAlso": [
@@ -4637,7 +4746,7 @@
       "reference": "https://spdx.org/licenses/InnoSetup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/InnoSetup.json",
-      "referenceNumber": 9,
+      "referenceNumber": 147,
       "name": "Inno Setup License",
       "licenseId": "InnoSetup",
       "seeAlso": [
@@ -4649,11 +4758,11 @@
       "reference": "https://spdx.org/licenses/Intel.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel.json",
-      "referenceNumber": 413,
+      "referenceNumber": 322,
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
-        "https://opensource.org/licenses/Intel"
+        "https://opensource.org/license/Intel"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4662,7 +4771,7 @@
       "reference": "https://spdx.org/licenses/Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": 320,
+      "referenceNumber": 582,
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -4674,7 +4783,7 @@
       "reference": "https://spdx.org/licenses/Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": 433,
+      "referenceNumber": 714,
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -4686,11 +4795,11 @@
       "reference": "https://spdx.org/licenses/IPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPA.json",
-      "referenceNumber": 507,
+      "referenceNumber": 194,
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
-        "https://opensource.org/licenses/IPA"
+        "https://opensource.org/license/IPA"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4699,11 +4808,11 @@
       "reference": "https://spdx.org/licenses/IPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": 332,
+      "referenceNumber": 279,
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/IPL-1.0"
+        "https://opensource.org/license/IPL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4712,13 +4821,13 @@
       "reference": "https://spdx.org/licenses/ISC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC.json",
-      "referenceNumber": 485,
+      "referenceNumber": 298,
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
         "https://www.isc.org/licenses/",
         "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "https://opensource.org/licenses/ISC"
+        "https://opensource.org/license/ISC"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4727,7 +4836,7 @@
       "reference": "https://spdx.org/licenses/ISC-Veillard.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC-Veillard.json",
-      "referenceNumber": 396,
+      "referenceNumber": 32,
       "name": "ISC Veillard variant",
       "licenseId": "ISC-Veillard",
       "seeAlso": [
@@ -4738,10 +4847,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/ISO-permission.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ISO-permission.json",
+      "referenceNumber": 238,
+      "name": "ISO permission notice",
+      "licenseId": "ISO-permission",
+      "seeAlso": [
+        "https://gitlab.com/agmartin/linuxdoc-tools/-/blob/master/iso-entities/COPYING?ref_type\u003dheads",
+        "https://www.itu.int/ITU-T/formal-language/itu-t/t/t173/1997/ISOMHEG-sir.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Jam.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Jam.json",
-      "referenceNumber": 109,
+      "referenceNumber": 209,
       "name": "Jam License",
       "licenseId": "Jam",
       "seeAlso": [
@@ -4754,7 +4876,7 @@
       "reference": "https://spdx.org/licenses/JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": 657,
+      "referenceNumber": 594,
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -4766,7 +4888,7 @@
       "reference": "https://spdx.org/licenses/jove.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/jove.json",
-      "referenceNumber": 230,
+      "referenceNumber": 261,
       "name": "Jove License",
       "licenseId": "jove",
       "seeAlso": [
@@ -4778,7 +4900,7 @@
       "reference": "https://spdx.org/licenses/JPL-image.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPL-image.json",
-      "referenceNumber": 30,
+      "referenceNumber": 300,
       "name": "JPL Image Use Policy",
       "licenseId": "JPL-image",
       "seeAlso": [
@@ -4790,7 +4912,7 @@
       "reference": "https://spdx.org/licenses/JPNIC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": 576,
+      "referenceNumber": 557,
       "name": "Japan Network Information Center License",
       "licenseId": "JPNIC",
       "seeAlso": [
@@ -4802,7 +4924,7 @@
       "reference": "https://spdx.org/licenses/JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JSON.json",
-      "referenceNumber": 305,
+      "referenceNumber": 221,
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -4815,7 +4937,7 @@
       "reference": "https://spdx.org/licenses/Kastrup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kastrup.json",
-      "referenceNumber": 663,
+      "referenceNumber": 630,
       "name": "Kastrup License",
       "licenseId": "Kastrup",
       "seeAlso": [
@@ -4827,7 +4949,7 @@
       "reference": "https://spdx.org/licenses/Kazlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kazlib.json",
-      "referenceNumber": 201,
+      "referenceNumber": 645,
       "name": "Kazlib License",
       "licenseId": "Kazlib",
       "seeAlso": [
@@ -4839,7 +4961,7 @@
       "reference": "https://spdx.org/licenses/Knuth-CTAN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Knuth-CTAN.json",
-      "referenceNumber": 362,
+      "referenceNumber": 180,
       "name": "Knuth CTAN License",
       "licenseId": "Knuth-CTAN",
       "seeAlso": [
@@ -4851,7 +4973,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": 236,
+      "referenceNumber": 54,
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -4863,7 +4985,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": 465,
+      "referenceNumber": 16,
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -4875,7 +4997,7 @@
       "reference": "https://spdx.org/licenses/Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": 225,
+      "referenceNumber": 526,
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -4887,7 +5009,7 @@
       "reference": "https://spdx.org/licenses/Latex2e-translated-notice.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e-translated-notice.json",
-      "referenceNumber": 66,
+      "referenceNumber": 234,
       "name": "Latex2e with translated notice permission",
       "licenseId": "Latex2e-translated-notice",
       "seeAlso": [
@@ -4899,7 +5021,7 @@
       "reference": "https://spdx.org/licenses/Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": 184,
+      "referenceNumber": 388,
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -4911,7 +5033,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": 365,
+      "referenceNumber": 357,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -4923,7 +5045,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": 479,
+      "referenceNumber": 86,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
@@ -4935,7 +5057,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": 294,
+      "referenceNumber": 243,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
@@ -4947,7 +5069,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": 264,
+      "referenceNumber": 706,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
@@ -4959,12 +5081,12 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": 256,
+      "referenceNumber": 546,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
+        "https://opensource.org/license/LGPL-2.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4973,12 +5095,12 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": 186,
+      "referenceNumber": 611,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
+        "https://opensource.org/license/LGPL-2.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -4987,12 +5109,13 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": 476,
+      "referenceNumber": 160,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html",
+        "https://opensource.org/license/LGPL-2.1-only"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5001,12 +5124,13 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": 328,
+      "referenceNumber": 512,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html",
+        "https://opensource.org/license/LGPL-2.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5015,13 +5139,13 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": 383,
+      "referenceNumber": 397,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
         "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
         "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
+        "https://opensource.org/license/LGPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5030,13 +5154,13 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": 567,
+      "referenceNumber": 732,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
         "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
         "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
+        "https://opensource.org/license/LGPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5045,13 +5169,13 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": 712,
+      "referenceNumber": 478,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
         "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
+        "https://opensource.org/license/LGPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5060,13 +5184,13 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": 548,
+      "referenceNumber": 491,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
         "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
-        "https://opensource.org/licenses/LGPL-3.0"
+        "https://opensource.org/license/LGPL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5075,7 +5199,7 @@
       "reference": "https://spdx.org/licenses/LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": 43,
+      "referenceNumber": 200,
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -5087,7 +5211,7 @@
       "reference": "https://spdx.org/licenses/Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Libpng.json",
-      "referenceNumber": 276,
+      "referenceNumber": 459,
       "name": "libpng License",
       "licenseId": "Libpng",
       "seeAlso": [
@@ -5099,7 +5223,7 @@
       "reference": "https://spdx.org/licenses/libpng-1.6.35.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libpng-1.6.35.json",
-      "referenceNumber": 431,
+      "referenceNumber": 350,
       "name": "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)",
       "licenseId": "libpng-1.6.35",
       "seeAlso": [
@@ -5111,7 +5235,7 @@
       "reference": "https://spdx.org/licenses/libpng-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": 333,
+      "referenceNumber": 669,
       "name": "PNG Reference Library version 2",
       "licenseId": "libpng-2.0",
       "seeAlso": [
@@ -5123,7 +5247,7 @@
       "reference": "https://spdx.org/licenses/libselinux-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
-      "referenceNumber": 321,
+      "referenceNumber": 597,
       "name": "libselinux public domain notice",
       "licenseId": "libselinux-1.0",
       "seeAlso": [
@@ -5135,7 +5259,7 @@
       "reference": "https://spdx.org/licenses/libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libtiff.json",
-      "referenceNumber": 215,
+      "referenceNumber": 259,
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -5147,7 +5271,7 @@
       "reference": "https://spdx.org/licenses/libutil-David-Nugent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libutil-David-Nugent.json",
-      "referenceNumber": 407,
+      "referenceNumber": 402,
       "name": "libutil David Nugent License",
       "licenseId": "libutil-David-Nugent",
       "seeAlso": [
@@ -5160,12 +5284,13 @@
       "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": 197,
+      "referenceNumber": 225,
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
         "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-P-1.1"
+        "http://opensource.org/license/LiLiQ-P-1.1",
+        "https://forge.gouv.qc.ca/licence/liliq-p/"
       ],
       "isOsiApproved": true
     },
@@ -5173,12 +5298,13 @@
       "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": 620,
+      "referenceNumber": 260,
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
         "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-R-1.1"
+        "http://opensource.org/license/LiLiQ-R-1.1",
+        "https://forge.gouv.qc.ca/licence/liliq-p"
       ],
       "isOsiApproved": true
     },
@@ -5186,12 +5312,13 @@
       "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": 506,
+      "referenceNumber": 220,
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
         "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
+        "http://opensource.org/license/LiLiQ-Rplus-1.1",
+        "https://forge.gouv.qc.ca/licence/liliq-r+/"
       ],
       "isOsiApproved": true
     },
@@ -5199,7 +5326,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-1-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-1-para.json",
-      "referenceNumber": 330,
+      "referenceNumber": 632,
       "name": "Linux man-pages - 1 paragraph",
       "licenseId": "Linux-man-pages-1-para",
       "seeAlso": [
@@ -5211,7 +5338,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
-      "referenceNumber": 360,
+      "referenceNumber": 148,
       "name": "Linux man-pages Copyleft",
       "licenseId": "Linux-man-pages-copyleft",
       "seeAlso": [
@@ -5223,7 +5350,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.json",
-      "referenceNumber": 603,
+      "referenceNumber": 602,
       "name": "Linux man-pages Copyleft - 2 paragraphs",
       "licenseId": "Linux-man-pages-copyleft-2-para",
       "seeAlso": [
@@ -5236,7 +5363,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.json",
-      "referenceNumber": 617,
+      "referenceNumber": 400,
       "name": "Linux man-pages Copyleft Variant",
       "licenseId": "Linux-man-pages-copyleft-var",
       "seeAlso": [
@@ -5248,7 +5375,7 @@
       "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": 631,
+      "referenceNumber": 681,
       "name": "Linux Kernel Variant of OpenIB.org license",
       "licenseId": "Linux-OpenIB",
       "seeAlso": [
@@ -5260,7 +5387,7 @@
       "reference": "https://spdx.org/licenses/LOOP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LOOP.json",
-      "referenceNumber": 515,
+      "referenceNumber": 698,
       "name": "Common Lisp LOOP License",
       "licenseId": "LOOP",
       "seeAlso": [
@@ -5277,7 +5404,7 @@
       "reference": "https://spdx.org/licenses/LPD-document.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPD-document.json",
-      "referenceNumber": 226,
+      "referenceNumber": 640,
       "name": "LPD Documentation License",
       "licenseId": "LPD-document",
       "seeAlso": [
@@ -5290,11 +5417,11 @@
       "reference": "https://spdx.org/licenses/LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": 39,
+      "referenceNumber": 415,
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/LPL-1.0"
+        "https://opensource.org/license/LPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -5302,12 +5429,12 @@
       "reference": "https://spdx.org/licenses/LPL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": 521,
+      "referenceNumber": 690,
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
         "http://plan9.bell-labs.com/plan9/license.html",
-        "https://opensource.org/licenses/LPL-1.02"
+        "https://opensource.org/license/LPL-1.02"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5316,7 +5443,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": 21,
+      "referenceNumber": 529,
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -5328,7 +5455,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": 370,
+      "referenceNumber": 533,
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -5340,7 +5467,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": 528,
+      "referenceNumber": 687,
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -5353,7 +5480,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": 464,
+      "referenceNumber": 69,
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -5366,12 +5493,12 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": 665,
+      "referenceNumber": 48,
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "https://opensource.org/licenses/LPPL-1.3c"
+        "http://www.latex-project.org/lppl/LPPL-1.3c.txt",
+        "https://opensource.org/license/LPPL-1.3c"
       ],
       "isOsiApproved": true
     },
@@ -5379,7 +5506,7 @@
       "reference": "https://spdx.org/licenses/lsof.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/lsof.json",
-      "referenceNumber": 652,
+      "referenceNumber": 141,
       "name": "lsof License",
       "licenseId": "lsof",
       "seeAlso": [
@@ -5391,7 +5518,7 @@
       "reference": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.json",
-      "referenceNumber": 525,
+      "referenceNumber": 263,
       "name": "Lucida Bitmap Fonts License",
       "licenseId": "Lucida-Bitmap-Fonts",
       "seeAlso": [
@@ -5403,7 +5530,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
-      "referenceNumber": 204,
+      "referenceNumber": 303,
       "name": "LZMA SDK License (versions 9.11 to 9.20)",
       "licenseId": "LZMA-SDK-9.11-to-9.20",
       "seeAlso": [
@@ -5416,7 +5543,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
-      "referenceNumber": 457,
+      "referenceNumber": 678,
       "name": "LZMA SDK License (versions 9.22 and beyond)",
       "licenseId": "LZMA-SDK-9.22",
       "seeAlso": [
@@ -5429,7 +5556,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause.json",
-      "referenceNumber": 8,
+      "referenceNumber": 498,
       "name": "Mackerras 3-Clause License",
       "licenseId": "Mackerras-3-Clause",
       "seeAlso": [
@@ -5441,7 +5568,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.json",
-      "referenceNumber": 385,
+      "referenceNumber": 363,
       "name": "Mackerras 3-Clause - acknowledgment variant",
       "licenseId": "Mackerras-3-Clause-acknowledgment",
       "seeAlso": [
@@ -5453,7 +5580,7 @@
       "reference": "https://spdx.org/licenses/magaz.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/magaz.json",
-      "referenceNumber": 138,
+      "referenceNumber": 65,
       "name": "magaz License",
       "licenseId": "magaz",
       "seeAlso": [
@@ -5466,7 +5593,7 @@
       "reference": "https://spdx.org/licenses/mailprio.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mailprio.json",
-      "referenceNumber": 107,
+      "referenceNumber": 170,
       "name": "mailprio License",
       "licenseId": "mailprio",
       "seeAlso": [
@@ -5478,7 +5605,7 @@
       "reference": "https://spdx.org/licenses/MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": 1,
+      "referenceNumber": 515,
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -5490,7 +5617,7 @@
       "reference": "https://spdx.org/licenses/man2html.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/man2html.json",
-      "referenceNumber": 704,
+      "referenceNumber": 562,
       "name": "man2html License",
       "licenseId": "man2html",
       "seeAlso": [
@@ -5504,7 +5631,7 @@
       "reference": "https://spdx.org/licenses/Martin-Birgmeier.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Martin-Birgmeier.json",
-      "referenceNumber": 447,
+      "referenceNumber": 97,
       "name": "Martin Birgmeier License",
       "licenseId": "Martin-Birgmeier",
       "seeAlso": [
@@ -5516,7 +5643,7 @@
       "reference": "https://spdx.org/licenses/McPhee-slideshow.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/McPhee-slideshow.json",
-      "referenceNumber": 29,
+      "referenceNumber": 473,
       "name": "McPhee Slideshow License",
       "licenseId": "McPhee-slideshow",
       "seeAlso": [
@@ -5528,7 +5655,7 @@
       "reference": "https://spdx.org/licenses/metamail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/metamail.json",
-      "referenceNumber": 144,
+      "referenceNumber": 10,
       "name": "metamail License",
       "licenseId": "metamail",
       "seeAlso": [
@@ -5540,7 +5667,7 @@
       "reference": "https://spdx.org/licenses/Minpack.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Minpack.json",
-      "referenceNumber": 357,
+      "referenceNumber": 289,
       "name": "Minpack License",
       "licenseId": "Minpack",
       "seeAlso": [
@@ -5553,7 +5680,7 @@
       "reference": "https://spdx.org/licenses/MIPS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIPS.json",
-      "referenceNumber": 79,
+      "referenceNumber": 468,
       "name": "MIPS License",
       "licenseId": "MIPS",
       "seeAlso": [
@@ -5565,11 +5692,11 @@
       "reference": "https://spdx.org/licenses/MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MirOS.json",
-      "referenceNumber": 2,
+      "referenceNumber": 196,
       "name": "The MirOS Licence",
       "licenseId": "MirOS",
       "seeAlso": [
-        "https://opensource.org/licenses/MirOS"
+        "https://opensource.org/license/MirOS"
       ],
       "isOsiApproved": true
     },
@@ -5577,12 +5704,12 @@
       "reference": "https://spdx.org/licenses/MIT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT.json",
-      "referenceNumber": 116,
+      "referenceNumber": 331,
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
-        "https://opensource.org/license/mit/",
-        "http://opensource.org/licenses/MIT"
+        "https://opensource.org/license/MIT",
+        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/dd5c2595a42d3ff0c4f18d9b53d1f6c3fd934fd4/COPYING#L365-389"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5591,7 +5718,7 @@
       "reference": "https://spdx.org/licenses/MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": 247,
+      "referenceNumber": 323,
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -5605,7 +5732,7 @@
       "reference": "https://spdx.org/licenses/MIT-advertising.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": 398,
+      "referenceNumber": 367,
       "name": "Enlightenment License (e16)",
       "licenseId": "MIT-advertising",
       "seeAlso": [
@@ -5617,7 +5744,7 @@
       "reference": "https://spdx.org/licenses/MIT-Click.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Click.json",
-      "referenceNumber": 439,
+      "referenceNumber": 346,
       "name": "MIT Click License",
       "licenseId": "MIT-Click",
       "seeAlso": [
@@ -5629,7 +5756,7 @@
       "reference": "https://spdx.org/licenses/MIT-CMU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": 344,
+      "referenceNumber": 496,
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
@@ -5642,7 +5769,7 @@
       "reference": "https://spdx.org/licenses/MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": 606,
+      "referenceNumber": 673,
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -5654,7 +5781,7 @@
       "reference": "https://spdx.org/licenses/MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": 710,
+      "referenceNumber": 240,
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -5666,7 +5793,7 @@
       "reference": "https://spdx.org/licenses/MIT-Festival.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Festival.json",
-      "referenceNumber": 102,
+      "referenceNumber": 508,
       "name": "MIT Festival Variant",
       "licenseId": "MIT-Festival",
       "seeAlso": [
@@ -5679,7 +5806,7 @@
       "reference": "https://spdx.org/licenses/MIT-Khronos-old.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Khronos-old.json",
-      "referenceNumber": 584,
+      "referenceNumber": 550,
       "name": "MIT Khronos - old variant",
       "licenseId": "MIT-Khronos-old",
       "seeAlso": [
@@ -5691,7 +5818,7 @@
       "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
-      "referenceNumber": 229,
+      "referenceNumber": 2,
       "name": "MIT License Modern Variant",
       "licenseId": "MIT-Modern-Variant",
       "seeAlso": [
@@ -5705,7 +5832,7 @@
       "reference": "https://spdx.org/licenses/MIT-open-group.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
-      "referenceNumber": 547,
+      "referenceNumber": 168,
       "name": "MIT Open Group variant",
       "licenseId": "MIT-open-group",
       "seeAlso": [
@@ -5719,7 +5846,7 @@
       "reference": "https://spdx.org/licenses/MIT-STK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-STK.json",
-      "referenceNumber": 291,
+      "referenceNumber": 619,
       "name": "MIT-STK License",
       "licenseId": "MIT-STK",
       "seeAlso": [
@@ -5731,7 +5858,7 @@
       "reference": "https://spdx.org/licenses/MIT-testregex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-testregex.json",
-      "referenceNumber": 632,
+      "referenceNumber": 387,
       "name": "MIT testregex Variant",
       "licenseId": "MIT-testregex",
       "seeAlso": [
@@ -5743,7 +5870,7 @@
       "reference": "https://spdx.org/licenses/MIT-Wu.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Wu.json",
-      "referenceNumber": 282,
+      "referenceNumber": 362,
       "name": "MIT Tom Wu Variant",
       "licenseId": "MIT-Wu",
       "seeAlso": [
@@ -5755,7 +5882,7 @@
       "reference": "https://spdx.org/licenses/MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": 430,
+      "referenceNumber": 727,
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -5767,7 +5894,7 @@
       "reference": "https://spdx.org/licenses/MMIXware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MMIXware.json",
-      "referenceNumber": 326,
+      "referenceNumber": 395,
       "name": "MMIXware License",
       "licenseId": "MMIXware",
       "seeAlso": [
@@ -5776,14 +5903,27 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/MMPL-1.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MMPL-1.0.1.json",
+      "referenceNumber": 595,
+      "name": "Minecraft Mod Public License v1.0.1",
+      "licenseId": "MMPL-1.0.1",
+      "seeAlso": [
+        "https://github.com/BuildCraft/BuildCraft/blob/623d323b1868712f29f4a8b0979a02e8d1835131/LICENSE",
+        "https://mod-buildcraft.com/MMPL-1.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": 157,
+      "referenceNumber": 71,
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
-        "https://opensource.org/licenses/Motosoto"
+        "https://opensource.org/license/Motosoto"
       ],
       "isOsiApproved": true
     },
@@ -5791,7 +5931,7 @@
       "reference": "https://spdx.org/licenses/MPEG-SSG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPEG-SSG.json",
-      "referenceNumber": 574,
+      "referenceNumber": 421,
       "name": "MPEG Software Simulation",
       "licenseId": "MPEG-SSG",
       "seeAlso": [
@@ -5803,7 +5943,7 @@
       "reference": "https://spdx.org/licenses/mpi-permissive.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
-      "referenceNumber": 76,
+      "referenceNumber": 12,
       "name": "mpi Permissive License",
       "licenseId": "mpi-permissive",
       "seeAlso": [
@@ -5815,7 +5955,7 @@
       "reference": "https://spdx.org/licenses/mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpich2.json",
-      "referenceNumber": 100,
+      "referenceNumber": 302,
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -5827,12 +5967,12 @@
       "reference": "https://spdx.org/licenses/MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": 426,
+      "referenceNumber": 372,
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
         "http://www.mozilla.org/MPL/MPL-1.0.html",
-        "https://opensource.org/licenses/MPL-1.0"
+        "https://opensource.org/license/MPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -5840,12 +5980,12 @@
       "reference": "https://spdx.org/licenses/MPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": 474,
+      "referenceNumber": 707,
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
         "http://www.mozilla.org/MPL/MPL-1.1.html",
-        "https://opensource.org/licenses/MPL-1.1"
+        "https://opensource.org/license/MPL-1.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5854,12 +5994,12 @@
       "reference": "https://spdx.org/licenses/MPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": 414,
+      "referenceNumber": 721,
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
         "https://www.mozilla.org/MPL/2.0/",
-        "https://opensource.org/licenses/MPL-2.0"
+        "https://opensource.org/license/MPL-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5868,12 +6008,12 @@
       "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": 519,
+      "referenceNumber": 31,
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
         "https://www.mozilla.org/MPL/2.0/",
-        "https://opensource.org/licenses/MPL-2.0"
+        "https://opensource.org/license/MPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -5881,7 +6021,7 @@
       "reference": "https://spdx.org/licenses/mplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mplus.json",
-      "referenceNumber": 253,
+      "referenceNumber": 612,
       "name": "mplus Font License",
       "licenseId": "mplus",
       "seeAlso": [
@@ -5893,7 +6033,7 @@
       "reference": "https://spdx.org/licenses/MS-LPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
-      "referenceNumber": 169,
+      "referenceNumber": 518,
       "name": "Microsoft Limited Public License",
       "licenseId": "MS-LPL",
       "seeAlso": [
@@ -5907,12 +6047,12 @@
       "reference": "https://spdx.org/licenses/MS-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": 60,
+      "referenceNumber": 649,
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
-        "https://opensource.org/licenses/MS-PL"
+        "https://opensource.org/license/MS-PL"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5921,12 +6061,12 @@
       "reference": "https://spdx.org/licenses/MS-RL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": 18,
+      "referenceNumber": 488,
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
-        "https://opensource.org/licenses/MS-RL"
+        "https://opensource.org/license/MS-RL"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -5935,7 +6075,7 @@
       "reference": "https://spdx.org/licenses/MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MTLL.json",
-      "referenceNumber": 368,
+      "referenceNumber": 37,
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -5947,7 +6087,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
-      "referenceNumber": 299,
+      "referenceNumber": 84,
       "name": "Mulan Permissive Software License, Version 1",
       "licenseId": "MulanPSL-1.0",
       "seeAlso": [
@@ -5960,7 +6100,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
-      "referenceNumber": 713,
+      "referenceNumber": 617,
       "name": "Mulan Permissive Software License, Version 2",
       "licenseId": "MulanPSL-2.0",
       "seeAlso": [
@@ -5972,11 +6112,11 @@
       "reference": "https://spdx.org/licenses/Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Multics.json",
-      "referenceNumber": 540,
+      "referenceNumber": 685,
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
-        "https://opensource.org/licenses/Multics"
+        "https://opensource.org/license/Multics"
       ],
       "isOsiApproved": true
     },
@@ -5984,7 +6124,7 @@
       "reference": "https://spdx.org/licenses/Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mup.json",
-      "referenceNumber": 711,
+      "referenceNumber": 425,
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -5993,10 +6133,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/MVT-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MVT-1.1.json",
+      "referenceNumber": 138,
+      "name": "MVT License 1.1",
+      "licenseId": "MVT-1.1",
+      "seeAlso": [
+        "https://license.mvt.re/1.1/",
+        "https://docs.mvt.re/en/latest/license/",
+        "https://github.com/mvt-project/mvt/blob/main/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/NAIST-2003.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
-      "referenceNumber": 673,
+      "referenceNumber": 656,
       "name": "Nara Institute of Science and Technology License (2003)",
       "licenseId": "NAIST-2003",
       "seeAlso": [
@@ -6009,12 +6163,12 @@
       "reference": "https://spdx.org/licenses/NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": 706,
+      "referenceNumber": 426,
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
         "http://ti.arc.nasa.gov/opensource/nosa/",
-        "https://opensource.org/licenses/NASA-1.3"
+        "https://opensource.org/license/NASA-1.3"
       ],
       "isOsiApproved": true,
       "isFsfLibre": false
@@ -6023,11 +6177,11 @@
       "reference": "https://spdx.org/licenses/Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Naumen.json",
-      "referenceNumber": 648,
+      "referenceNumber": 467,
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
-        "https://opensource.org/licenses/Naumen"
+        "https://opensource.org/license/Naumen"
       ],
       "isOsiApproved": true
     },
@@ -6035,7 +6189,7 @@
       "reference": "https://spdx.org/licenses/NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": 310,
+      "referenceNumber": 717,
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -6047,7 +6201,7 @@
       "reference": "https://spdx.org/licenses/NCBI-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCBI-PD.json",
-      "referenceNumber": 542,
+      "referenceNumber": 431,
       "name": "NCBI Public Domain Notice",
       "licenseId": "NCBI-PD",
       "seeAlso": [
@@ -6063,7 +6217,7 @@
       "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
-      "referenceNumber": 387,
+      "referenceNumber": 276,
       "name": "Non-Commercial Government Licence",
       "licenseId": "NCGL-UK-2.0",
       "seeAlso": [
@@ -6075,7 +6229,7 @@
       "reference": "https://spdx.org/licenses/NCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCL.json",
-      "referenceNumber": 520,
+      "referenceNumber": 330,
       "name": "NCL Source Code License",
       "licenseId": "NCL",
       "seeAlso": [
@@ -6087,12 +6241,12 @@
       "reference": "https://spdx.org/licenses/NCSA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCSA.json",
-      "referenceNumber": 86,
+      "referenceNumber": 236,
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
         "http://otm.illinois.edu/uiuc_openSource",
-        "https://opensource.org/licenses/NCSA"
+        "https://opensource.org/license/NCSA"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -6101,7 +6255,7 @@
       "reference": "https://spdx.org/licenses/Net-SNMP.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": 78,
+      "referenceNumber": 389,
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -6113,7 +6267,7 @@
       "reference": "https://spdx.org/licenses/NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": 687,
+      "referenceNumber": 3,
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -6125,7 +6279,7 @@
       "reference": "https://spdx.org/licenses/Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": 454,
+      "referenceNumber": 393,
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -6137,11 +6291,11 @@
       "reference": "https://spdx.org/licenses/NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NGPL.json",
-      "referenceNumber": 417,
+      "referenceNumber": 212,
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
-        "https://opensource.org/licenses/NGPL"
+        "https://opensource.org/license/NGPL"
       ],
       "isOsiApproved": true
     },
@@ -6149,7 +6303,7 @@
       "reference": "https://spdx.org/licenses/ngrep.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ngrep.json",
-      "referenceNumber": 165,
+      "referenceNumber": 70,
       "name": "ngrep License",
       "licenseId": "ngrep",
       "seeAlso": [
@@ -6161,7 +6315,7 @@
       "reference": "https://spdx.org/licenses/NICTA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
-      "referenceNumber": 388,
+      "referenceNumber": 490,
       "name": "NICTA Public Software License, Version 1.0",
       "licenseId": "NICTA-1.0",
       "seeAlso": [
@@ -6173,7 +6327,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
-      "referenceNumber": 424,
+      "referenceNumber": 586,
       "name": "NIST Public Domain Notice",
       "licenseId": "NIST-PD",
       "seeAlso": [
@@ -6186,7 +6340,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
-      "referenceNumber": 195,
+      "referenceNumber": 159,
       "name": "NIST Public Domain Notice with license fallback",
       "licenseId": "NIST-PD-fallback",
       "seeAlso": [
@@ -6199,7 +6353,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD-TNT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD-TNT.json",
-      "referenceNumber": 112,
+      "referenceNumber": 277,
       "name": "NIST    Public Domain Notice TNT variant",
       "licenseId": "NIST-PD-TNT",
       "seeAlso": [
@@ -6211,10 +6365,11 @@
       "reference": "https://spdx.org/licenses/NIST-Software.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-Software.json",
-      "referenceNumber": 20,
+      "referenceNumber": 318,
       "name": "NIST Software License",
       "licenseId": "NIST-Software",
       "seeAlso": [
+        "https://www.nist.gov/open/copyright-fair-use-and-licensing-statements-srd-data-software-and-technical-series-publications",
         "https://github.com/open-quantum-safe/liboqs/blob/40b01fdbb270f8614fde30e65d30e9da18c02393/src/common/rand/rand_nist.c#L1-L15"
       ],
       "isOsiApproved": false
@@ -6223,7 +6378,7 @@
       "reference": "https://spdx.org/licenses/NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": 656,
+      "referenceNumber": 131,
       "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -6235,7 +6390,7 @@
       "reference": "https://spdx.org/licenses/NLOD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
-      "referenceNumber": 363,
+      "referenceNumber": 78,
       "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
       "licenseId": "NLOD-2.0",
       "seeAlso": [
@@ -6247,7 +6402,7 @@
       "reference": "https://spdx.org/licenses/NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLPL.json",
-      "referenceNumber": 436,
+      "referenceNumber": 648,
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -6259,11 +6414,11 @@
       "reference": "https://spdx.org/licenses/Nokia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Nokia.json",
-      "referenceNumber": 32,
+      "referenceNumber": 44,
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
-        "https://opensource.org/licenses/nokia"
+        "https://opensource.org/license/Nokia"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -6272,7 +6427,7 @@
       "reference": "https://spdx.org/licenses/NOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NOSL.json",
-      "referenceNumber": 260,
+      "referenceNumber": 39,
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -6285,7 +6440,7 @@
       "reference": "https://spdx.org/licenses/Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Noweb.json",
-      "referenceNumber": 12,
+      "referenceNumber": 19,
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -6297,7 +6452,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": 119,
+      "referenceNumber": 569,
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -6310,7 +6465,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": 621,
+      "referenceNumber": 670,
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -6323,11 +6478,11 @@
       "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": 304,
+      "referenceNumber": 120,
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
-        "https://opensource.org/licenses/NOSL3.0"
+        "https://opensource.org/license/NPOSL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -6335,7 +6490,7 @@
       "reference": "https://spdx.org/licenses/NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NRL.json",
-      "referenceNumber": 10,
+      "referenceNumber": 255,
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -6347,7 +6502,7 @@
       "reference": "https://spdx.org/licenses/NTIA-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTIA-PD.json",
-      "referenceNumber": 47,
+      "referenceNumber": 241,
       "name": "NTIA Public Domain Notice",
       "licenseId": "NTIA-PD",
       "seeAlso": [
@@ -6360,11 +6515,11 @@
       "reference": "https://spdx.org/licenses/NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP.json",
-      "referenceNumber": 239,
+      "referenceNumber": 18,
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
-        "https://opensource.org/licenses/NTP"
+        "https://opensource.org/license/NTP"
       ],
       "isOsiApproved": true
     },
@@ -6372,7 +6527,7 @@
       "reference": "https://spdx.org/licenses/NTP-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
-      "referenceNumber": 391,
+      "referenceNumber": 83,
       "name": "NTP No Attribution",
       "licenseId": "NTP-0",
       "seeAlso": [
@@ -6384,7 +6539,7 @@
       "reference": "https://spdx.org/licenses/Nunit.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Nunit.json",
-      "referenceNumber": 689,
+      "referenceNumber": 414,
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -6397,7 +6552,7 @@
       "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
-      "referenceNumber": 578,
+      "referenceNumber": 531,
       "name": "Open Use of Data Agreement v1.0",
       "licenseId": "O-UDA-1.0",
       "seeAlso": [
@@ -6410,7 +6565,7 @@
       "reference": "https://spdx.org/licenses/OAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OAR.json",
-      "referenceNumber": 81,
+      "referenceNumber": 581,
       "name": "OAR License",
       "licenseId": "OAR",
       "seeAlso": [
@@ -6422,7 +6577,7 @@
       "reference": "https://spdx.org/licenses/OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": 425,
+      "referenceNumber": 265,
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -6434,12 +6589,12 @@
       "reference": "https://spdx.org/licenses/OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": 54,
+      "referenceNumber": 310,
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
         "http://www.oclc.org/research/activities/software/license/v2final.htm",
-        "https://opensource.org/licenses/OCLC-2.0"
+        "https://opensource.org/license/OCLC-2.0"
       ],
       "isOsiApproved": true
     },
@@ -6447,7 +6602,7 @@
       "reference": "https://spdx.org/licenses/ODbL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": 614,
+      "referenceNumber": 667,
       "name": "Open Data Commons Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -6461,7 +6616,7 @@
       "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": 481,
+      "referenceNumber": 639,
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -6473,7 +6628,7 @@
       "reference": "https://spdx.org/licenses/OFFIS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFFIS.json",
-      "referenceNumber": 265,
+      "referenceNumber": 668,
       "name": "OFFIS License",
       "licenseId": "OFFIS",
       "seeAlso": [
@@ -6485,7 +6640,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": 68,
+      "referenceNumber": 157,
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -6498,7 +6653,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
-      "referenceNumber": 115,
+      "referenceNumber": 593,
       "name": "SIL Open Font License 1.0 with no Reserved Font Name",
       "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
@@ -6510,7 +6665,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
-      "referenceNumber": 401,
+      "referenceNumber": 370,
       "name": "SIL Open Font License 1.0 with Reserved Font Name",
       "licenseId": "OFL-1.0-RFN",
       "seeAlso": [
@@ -6522,12 +6677,12 @@
       "reference": "https://spdx.org/licenses/OFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": 462,
+      "referenceNumber": 458,
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
+        "https://opensource.org/license/OFL-1.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -6536,12 +6691,12 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
-      "referenceNumber": 120,
+      "referenceNumber": 620,
       "name": "SIL Open Font License 1.1 with no Reserved Font Name",
       "licenseId": "OFL-1.1-no-RFN",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
+        "https://opensource.org/license/OFL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -6549,12 +6704,12 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
-      "referenceNumber": 318,
+      "referenceNumber": 729,
       "name": "SIL Open Font License 1.1 with Reserved Font Name",
       "licenseId": "OFL-1.1-RFN",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
-        "https://opensource.org/licenses/OFL-1.1"
+        "https://opensource.org/license/OFL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -6562,7 +6717,7 @@
       "reference": "https://spdx.org/licenses/OGC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
-      "referenceNumber": 53,
+      "referenceNumber": 38,
       "name": "OGC Software License, Version 1.0",
       "licenseId": "OGC-1.0",
       "seeAlso": [
@@ -6574,7 +6729,7 @@
       "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
-      "referenceNumber": 613,
+      "referenceNumber": 233,
       "name": "Taiwan Open Government Data License, version 1.0",
       "licenseId": "OGDL-Taiwan-1.0",
       "seeAlso": [
@@ -6586,7 +6741,7 @@
       "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
-      "referenceNumber": 309,
+      "referenceNumber": 82,
       "name": "Open Government Licence - Canada",
       "licenseId": "OGL-Canada-2.0",
       "seeAlso": [
@@ -6598,7 +6753,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": 220,
+      "referenceNumber": 607,
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -6610,7 +6765,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": 111,
+      "referenceNumber": 166,
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -6622,7 +6777,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": 146,
+      "referenceNumber": 694,
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -6634,12 +6789,12 @@
       "reference": "https://spdx.org/licenses/OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": 643,
+      "referenceNumber": 256,
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
         "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
-        "https://opensource.org/licenses/OGTSL"
+        "https://opensource.org/license/OGTSL"
       ],
       "isOsiApproved": true
     },
@@ -6647,7 +6802,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": 552,
+      "referenceNumber": 598,
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -6659,7 +6814,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": 228,
+      "referenceNumber": 492,
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -6671,7 +6826,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": 592,
+      "referenceNumber": 40,
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -6683,7 +6838,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": 104,
+      "referenceNumber": 319,
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -6695,7 +6850,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": 683,
+      "referenceNumber": 493,
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -6707,7 +6862,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": 26,
+      "referenceNumber": 652,
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -6719,7 +6874,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": 458,
+      "referenceNumber": 563,
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -6731,7 +6886,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": 658,
+      "referenceNumber": 696,
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -6743,7 +6898,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": 279,
+      "referenceNumber": 713,
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -6755,7 +6910,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": 114,
+      "referenceNumber": 423,
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -6767,7 +6922,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": 677,
+      "referenceNumber": 725,
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -6780,7 +6935,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": 106,
+      "referenceNumber": 371,
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -6792,7 +6947,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": 156,
+      "referenceNumber": 94,
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -6804,7 +6959,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": 339,
+      "referenceNumber": 72,
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -6816,7 +6971,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": 163,
+      "referenceNumber": 545,
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -6829,7 +6984,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": 698,
+      "referenceNumber": 435,
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -6841,12 +6996,12 @@
       "reference": "https://spdx.org/licenses/OLFL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLFL-1.3.json",
-      "referenceNumber": 126,
+      "referenceNumber": 419,
       "name": "Open Logistics Foundation License Version 1.3",
       "licenseId": "OLFL-1.3",
       "seeAlso": [
         "https://openlogisticsfoundation.org/licenses/",
-        "https://opensource.org/license/olfl-1-3/"
+        "https://opensource.org/license/OLFL-1.3"
       ],
       "isOsiApproved": true
     },
@@ -6854,7 +7009,7 @@
       "reference": "https://spdx.org/licenses/OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OML.json",
-      "referenceNumber": 366,
+      "referenceNumber": 252,
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -6863,10 +7018,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/OpenMDW-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenMDW-1.0.json",
+      "referenceNumber": 17,
+      "name": "OpenMDW License Agreement v1.0",
+      "licenseId": "OpenMDW-1.0",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/OpenMDW/OpenMDW/refs/heads/main/1.0/LICENSE.openmdw",
+        "https://openmdw.ai/license/"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/OpenPBS-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenPBS-2.3.json",
-      "referenceNumber": 377,
+      "referenceNumber": 710,
       "name": "OpenPBS v2.3 Software License",
       "licenseId": "OpenPBS-2.3",
       "seeAlso": [
@@ -6879,7 +7047,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": 173,
+      "referenceNumber": 125,
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -6892,7 +7060,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL-standalone.json",
-      "referenceNumber": 437,
+      "referenceNumber": 329,
       "name": "OpenSSL License - standalone",
       "licenseId": "OpenSSL-standalone",
       "seeAlso": [
@@ -6905,7 +7073,7 @@
       "reference": "https://spdx.org/licenses/OpenVision.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenVision.json",
-      "referenceNumber": 233,
+      "referenceNumber": 447,
       "name": "OpenVision License",
       "licenseId": "OpenVision",
       "seeAlso": [
@@ -6919,7 +7087,7 @@
       "reference": "https://spdx.org/licenses/OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": 340,
+      "referenceNumber": 680,
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -6933,7 +7101,7 @@
       "reference": "https://spdx.org/licenses/OPL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-UK-3.0.json",
-      "referenceNumber": 73,
+      "referenceNumber": 671,
       "name": "United    Kingdom Open Parliament Licence v3.0",
       "licenseId": "OPL-UK-3.0",
       "seeAlso": [
@@ -6945,7 +7113,7 @@
       "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
-      "referenceNumber": 409,
+      "referenceNumber": 499,
       "name": "Open Publication License v1.0",
       "licenseId": "OPUBL-1.0",
       "seeAlso": [
@@ -6956,15 +7124,27 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/OSC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSC-1.0.json",
+      "referenceNumber": 711,
+      "name": "OSC License 1.0",
+      "licenseId": "OSC-1.0",
+      "seeAlso": [
+        "https://opensource.org/license/OSC-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": 419,
+      "referenceNumber": 46,
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
         "http://www.osetfoundation.org/public-license",
-        "https://opensource.org/licenses/OPL-2.1"
+        "https://opensource.org/license/OSET-PL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -6972,11 +7152,11 @@
       "reference": "https://spdx.org/licenses/OSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": 661,
+      "referenceNumber": 186,
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/OSL-1.0"
+        "https://opensource.org/license/OSL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -6985,7 +7165,7 @@
       "reference": "https://spdx.org/licenses/OSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": 438,
+      "referenceNumber": 222,
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -6998,7 +7178,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": 666,
+      "referenceNumber": 664,
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -7011,12 +7191,12 @@
       "reference": "https://spdx.org/licenses/OSL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": 286,
+      "referenceNumber": 424,
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
         "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
-        "https://opensource.org/licenses/OSL-2.1"
+        "https://opensource.org/license/OSL-2.1"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -7025,12 +7205,12 @@
       "reference": "https://spdx.org/licenses/OSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": 351,
+      "referenceNumber": 340,
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
         "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
-        "https://opensource.org/licenses/OSL-3.0"
+        "https://opensource.org/license/OSL-3.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -7039,7 +7219,7 @@
       "reference": "https://spdx.org/licenses/OSSP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSSP.json",
-      "referenceNumber": 283,
+      "referenceNumber": 356,
       "name": "OSSP License",
       "licenseId": "OSSP",
       "seeAlso": [
@@ -7051,7 +7231,7 @@
       "reference": "https://spdx.org/licenses/PADL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PADL.json",
-      "referenceNumber": 585,
+      "referenceNumber": 89,
       "name": "PADL License",
       "licenseId": "PADL",
       "seeAlso": [
@@ -7060,10 +7240,23 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/ParaType-Free-Font-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ParaType-Free-Font-1.3.json",
+      "referenceNumber": 461,
+      "name": "ParaType Free Font Licensing Agreement v1.3",
+      "licenseId": "ParaType-Free-Font-1.3",
+      "seeAlso": [
+        "https://web.archive.org/web/20161209023955/http://www.paratype.ru/public/pt_openlicense_eng.asp",
+        "https://metadata.ftp-master.debian.org/changelogs//main/f/fonts-paratype/fonts-paratype_20181108-4_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
-      "referenceNumber": 48,
+      "referenceNumber": 294,
       "name": "The Parity Public License 6.0.0",
       "licenseId": "Parity-6.0.0",
       "seeAlso": [
@@ -7075,7 +7268,7 @@
       "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
-      "referenceNumber": 622,
+      "referenceNumber": 439,
       "name": "The Parity Public License 7.0.0",
       "licenseId": "Parity-7.0.0",
       "seeAlso": [
@@ -7087,7 +7280,7 @@
       "reference": "https://spdx.org/licenses/PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": 688,
+      "referenceNumber": 481,
       "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
@@ -7100,12 +7293,12 @@
       "reference": "https://spdx.org/licenses/PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": 494,
+      "referenceNumber": 525,
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
         "http://www.php.net/license/3_0.txt",
-        "https://opensource.org/licenses/PHP-3.0"
+        "https://opensource.org/license/PHP-3.0"
       ],
       "isOsiApproved": true
     },
@@ -7113,7 +7306,7 @@
       "reference": "https://spdx.org/licenses/PHP-3.01.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": 278,
+      "referenceNumber": 659,
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
@@ -7126,7 +7319,7 @@
       "reference": "https://spdx.org/licenses/Pixar.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Pixar.json",
-      "referenceNumber": 625,
+      "referenceNumber": 647,
       "name": "Pixar License",
       "licenseId": "Pixar",
       "seeAlso": [
@@ -7140,7 +7333,7 @@
       "reference": "https://spdx.org/licenses/pkgconf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pkgconf.json",
-      "referenceNumber": 219,
+      "referenceNumber": 646,
       "name": "pkgconf License",
       "licenseId": "pkgconf",
       "seeAlso": [
@@ -7152,7 +7345,7 @@
       "reference": "https://spdx.org/licenses/Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Plexus.json",
-      "referenceNumber": 153,
+      "referenceNumber": 145,
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -7164,7 +7357,7 @@
       "reference": "https://spdx.org/licenses/pnmstitch.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pnmstitch.json",
-      "referenceNumber": 200,
+      "referenceNumber": 337,
       "name": "pnmstitch License",
       "licenseId": "pnmstitch",
       "seeAlso": [
@@ -7176,7 +7369,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
-      "referenceNumber": 616,
+      "referenceNumber": 150,
       "name": "PolyForm Noncommercial License 1.0.0",
       "licenseId": "PolyForm-Noncommercial-1.0.0",
       "seeAlso": [
@@ -7188,7 +7381,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
-      "referenceNumber": 496,
+      "referenceNumber": 522,
       "name": "PolyForm Small Business License 1.0.0",
       "licenseId": "PolyForm-Small-Business-1.0.0",
       "seeAlso": [
@@ -7200,12 +7393,12 @@
       "reference": "https://spdx.org/licenses/PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": 708,
+      "referenceNumber": 161,
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
         "http://www.postgresql.org/about/licence",
-        "https://opensource.org/licenses/PostgreSQL"
+        "https://opensource.org/license/PostgreSQL"
       ],
       "isOsiApproved": true
     },
@@ -7213,7 +7406,7 @@
       "reference": "https://spdx.org/licenses/PPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PPL.json",
-      "referenceNumber": 672,
+      "referenceNumber": 658,
       "name": "Peer Production License",
       "licenseId": "PPL",
       "seeAlso": [
@@ -7227,11 +7420,11 @@
       "reference": "https://spdx.org/licenses/PSF-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
-      "referenceNumber": 483,
+      "referenceNumber": 433,
       "name": "Python Software Foundation License 2.0",
       "licenseId": "PSF-2.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Python-2.0",
+        "https://opensource.org/license/PSF-2-0",
         "https://matplotlib.org/stable/project/license.html"
       ],
       "isOsiApproved": false
@@ -7240,7 +7433,7 @@
       "reference": "https://spdx.org/licenses/psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psfrag.json",
-      "referenceNumber": 162,
+      "referenceNumber": 165,
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -7252,7 +7445,7 @@
       "reference": "https://spdx.org/licenses/psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psutils.json",
-      "referenceNumber": 262,
+      "referenceNumber": 591,
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -7264,11 +7457,11 @@
       "reference": "https://spdx.org/licenses/Python-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": 108,
+      "referenceNumber": 99,
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Python-2.0"
+        "https://opensource.org/license/Python-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -7277,7 +7470,7 @@
       "reference": "https://spdx.org/licenses/Python-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
-      "referenceNumber": 164,
+      "referenceNumber": 57,
       "name": "Python License 2.0.1",
       "licenseId": "Python-2.0.1",
       "seeAlso": [
@@ -7291,7 +7484,7 @@
       "reference": "https://spdx.org/licenses/python-ldap.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/python-ldap.json",
-      "referenceNumber": 272,
+      "referenceNumber": 290,
       "name": "Python ldap License",
       "licenseId": "python-ldap",
       "seeAlso": [
@@ -7303,7 +7496,7 @@
       "reference": "https://spdx.org/licenses/Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Qhull.json",
-      "referenceNumber": 61,
+      "referenceNumber": 251,
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -7315,12 +7508,12 @@
       "reference": "https://spdx.org/licenses/QPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": 421,
+      "referenceNumber": 383,
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
         "http://doc.qt.nokia.com/3.3/license.html",
-        "https://opensource.org/licenses/QPL-1.0",
+        "https://opensource.org/license/QPL-1.0",
         "https://doc.qt.io/archives/3.3/license.html"
       ],
       "isOsiApproved": true,
@@ -7330,7 +7523,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.json",
-      "referenceNumber": 319,
+      "referenceNumber": 20,
       "name": "Q Public License 1.0 - INRIA 2004 variant",
       "licenseId": "QPL-1.0-INRIA-2004",
       "seeAlso": [
@@ -7342,7 +7535,7 @@
       "reference": "https://spdx.org/licenses/radvd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/radvd.json",
-      "referenceNumber": 605,
+      "referenceNumber": 155,
       "name": "radvd License",
       "licenseId": "radvd",
       "seeAlso": [
@@ -7354,7 +7547,7 @@
       "reference": "https://spdx.org/licenses/Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": 158,
+      "referenceNumber": 61,
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -7366,7 +7559,7 @@
       "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": 599,
+      "referenceNumber": 285,
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -7379,11 +7572,11 @@
       "reference": "https://spdx.org/licenses/RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": 132,
+      "referenceNumber": 482,
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
-        "https://opensource.org/licenses/RPL-1.1"
+        "https://opensource.org/license/RPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -7391,11 +7584,11 @@
       "reference": "https://spdx.org/licenses/RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": 298,
+      "referenceNumber": 643,
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
-        "https://opensource.org/licenses/RPL-1.5"
+        "https://opensource.org/license/RPL-1.5"
       ],
       "isOsiApproved": true
     },
@@ -7403,12 +7596,12 @@
       "reference": "https://spdx.org/licenses/RPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": 25,
+      "referenceNumber": 81,
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
         "https://helixcommunity.org/content/rpsl",
-        "https://opensource.org/licenses/RPSL-1.0"
+        "https://opensource.org/license/RPSL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -7417,7 +7610,7 @@
       "reference": "https://spdx.org/licenses/RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": 527,
+      "referenceNumber": 500,
       "name": "RSA Message-Digest License",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -7429,12 +7622,12 @@
       "reference": "https://spdx.org/licenses/RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": 565,
+      "referenceNumber": 703,
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
         "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
-        "https://opensource.org/licenses/RSCPL"
+        "https://opensource.org/license/RSCPL"
       ],
       "isOsiApproved": true
     },
@@ -7442,7 +7635,7 @@
       "reference": "https://spdx.org/licenses/Ruby.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ruby.json",
-      "referenceNumber": 324,
+      "referenceNumber": 723,
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -7455,7 +7648,7 @@
       "reference": "https://spdx.org/licenses/Ruby-pty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ruby-pty.json",
-      "referenceNumber": 662,
+      "referenceNumber": 686,
       "name": "Ruby pty extension license",
       "licenseId": "Ruby-pty",
       "seeAlso": [
@@ -7469,7 +7662,7 @@
       "reference": "https://spdx.org/licenses/SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": 179,
+      "referenceNumber": 270,
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -7481,7 +7674,7 @@
       "reference": "https://spdx.org/licenses/SAX-PD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD-2.0.json",
-      "referenceNumber": 287,
+      "referenceNumber": 584,
       "name": "Sax Public Domain Notice 2.0",
       "licenseId": "SAX-PD-2.0",
       "seeAlso": [
@@ -7493,7 +7686,7 @@
       "reference": "https://spdx.org/licenses/Saxpath.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": 50,
+      "referenceNumber": 184,
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -7505,7 +7698,7 @@
       "reference": "https://spdx.org/licenses/SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SCEA.json",
-      "referenceNumber": 646,
+      "referenceNumber": 304,
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -7517,7 +7710,7 @@
       "reference": "https://spdx.org/licenses/SchemeReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
-      "referenceNumber": 269,
+      "referenceNumber": 422,
       "name": "Scheme Language Report License",
       "licenseId": "SchemeReport",
       "seeAlso": [],
@@ -7527,7 +7720,7 @@
       "reference": "https://spdx.org/licenses/Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": 654,
+      "referenceNumber": 50,
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -7540,7 +7733,7 @@
       "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": 551,
+      "referenceNumber": 36,
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -7553,7 +7746,7 @@
       "reference": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.json",
-      "referenceNumber": 703,
+      "referenceNumber": 127,
       "name": "Sendmail Open Source License v1.1",
       "licenseId": "Sendmail-Open-Source-1.1",
       "seeAlso": [
@@ -7565,7 +7758,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": 538,
+      "referenceNumber": 572,
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -7577,7 +7770,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": 664,
+      "referenceNumber": 520,
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -7589,7 +7782,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": 444,
+      "referenceNumber": 571,
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -7602,7 +7795,7 @@
       "reference": "https://spdx.org/licenses/SGI-OpenGL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-OpenGL.json",
-      "referenceNumber": 505,
+      "referenceNumber": 377,
       "name": "SGI OpenGL License",
       "licenseId": "SGI-OpenGL",
       "seeAlso": [
@@ -7614,7 +7807,7 @@
       "reference": "https://spdx.org/licenses/SGMLUG-PM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGMLUG-PM.json",
-      "referenceNumber": 635,
+      "referenceNumber": 600,
       "name": "SGMLUG Parser Materials License",
       "licenseId": "SGMLUG-PM",
       "seeAlso": [
@@ -7626,7 +7819,7 @@
       "reference": "https://spdx.org/licenses/SGP4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGP4.json",
-      "referenceNumber": 227,
+      "referenceNumber": 76,
       "name": "SGP4 Permission Notice",
       "licenseId": "SGP4",
       "seeAlso": [
@@ -7638,7 +7831,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
-      "referenceNumber": 124,
+      "referenceNumber": 113,
       "name": "Solderpad Hardware License v0.5",
       "licenseId": "SHL-0.5",
       "seeAlso": [
@@ -7650,7 +7843,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.51.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
-      "referenceNumber": 337,
+      "referenceNumber": 380,
       "name": "Solderpad Hardware License, Version 0.51",
       "licenseId": "SHL-0.51",
       "seeAlso": [
@@ -7662,11 +7855,11 @@
       "reference": "https://spdx.org/licenses/SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": 174,
+      "referenceNumber": 628,
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
-        "https://opensource.org/licenses/SimPL-2.0"
+        "https://opensource.org/license/SiMPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -7674,12 +7867,12 @@
       "reference": "https://spdx.org/licenses/SISSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL.json",
-      "referenceNumber": 7,
+      "referenceNumber": 417,
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
         "http://www.openoffice.org/licenses/sissl_license.html",
-        "https://opensource.org/licenses/SISSL"
+        "https://opensource.org/license/SISSL"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -7688,7 +7881,7 @@
       "reference": "https://spdx.org/licenses/SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": 504,
+      "referenceNumber": 353,
       "name": "Sun Industry Standards Source License v1.2",
       "licenseId": "SISSL-1.2",
       "seeAlso": [
@@ -7700,7 +7893,7 @@
       "reference": "https://spdx.org/licenses/SL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SL.json",
-      "referenceNumber": 647,
+      "referenceNumber": 307,
       "name": "SL License",
       "licenseId": "SL",
       "seeAlso": [
@@ -7712,11 +7905,11 @@
       "reference": "https://spdx.org/licenses/Sleepycat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": 570,
+      "referenceNumber": 604,
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
-        "https://opensource.org/licenses/Sleepycat"
+        "https://opensource.org/license/Sleepycat"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -7725,7 +7918,7 @@
       "reference": "https://spdx.org/licenses/SMAIL-GPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMAIL-GPL.json",
-      "referenceNumber": 99,
+      "referenceNumber": 502,
       "name": "SMAIL General Public License",
       "licenseId": "SMAIL-GPL",
       "seeAlso": [
@@ -7737,7 +7930,7 @@
       "reference": "https://spdx.org/licenses/SMLNJ.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": 59,
+      "referenceNumber": 428,
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -7750,7 +7943,7 @@
       "reference": "https://spdx.org/licenses/SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": 512,
+      "referenceNumber": 173,
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -7762,7 +7955,7 @@
       "reference": "https://spdx.org/licenses/SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SNIA.json",
-      "referenceNumber": 390,
+      "referenceNumber": 122,
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -7774,7 +7967,7 @@
       "reference": "https://spdx.org/licenses/snprintf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/snprintf.json",
-      "referenceNumber": 57,
+      "referenceNumber": 441,
       "name": "snprintf License",
       "licenseId": "snprintf",
       "seeAlso": [
@@ -7786,7 +7979,7 @@
       "reference": "https://spdx.org/licenses/SOFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SOFA.json",
-      "referenceNumber": 608,
+      "referenceNumber": 470,
       "name": "SOFA Software License",
       "licenseId": "SOFA",
       "seeAlso": [
@@ -7798,7 +7991,7 @@
       "reference": "https://spdx.org/licenses/softSurfer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/softSurfer.json",
-      "referenceNumber": 455,
+      "referenceNumber": 5,
       "name": "softSurfer License",
       "licenseId": "softSurfer",
       "seeAlso": [
@@ -7811,7 +8004,7 @@
       "reference": "https://spdx.org/licenses/Soundex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Soundex.json",
-      "referenceNumber": 514,
+      "referenceNumber": 144,
       "name": "Soundex License",
       "licenseId": "Soundex",
       "seeAlso": [
@@ -7823,7 +8016,7 @@
       "reference": "https://spdx.org/licenses/Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": 127,
+      "referenceNumber": 614,
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -7835,7 +8028,7 @@
       "reference": "https://spdx.org/licenses/Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": 593,
+      "referenceNumber": 436,
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -7848,7 +8041,7 @@
       "reference": "https://spdx.org/licenses/Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": 58,
+      "referenceNumber": 538,
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -7860,11 +8053,11 @@
       "reference": "https://spdx.org/licenses/SPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": 618,
+      "referenceNumber": 326,
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/SPL-1.0"
+        "https://opensource.org/license/SPL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -7873,7 +8066,7 @@
       "reference": "https://spdx.org/licenses/ssh-keyscan.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ssh-keyscan.json",
-      "referenceNumber": 290,
+      "referenceNumber": 366,
       "name": "ssh-keyscan License",
       "licenseId": "ssh-keyscan",
       "seeAlso": [
@@ -7885,7 +8078,7 @@
       "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
-      "referenceNumber": 306,
+      "referenceNumber": 146,
       "name": "SSH OpenSSH license",
       "licenseId": "SSH-OpenSSH",
       "seeAlso": [
@@ -7897,7 +8090,7 @@
       "reference": "https://spdx.org/licenses/SSH-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
-      "referenceNumber": 171,
+      "referenceNumber": 456,
       "name": "SSH short notice",
       "licenseId": "SSH-short",
       "seeAlso": [
@@ -7911,7 +8104,7 @@
       "reference": "https://spdx.org/licenses/SSLeay-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSLeay-standalone.json",
-      "referenceNumber": 382,
+      "referenceNumber": 558,
       "name": "SSLeay License - standalone",
       "licenseId": "SSLeay-standalone",
       "seeAlso": [
@@ -7923,7 +8116,7 @@
       "reference": "https://spdx.org/licenses/SSPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
-      "referenceNumber": 532,
+      "referenceNumber": 309,
       "name": "Server Side Public License, v 1",
       "licenseId": "SSPL-1.0",
       "seeAlso": [
@@ -7935,7 +8128,7 @@
       "reference": "https://spdx.org/licenses/StandardML-NJ.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": 660,
+      "referenceNumber": 437,
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -7948,7 +8141,7 @@
       "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": 192,
+      "referenceNumber": 663,
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -7960,7 +8153,7 @@
       "reference": "https://spdx.org/licenses/SUL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SUL-1.0.json",
-      "referenceNumber": 147,
+      "referenceNumber": 214,
       "name": "Sustainable Use License v1.0",
       "licenseId": "SUL-1.0",
       "seeAlso": [
@@ -7972,7 +8165,7 @@
       "reference": "https://spdx.org/licenses/Sun-PPP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP.json",
-      "referenceNumber": 98,
+      "referenceNumber": 171,
       "name": "Sun PPP License",
       "licenseId": "Sun-PPP",
       "seeAlso": [
@@ -7984,7 +8177,7 @@
       "reference": "https://spdx.org/licenses/Sun-PPP-2000.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP-2000.json",
-      "referenceNumber": 148,
+      "referenceNumber": 486,
       "name": "Sun PPP License (2000)",
       "licenseId": "Sun-PPP-2000",
       "seeAlso": [
@@ -7996,7 +8189,7 @@
       "reference": "https://spdx.org/licenses/SunPro.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SunPro.json",
-      "referenceNumber": 267,
+      "referenceNumber": 191,
       "name": "SunPro License",
       "licenseId": "SunPro",
       "seeAlso": [
@@ -8009,7 +8202,7 @@
       "reference": "https://spdx.org/licenses/SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SWL.json",
-      "referenceNumber": 180,
+      "referenceNumber": 445,
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -8021,7 +8214,7 @@
       "reference": "https://spdx.org/licenses/swrule.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/swrule.json",
-      "referenceNumber": 94,
+      "referenceNumber": 287,
       "name": "swrule License",
       "licenseId": "swrule",
       "seeAlso": [
@@ -8033,7 +8226,7 @@
       "reference": "https://spdx.org/licenses/Symlinks.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Symlinks.json",
-      "referenceNumber": 468,
+      "referenceNumber": 164,
       "name": "Symlinks License",
       "licenseId": "Symlinks",
       "seeAlso": [
@@ -8045,7 +8238,7 @@
       "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": 159,
+      "referenceNumber": 674,
       "name": "TAPR Open Hardware License v1.0",
       "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
@@ -8057,7 +8250,7 @@
       "reference": "https://spdx.org/licenses/TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCL.json",
-      "referenceNumber": 49,
+      "referenceNumber": 102,
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -8070,7 +8263,7 @@
       "reference": "https://spdx.org/licenses/TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": 543,
+      "referenceNumber": 211,
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -8082,7 +8275,7 @@
       "reference": "https://spdx.org/licenses/TekHVC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TekHVC.json",
-      "referenceNumber": 539,
+      "referenceNumber": 258,
       "name": "TekHVC License",
       "licenseId": "TekHVC",
       "seeAlso": [
@@ -8094,7 +8287,7 @@
       "reference": "https://spdx.org/licenses/TermReadKey.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TermReadKey.json",
-      "referenceNumber": 172,
+      "referenceNumber": 453,
       "name": "TermReadKey License",
       "licenseId": "TermReadKey",
       "seeAlso": [
@@ -8106,7 +8299,7 @@
       "reference": "https://spdx.org/licenses/TGPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TGPPL-1.0.json",
-      "referenceNumber": 237,
+      "referenceNumber": 278,
       "name": "Transitive Grace Period Public Licence 1.0",
       "licenseId": "TGPPL-1.0",
       "seeAlso": [
@@ -8119,7 +8312,7 @@
       "reference": "https://spdx.org/licenses/ThirdEye.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ThirdEye.json",
-      "referenceNumber": 242,
+      "referenceNumber": 360,
       "name": "ThirdEye License",
       "licenseId": "ThirdEye",
       "seeAlso": [
@@ -8131,7 +8324,7 @@
       "reference": "https://spdx.org/licenses/threeparttable.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/threeparttable.json",
-      "referenceNumber": 675,
+      "referenceNumber": 368,
       "name": "threeparttable License",
       "licenseId": "threeparttable",
       "seeAlso": [
@@ -8143,7 +8336,7 @@
       "reference": "https://spdx.org/licenses/TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TMate.json",
-      "referenceNumber": 311,
+      "referenceNumber": 391,
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -8155,7 +8348,7 @@
       "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": 359,
+      "referenceNumber": 720,
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -8167,7 +8360,7 @@
       "reference": "https://spdx.org/licenses/TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TOSL.json",
-      "referenceNumber": 129,
+      "referenceNumber": 9,
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -8179,7 +8372,7 @@
       "reference": "https://spdx.org/licenses/TPDL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPDL.json",
-      "referenceNumber": 581,
+      "referenceNumber": 51,
       "name": "Time::ParseDate License",
       "licenseId": "TPDL",
       "seeAlso": [
@@ -8191,7 +8384,7 @@
       "reference": "https://spdx.org/licenses/TPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPL-1.0.json",
-      "referenceNumber": 518,
+      "referenceNumber": 716,
       "name": "THOR Public License 1.0",
       "licenseId": "TPL-1.0",
       "seeAlso": [
@@ -8203,7 +8396,7 @@
       "reference": "https://spdx.org/licenses/TrustedQSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TrustedQSL.json",
-      "referenceNumber": 644,
+      "referenceNumber": 312,
       "name": "TrustedQSL License",
       "licenseId": "TrustedQSL",
       "seeAlso": [
@@ -8215,7 +8408,7 @@
       "reference": "https://spdx.org/licenses/TTWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTWL.json",
-      "referenceNumber": 428,
+      "referenceNumber": 693,
       "name": "Text-Tabs+Wrap License",
       "licenseId": "TTWL",
       "seeAlso": [
@@ -8228,7 +8421,7 @@
       "reference": "https://spdx.org/licenses/TTYP0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTYP0.json",
-      "referenceNumber": 85,
+      "referenceNumber": 469,
       "name": "TTYP0 License",
       "licenseId": "TTYP0",
       "seeAlso": [
@@ -8240,7 +8433,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": 410,
+      "referenceNumber": 650,
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -8252,7 +8445,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": 4,
+      "referenceNumber": 313,
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -8264,7 +8457,7 @@
       "reference": "https://spdx.org/licenses/Ubuntu-font-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ubuntu-font-1.0.json",
-      "referenceNumber": 295,
+      "referenceNumber": 199,
       "name": "Ubuntu Font Licence v1.0",
       "licenseId": "Ubuntu-font-1.0",
       "seeAlso": [
@@ -8277,7 +8470,7 @@
       "reference": "https://spdx.org/licenses/UCAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCAR.json",
-      "referenceNumber": 649,
+      "referenceNumber": 657,
       "name": "UCAR License",
       "licenseId": "UCAR",
       "seeAlso": [
@@ -8289,11 +8482,11 @@
       "reference": "https://spdx.org/licenses/UCL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
-      "referenceNumber": 70,
+      "referenceNumber": 152,
       "name": "Upstream Compatibility License v1.0",
       "licenseId": "UCL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/UCL-1.0"
+        "https://opensource.org/license/UCL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -8301,7 +8494,7 @@
       "reference": "https://spdx.org/licenses/ulem.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ulem.json",
-      "referenceNumber": 292,
+      "referenceNumber": 381,
       "name": "ulem License",
       "licenseId": "ulem",
       "seeAlso": [
@@ -8313,7 +8506,7 @@
       "reference": "https://spdx.org/licenses/UMich-Merit.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UMich-Merit.json",
-      "referenceNumber": 307,
+      "referenceNumber": 406,
       "name": "Michigan/Merit Networks License",
       "licenseId": "UMich-Merit",
       "seeAlso": [
@@ -8325,7 +8518,7 @@
       "reference": "https://spdx.org/licenses/Unicode-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-3.0.json",
-      "referenceNumber": 44,
+      "referenceNumber": 28,
       "name": "Unicode License v3",
       "licenseId": "Unicode-3.0",
       "seeAlso": [
@@ -8337,7 +8530,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": 350,
+      "referenceNumber": 449,
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -8349,7 +8542,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": 500,
+      "referenceNumber": 292,
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -8363,7 +8556,7 @@
       "reference": "https://spdx.org/licenses/Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": 651,
+      "referenceNumber": 123,
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -8376,7 +8569,7 @@
       "reference": "https://spdx.org/licenses/UnixCrypt.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UnixCrypt.json",
-      "referenceNumber": 418,
+      "referenceNumber": 119,
       "name": "UnixCrypt License",
       "licenseId": "UnixCrypt",
       "seeAlso": [
@@ -8390,7 +8583,7 @@
       "reference": "https://spdx.org/licenses/Unlicense.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": 149,
+      "referenceNumber": 228,
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -8403,7 +8596,7 @@
       "reference": "https://spdx.org/licenses/Unlicense-libtelnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unlicense-libtelnet.json",
-      "referenceNumber": 273,
+      "referenceNumber": 513,
       "name": "Unlicense - libtelnet variant",
       "licenseId": "Unlicense-libtelnet",
       "seeAlso": [
@@ -8415,7 +8608,7 @@
       "reference": "https://spdx.org/licenses/Unlicense-libwhirlpool.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unlicense-libwhirlpool.json",
-      "referenceNumber": 19,
+      "referenceNumber": 487,
       "name": "Unlicense - libwhirlpool variant",
       "licenseId": "Unlicense-libwhirlpool",
       "seeAlso": [
@@ -8424,14 +8617,26 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/UnRAR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UnRAR.json",
+      "referenceNumber": 24,
+      "name": "UnRAR License",
+      "licenseId": "UnRAR",
+      "seeAlso": [
+        "https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/LICENSES/unRAR.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/UPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": 141,
+      "referenceNumber": 267,
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/UPL"
+        "https://opensource.org/license/UPL-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -8440,7 +8645,7 @@
       "reference": "https://spdx.org/licenses/URT-RLE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/URT-RLE.json",
-      "referenceNumber": 133,
+      "referenceNumber": 282,
       "name": "Utah Raster Toolkit Run Length Encoded License",
       "licenseId": "URT-RLE",
       "seeAlso": [
@@ -8453,7 +8658,7 @@
       "reference": "https://spdx.org/licenses/Vim.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Vim.json",
-      "referenceNumber": 270,
+      "referenceNumber": 34,
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -8463,10 +8668,22 @@
       "isFsfLibre": true
     },
     {
+      "reference": "https://spdx.org/licenses/Vixie-Cron.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Vixie-Cron.json",
+      "referenceNumber": 385,
+      "name": "Vixie Cron License",
+      "licenseId": "Vixie-Cron",
+      "seeAlso": [
+        "https://github.com/vixie/cron/tree/545b3f5246824a9cda5905eeb7cf019c95e66995"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": 74,
+      "referenceNumber": 603,
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -8478,11 +8695,11 @@
       "reference": "https://spdx.org/licenses/VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": 92,
+      "referenceNumber": 185,
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/VSL-1.0"
+        "https://opensource.org/license/VSL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -8490,12 +8707,12 @@
       "reference": "https://spdx.org/licenses/W3C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C.json",
-      "referenceNumber": 486,
+      "referenceNumber": 172,
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
         "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
-        "https://opensource.org/licenses/W3C"
+        "https://opensource.org/license/W3C"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -8504,7 +8721,7 @@
       "reference": "https://spdx.org/licenses/W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": 51,
+      "referenceNumber": 495,
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -8516,7 +8733,7 @@
       "reference": "https://spdx.org/licenses/W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": 508,
+      "referenceNumber": 451,
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -8530,7 +8747,7 @@
       "reference": "https://spdx.org/licenses/w3m.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/w3m.json",
-      "referenceNumber": 166,
+      "referenceNumber": 29,
       "name": "w3m License",
       "licenseId": "w3m",
       "seeAlso": [
@@ -8542,11 +8759,11 @@
       "reference": "https://spdx.org/licenses/Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": 674,
+      "referenceNumber": 532,
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/Watcom-1.0"
+        "https://opensource.org/license/Watcom-1.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": false
@@ -8555,7 +8772,7 @@
       "reference": "https://spdx.org/licenses/Widget-Workshop.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Widget-Workshop.json",
-      "referenceNumber": 624,
+      "referenceNumber": 379,
       "name": "Widget Workshop License",
       "licenseId": "Widget-Workshop",
       "seeAlso": [
@@ -8567,7 +8784,7 @@
       "reference": "https://spdx.org/licenses/WordNet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/WordNet.json",
-      "referenceNumber": 313,
+      "referenceNumber": 566,
       "name": "WordNet License",
       "licenseId": "WordNet",
       "seeAlso": [
@@ -8579,7 +8796,7 @@
       "reference": "https://spdx.org/licenses/Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": 364,
+      "referenceNumber": 321,
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -8591,7 +8808,7 @@
       "reference": "https://spdx.org/licenses/WTFNMFPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/WTFNMFPL.json",
-      "referenceNumber": 560,
+      "referenceNumber": 87,
       "name": "Do What The F*ck You Want To But It\u0027s Not My Fault Public License",
       "licenseId": "WTFNMFPL",
       "seeAlso": [
@@ -8604,7 +8821,7 @@
       "reference": "https://spdx.org/licenses/WTFPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": 460,
+      "referenceNumber": 412,
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
@@ -8618,7 +8835,7 @@
       "reference": "https://spdx.org/licenses/wwl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/wwl.json",
-      "referenceNumber": 187,
+      "referenceNumber": 462,
       "name": "WWL License",
       "licenseId": "wwl",
       "seeAlso": [
@@ -8630,11 +8847,11 @@
       "reference": "https://spdx.org/licenses/wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": 345,
+      "referenceNumber": 592,
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
-        "https://opensource.org/licenses/WXwindows"
+        "https://opensource.org/license/wxWindows"
       ],
       "isOsiApproved": true
     },
@@ -8642,7 +8859,7 @@
       "reference": "https://spdx.org/licenses/X11.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11.json",
-      "referenceNumber": 453,
+      "referenceNumber": 704,
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -8655,7 +8872,7 @@
       "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
-      "referenceNumber": 693,
+      "referenceNumber": 432,
       "name": "X11 License Distribution Modification Variant",
       "licenseId": "X11-distribute-modifications-variant",
       "seeAlso": [
@@ -8667,7 +8884,7 @@
       "reference": "https://spdx.org/licenses/X11-no-permit-persons.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-no-permit-persons.json",
-      "referenceNumber": 255,
+      "referenceNumber": 527,
       "name": "X11 no permit persons clause",
       "licenseId": "X11-no-permit-persons",
       "seeAlso": [
@@ -8679,7 +8896,7 @@
       "reference": "https://spdx.org/licenses/X11-swapped.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-swapped.json",
-      "referenceNumber": 558,
+      "referenceNumber": 416,
       "name": "X11 swapped final paragraphs",
       "licenseId": "X11-swapped",
       "seeAlso": [
@@ -8691,7 +8908,7 @@
       "reference": "https://spdx.org/licenses/Xdebug-1.03.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xdebug-1.03.json",
-      "referenceNumber": 263,
+      "referenceNumber": 280,
       "name": "Xdebug License v 1.03",
       "licenseId": "Xdebug-1.03",
       "seeAlso": [
@@ -8703,7 +8920,7 @@
       "reference": "https://spdx.org/licenses/Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xerox.json",
-      "referenceNumber": 530,
+      "referenceNumber": 728,
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -8715,7 +8932,7 @@
       "reference": "https://spdx.org/licenses/Xfig.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xfig.json",
-      "referenceNumber": 404,
+      "referenceNumber": 548,
       "name": "Xfig License",
       "licenseId": "Xfig",
       "seeAlso": [
@@ -8729,7 +8946,7 @@
       "reference": "https://spdx.org/licenses/XFree86-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": 611,
+      "referenceNumber": 692,
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -8742,7 +8959,7 @@
       "reference": "https://spdx.org/licenses/xinetd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xinetd.json",
-      "referenceNumber": 623,
+      "referenceNumber": 555,
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -8755,7 +8972,7 @@
       "reference": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.json",
-      "referenceNumber": 583,
+      "referenceNumber": 601,
       "name": "xkeyboard-config Zinoviev License",
       "licenseId": "xkeyboard-config-Zinoviev",
       "seeAlso": [
@@ -8767,7 +8984,7 @@
       "reference": "https://spdx.org/licenses/xlock.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xlock.json",
-      "referenceNumber": 175,
+      "referenceNumber": 588,
       "name": "xlock License",
       "licenseId": "xlock",
       "seeAlso": [
@@ -8779,11 +8996,11 @@
       "reference": "https://spdx.org/licenses/Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xnet.json",
-      "referenceNumber": 349,
+      "referenceNumber": 118,
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
-        "https://opensource.org/licenses/Xnet"
+        "https://opensource.org/license/Xnet"
       ],
       "isOsiApproved": true
     },
@@ -8791,7 +9008,7 @@
       "reference": "https://spdx.org/licenses/xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xpp.json",
-      "referenceNumber": 56,
+      "referenceNumber": 47,
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -8803,7 +9020,7 @@
       "reference": "https://spdx.org/licenses/XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XSkat.json",
-      "referenceNumber": 591,
+      "referenceNumber": 62,
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -8815,7 +9032,7 @@
       "reference": "https://spdx.org/licenses/xzoom.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xzoom.json",
-      "referenceNumber": 266,
+      "referenceNumber": 382,
       "name": "xzoom License",
       "licenseId": "xzoom",
       "seeAlso": [
@@ -8827,7 +9044,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": 191,
+      "referenceNumber": 201,
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -8839,7 +9056,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": 405,
+      "referenceNumber": 139,
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -8852,7 +9069,7 @@
       "reference": "https://spdx.org/licenses/Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zed.json",
-      "referenceNumber": 594,
+      "referenceNumber": 169,
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -8864,7 +9081,7 @@
       "reference": "https://spdx.org/licenses/Zeeff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zeeff.json",
-      "referenceNumber": 40,
+      "referenceNumber": 249,
       "name": "Zeeff License",
       "licenseId": "Zeeff",
       "seeAlso": [
@@ -8876,7 +9093,7 @@
       "reference": "https://spdx.org/licenses/Zend-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": 531,
+      "referenceNumber": 13,
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -8889,7 +9106,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": 452,
+      "referenceNumber": 672,
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
       "seeAlso": [
@@ -8902,7 +9119,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": 488,
+      "referenceNumber": 429,
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -8914,12 +9131,12 @@
       "reference": "https://spdx.org/licenses/Zlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zlib.json",
-      "referenceNumber": 655,
+      "referenceNumber": 177,
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
         "http://www.zlib.net/zlib_license.html",
-        "https://opensource.org/licenses/Zlib"
+        "https://opensource.org/license/Zlib"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -8928,7 +9145,7 @@
       "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": 402,
+      "referenceNumber": 100,
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -8940,7 +9157,7 @@
       "reference": "https://spdx.org/licenses/ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": 125,
+      "referenceNumber": 149,
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -8952,12 +9169,12 @@
       "reference": "https://spdx.org/licenses/ZPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": 509,
+      "referenceNumber": 105,
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
         "http://old.zope.org/Resources/License/ZPL-2.0",
-        "https://opensource.org/licenses/ZPL-2.0"
+        "https://opensource.org/license/ZPL-2.0"
       ],
       "isOsiApproved": true,
       "isFsfLibre": true
@@ -8966,7 +9183,7 @@
       "reference": "https://spdx.org/licenses/ZPL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": 597,
+      "referenceNumber": 88,
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -8976,5 +9193,5 @@
       "isFsfLibre": true
     }
   ],
-  "releaseDate": "2025-11-21T00:00:00Z"
+  "releaseDate": "2026-07-16T00:00:00Z"
 }

--- a/pkg/licenses/files/licenses_spdx_exception.json
+++ b/pkg/licenses/files/licenses_spdx_exception.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "2e6a0e5",
+  "licenseListVersion": "e4c1f27",
   "exceptions": [
     {
       "reference": "https://spdx.org/licenses/389-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/389-exception.json",
-      "referenceNumber": 47,
+      "referenceNumber": 50,
       "name": "389 Directory Server Exception",
       "licenseExceptionId": "389-exception",
       "seeAlso": [
@@ -17,7 +17,7 @@
       "reference": "https://spdx.org/licenses/Asterisk-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Asterisk-exception.json",
-      "referenceNumber": 3,
+      "referenceNumber": 29,
       "name": "Asterisk exception",
       "licenseExceptionId": "Asterisk-exception",
       "seeAlso": [
@@ -29,7 +29,7 @@
       "reference": "https://spdx.org/licenses/Asterisk-linking-protocols-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Asterisk-linking-protocols-exception.json",
-      "referenceNumber": 4,
+      "referenceNumber": 74,
       "name": "Asterisk linking protocols exception",
       "licenseExceptionId": "Asterisk-linking-protocols-exception",
       "seeAlso": [
@@ -40,7 +40,7 @@
       "reference": "https://spdx.org/licenses/Autoconf-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-2.0.json",
-      "referenceNumber": 29,
+      "referenceNumber": 75,
       "name": "Autoconf exception 2.0",
       "licenseExceptionId": "Autoconf-exception-2.0",
       "seeAlso": [
@@ -52,7 +52,7 @@
       "reference": "https://spdx.org/licenses/Autoconf-exception-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-3.0.json",
-      "referenceNumber": 49,
+      "referenceNumber": 13,
       "name": "Autoconf exception 3.0",
       "licenseExceptionId": "Autoconf-exception-3.0",
       "seeAlso": [
@@ -63,7 +63,7 @@
       "reference": "https://spdx.org/licenses/Autoconf-exception-generic.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-generic.json",
-      "referenceNumber": 27,
+      "referenceNumber": 47,
       "name": "Autoconf generic exception",
       "licenseExceptionId": "Autoconf-exception-generic",
       "seeAlso": [
@@ -77,7 +77,7 @@
       "reference": "https://spdx.org/licenses/Autoconf-exception-generic-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-generic-3.0.json",
-      "referenceNumber": 35,
+      "referenceNumber": 30,
       "name": "Autoconf generic exception for GPL-3.0",
       "licenseExceptionId": "Autoconf-exception-generic-3.0",
       "seeAlso": [
@@ -88,7 +88,7 @@
       "reference": "https://spdx.org/licenses/Autoconf-exception-macro.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Autoconf-exception-macro.json",
-      "referenceNumber": 26,
+      "referenceNumber": 18,
       "name": "Autoconf macro exception",
       "licenseExceptionId": "Autoconf-exception-macro",
       "seeAlso": [
@@ -101,7 +101,7 @@
       "reference": "https://spdx.org/licenses/Bison-exception-1.24.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bison-exception-1.24.json",
-      "referenceNumber": 14,
+      "referenceNumber": 80,
       "name": "Bison exception 1.24",
       "licenseExceptionId": "Bison-exception-1.24",
       "seeAlso": [
@@ -112,7 +112,7 @@
       "reference": "https://spdx.org/licenses/Bison-exception-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bison-exception-2.2.json",
-      "referenceNumber": 72,
+      "referenceNumber": 16,
       "name": "Bison exception 2.2",
       "licenseExceptionId": "Bison-exception-2.2",
       "seeAlso": [
@@ -123,7 +123,7 @@
       "reference": "https://spdx.org/licenses/Bootloader-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bootloader-exception.json",
-      "referenceNumber": 28,
+      "referenceNumber": 86,
       "name": "Bootloader Distribution Exception",
       "licenseExceptionId": "Bootloader-exception",
       "seeAlso": [
@@ -134,7 +134,7 @@
       "reference": "https://spdx.org/licenses/CGAL-linking-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CGAL-linking-exception.json",
-      "referenceNumber": 60,
+      "referenceNumber": 52,
       "name": "CGAL Linking Exception",
       "licenseExceptionId": "CGAL-linking-exception",
       "seeAlso": [
@@ -146,7 +146,7 @@
       "reference": "https://spdx.org/licenses/Classpath-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Classpath-exception-2.0.json",
-      "referenceNumber": 2,
+      "referenceNumber": 38,
       "name": "Classpath exception 2.0",
       "licenseExceptionId": "Classpath-exception-2.0",
       "seeAlso": [
@@ -158,7 +158,7 @@
       "reference": "https://spdx.org/licenses/Classpath-exception-2.0-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Classpath-exception-2.0-short.json",
-      "referenceNumber": 50,
+      "referenceNumber": 5,
       "name": "Classpath exception 2.0 - short",
       "licenseExceptionId": "Classpath-exception-2.0-short",
       "seeAlso": [
@@ -169,7 +169,7 @@
       "reference": "https://spdx.org/licenses/CLISP-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CLISP-exception-2.0.json",
-      "referenceNumber": 20,
+      "referenceNumber": 73,
       "name": "CLISP exception 2.0",
       "licenseExceptionId": "CLISP-exception-2.0",
       "seeAlso": [
@@ -180,7 +180,7 @@
       "reference": "https://spdx.org/licenses/cryptsetup-OpenSSL-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/cryptsetup-OpenSSL-exception.json",
-      "referenceNumber": 1,
+      "referenceNumber": 59,
       "name": "cryptsetup OpenSSL exception",
       "licenseExceptionId": "cryptsetup-OpenSSL-exception",
       "seeAlso": [
@@ -196,7 +196,7 @@
       "reference": "https://spdx.org/licenses/Digia-Qt-LGPL-exception-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Digia-Qt-LGPL-exception-1.1.json",
-      "referenceNumber": 5,
+      "referenceNumber": 46,
       "name": "Digia Qt LGPL Exception version 1.1",
       "licenseExceptionId": "Digia-Qt-LGPL-exception-1.1",
       "seeAlso": [
@@ -207,7 +207,7 @@
       "reference": "https://spdx.org/licenses/DigiRule-FOSS-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DigiRule-FOSS-exception.json",
-      "referenceNumber": 78,
+      "referenceNumber": 66,
       "name": "DigiRule FOSS License Exception",
       "licenseExceptionId": "DigiRule-FOSS-exception",
       "seeAlso": [
@@ -218,7 +218,7 @@
       "reference": "https://spdx.org/licenses/eCos-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/eCos-exception-2.0.json",
-      "referenceNumber": 34,
+      "referenceNumber": 69,
       "name": "eCos exception 2.0",
       "licenseExceptionId": "eCos-exception-2.0",
       "seeAlso": [
@@ -229,7 +229,7 @@
       "reference": "https://spdx.org/licenses/erlang-otp-linking-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/erlang-otp-linking-exception.json",
-      "referenceNumber": 25,
+      "referenceNumber": 33,
       "name": "Erlang/OTP Linking Exception",
       "licenseExceptionId": "erlang-otp-linking-exception",
       "seeAlso": [
@@ -242,7 +242,7 @@
       "reference": "https://spdx.org/licenses/Fawkes-Runtime-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Fawkes-Runtime-exception.json",
-      "referenceNumber": 24,
+      "referenceNumber": 41,
       "name": "Fawkes Runtime Exception",
       "licenseExceptionId": "Fawkes-Runtime-exception",
       "seeAlso": [
@@ -253,7 +253,7 @@
       "reference": "https://spdx.org/licenses/FLTK-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FLTK-exception.json",
-      "referenceNumber": 31,
+      "referenceNumber": 72,
       "name": "FLTK exception",
       "licenseExceptionId": "FLTK-exception",
       "seeAlso": [
@@ -264,7 +264,7 @@
       "reference": "https://spdx.org/licenses/fmt-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/fmt-exception.json",
-      "referenceNumber": 70,
+      "referenceNumber": 7,
       "name": "fmt exception",
       "licenseExceptionId": "fmt-exception",
       "seeAlso": [
@@ -276,7 +276,7 @@
       "reference": "https://spdx.org/licenses/Font-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Font-exception-2.0.json",
-      "referenceNumber": 37,
+      "referenceNumber": 40,
       "name": "Font exception 2.0",
       "licenseExceptionId": "Font-exception-2.0",
       "seeAlso": [
@@ -287,7 +287,7 @@
       "reference": "https://spdx.org/licenses/freertos-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/freertos-exception-2.0.json",
-      "referenceNumber": 36,
+      "referenceNumber": 84,
       "name": "FreeRTOS Exception 2.0",
       "licenseExceptionId": "freertos-exception-2.0",
       "seeAlso": [
@@ -310,7 +310,7 @@
       "reference": "https://spdx.org/licenses/GCC-exception-2.0-note.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GCC-exception-2.0-note.json",
-      "referenceNumber": 51,
+      "referenceNumber": 12,
       "name": "GCC    Runtime Library exception 2.0 - note variant",
       "licenseExceptionId": "GCC-exception-2.0-note",
       "seeAlso": [
@@ -321,7 +321,7 @@
       "reference": "https://spdx.org/licenses/GCC-exception-3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GCC-exception-3.1.json",
-      "referenceNumber": 46,
+      "referenceNumber": 55,
       "name": "GCC Runtime Library exception 3.1",
       "licenseExceptionId": "GCC-exception-3.1",
       "seeAlso": [
@@ -332,7 +332,7 @@
       "reference": "https://spdx.org/licenses/Gmsh-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Gmsh-exception.json",
-      "referenceNumber": 21,
+      "referenceNumber": 61,
       "name": "Gmsh exception",
       "licenseExceptionId": "Gmsh-exception",
       "seeAlso": [
@@ -343,7 +343,7 @@
       "reference": "https://spdx.org/licenses/GNAT-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GNAT-exception.json",
-      "referenceNumber": 19,
+      "referenceNumber": 15,
       "name": "GNAT exception",
       "licenseExceptionId": "GNAT-exception",
       "seeAlso": [
@@ -354,7 +354,7 @@
       "reference": "https://spdx.org/licenses/GNOME-examples-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GNOME-examples-exception.json",
-      "referenceNumber": 33,
+      "referenceNumber": 63,
       "name": "GNOME examples exception",
       "licenseExceptionId": "GNOME-examples-exception",
       "seeAlso": [
@@ -366,7 +366,7 @@
       "reference": "https://spdx.org/licenses/GNU-compiler-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GNU-compiler-exception.json",
-      "referenceNumber": 18,
+      "referenceNumber": 70,
       "name": "GNU Compiler Exception",
       "licenseExceptionId": "GNU-compiler-exception",
       "seeAlso": [
@@ -378,7 +378,7 @@
       "reference": "https://spdx.org/licenses/gnu-javamail-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gnu-javamail-exception.json",
-      "referenceNumber": 69,
+      "referenceNumber": 78,
       "name": "GNU JavaMail exception",
       "licenseExceptionId": "gnu-javamail-exception",
       "seeAlso": [
@@ -386,10 +386,21 @@
       ]
     },
     {
+      "reference": "https://spdx.org/licenses/Google-Patent-WebM.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Google-Patent-WebM.json",
+      "referenceNumber": 48,
+      "name": "Google Additional IP Rights Grant (Patents) - WebM",
+      "licenseExceptionId": "Google-Patent-WebM",
+      "seeAlso": [
+        "https://www.webmproject.org/license/additional/"
+      ]
+    },
+    {
       "reference": "https://spdx.org/licenses/GPL-3.0-389-ds-base-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-389-ds-base-exception.json",
-      "referenceNumber": 12,
+      "referenceNumber": 34,
       "name": "GPL-3.0 389 DS Base Exception",
       "licenseExceptionId": "GPL-3.0-389-ds-base-exception",
       "seeAlso": []
@@ -398,7 +409,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-interface-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-interface-exception.json",
-      "referenceNumber": 11,
+      "referenceNumber": 39,
       "name": "GPL-3.0 Interface Exception",
       "licenseExceptionId": "GPL-3.0-interface-exception",
       "seeAlso": [
@@ -409,7 +420,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-linking-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-linking-exception.json",
-      "referenceNumber": 57,
+      "referenceNumber": 31,
       "name": "GPL-3.0 Linking Exception",
       "licenseExceptionId": "GPL-3.0-linking-exception",
       "seeAlso": [
@@ -432,7 +443,7 @@
       "reference": "https://spdx.org/licenses/GPL-CC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-CC-1.0.json",
-      "referenceNumber": 38,
+      "referenceNumber": 81,
       "name": "GPL Cooperation Commitment 1.0",
       "licenseExceptionId": "GPL-CC-1.0",
       "seeAlso": [
@@ -444,7 +455,7 @@
       "reference": "https://spdx.org/licenses/GStreamer-exception-2005.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GStreamer-exception-2005.json",
-      "referenceNumber": 15,
+      "referenceNumber": 64,
       "name": "GStreamer Exception (2005)",
       "licenseExceptionId": "GStreamer-exception-2005",
       "seeAlso": [
@@ -455,7 +466,7 @@
       "reference": "https://spdx.org/licenses/GStreamer-exception-2008.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GStreamer-exception-2008.json",
-      "referenceNumber": 39,
+      "referenceNumber": 27,
       "name": "GStreamer Exception (2008)",
       "licenseExceptionId": "GStreamer-exception-2008",
       "seeAlso": [
@@ -466,7 +477,7 @@
       "reference": "https://spdx.org/licenses/harbour-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/harbour-exception.json",
-      "referenceNumber": 58,
+      "referenceNumber": 62,
       "name": "harbour exception",
       "licenseExceptionId": "harbour-exception",
       "seeAlso": [
@@ -488,7 +499,7 @@
       "reference": "https://spdx.org/licenses/Independent-modules-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Independent-modules-exception.json",
-      "referenceNumber": 9,
+      "referenceNumber": 28,
       "name": "Independent Module Linking exception",
       "licenseExceptionId": "Independent-modules-exception",
       "seeAlso": [
@@ -499,7 +510,7 @@
       "reference": "https://spdx.org/licenses/KiCad-libraries-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/KiCad-libraries-exception.json",
-      "referenceNumber": 44,
+      "referenceNumber": 49,
       "name": "KiCad Libraries Exception",
       "licenseExceptionId": "KiCad-libraries-exception",
       "seeAlso": [
@@ -510,7 +521,7 @@
       "reference": "https://spdx.org/licenses/kvirc-openssl-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/kvirc-openssl-exception.json",
-      "referenceNumber": 32,
+      "referenceNumber": 82,
       "name": "kvirc OpenSSL Exception",
       "licenseExceptionId": "kvirc-openssl-exception",
       "seeAlso": [
@@ -521,7 +532,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-linking-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-linking-exception.json",
-      "referenceNumber": 54,
+      "referenceNumber": 9,
       "name": "LGPL-3.0 Linking Exception",
       "licenseExceptionId": "LGPL-3.0-linking-exception",
       "seeAlso": [
@@ -534,7 +545,7 @@
       "reference": "https://spdx.org/licenses/libpri-OpenH323-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libpri-OpenH323-exception.json",
-      "referenceNumber": 79,
+      "referenceNumber": 8,
       "name": "libpri OpenH323 exception",
       "licenseExceptionId": "libpri-OpenH323-exception",
       "seeAlso": [
@@ -545,7 +556,7 @@
       "reference": "https://spdx.org/licenses/Libtool-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Libtool-exception.json",
-      "referenceNumber": 13,
+      "referenceNumber": 10,
       "name": "Libtool Exception",
       "licenseExceptionId": "Libtool-exception",
       "seeAlso": [
@@ -557,7 +568,7 @@
       "reference": "https://spdx.org/licenses/Linux-syscall-note.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-syscall-note.json",
-      "referenceNumber": 42,
+      "referenceNumber": 20,
       "name": "Linux Syscall Note",
       "licenseExceptionId": "Linux-syscall-note",
       "seeAlso": [
@@ -579,7 +590,7 @@
       "reference": "https://spdx.org/licenses/LLVM-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LLVM-exception.json",
-      "referenceNumber": 80,
+      "referenceNumber": 44,
       "name": "LLVM Exception",
       "licenseExceptionId": "LLVM-exception",
       "seeAlso": [
@@ -591,7 +602,7 @@
       "reference": "https://spdx.org/licenses/LZMA-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-exception.json",
-      "referenceNumber": 81,
+      "referenceNumber": 26,
       "name": "LZMA exception",
       "licenseExceptionId": "LZMA-exception",
       "seeAlso": [
@@ -602,7 +613,7 @@
       "reference": "https://spdx.org/licenses/mif-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mif-exception.json",
-      "referenceNumber": 41,
+      "referenceNumber": 32,
       "name": "Macros and Inline Functions Exception",
       "licenseExceptionId": "mif-exception",
       "seeAlso": [
@@ -615,7 +626,7 @@
       "reference": "https://spdx.org/licenses/mxml-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mxml-exception.json",
-      "referenceNumber": 59,
+      "referenceNumber": 42,
       "name": "mxml Exception",
       "licenseExceptionId": "mxml-exception",
       "seeAlso": [
@@ -627,7 +638,7 @@
       "reference": "https://spdx.org/licenses/Nokia-Qt-exception-1.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Nokia-Qt-exception-1.1.json",
-      "referenceNumber": 7,
+      "referenceNumber": 54,
       "name": "Nokia Qt LGPL exception 1.1",
       "licenseExceptionId": "Nokia-Qt-exception-1.1",
       "seeAlso": [
@@ -638,7 +649,7 @@
       "reference": "https://spdx.org/licenses/OCaml-LGPL-linking-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCaml-LGPL-linking-exception.json",
-      "referenceNumber": 52,
+      "referenceNumber": 37,
       "name": "OCaml LGPL Linking Exception",
       "licenseExceptionId": "OCaml-LGPL-linking-exception",
       "seeAlso": [
@@ -649,7 +660,7 @@
       "reference": "https://spdx.org/licenses/OCCT-exception-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCCT-exception-1.0.json",
-      "referenceNumber": 65,
+      "referenceNumber": 85,
       "name": "Open CASCADE Exception 1.0",
       "licenseExceptionId": "OCCT-exception-1.0",
       "seeAlso": [
@@ -660,7 +671,7 @@
       "reference": "https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.json",
-      "referenceNumber": 22,
+      "referenceNumber": 58,
       "name": "OpenJDK Assembly exception 1.0",
       "licenseExceptionId": "OpenJDK-assembly-exception-1.0",
       "seeAlso": [
@@ -671,7 +682,7 @@
       "reference": "https://spdx.org/licenses/openvpn-openssl-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/openvpn-openssl-exception.json",
-      "referenceNumber": 17,
+      "referenceNumber": 22,
       "name": "OpenVPN OpenSSL Exception",
       "licenseExceptionId": "openvpn-openssl-exception",
       "seeAlso": [
@@ -683,7 +694,7 @@
       "reference": "https://spdx.org/licenses/PCRE2-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PCRE2-exception.json",
-      "referenceNumber": 53,
+      "referenceNumber": 17,
       "name": "PCRE2 exception",
       "licenseExceptionId": "PCRE2-exception",
       "seeAlso": [
@@ -694,7 +705,7 @@
       "reference": "https://spdx.org/licenses/polyparse-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/polyparse-exception.json",
-      "referenceNumber": 6,
+      "referenceNumber": 19,
       "name": "Polyparse Exception",
       "licenseExceptionId": "polyparse-exception",
       "seeAlso": [
@@ -705,7 +716,7 @@
       "reference": "https://spdx.org/licenses/PS-or-PDF-font-exception-20170817.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PS-or-PDF-font-exception-20170817.json",
-      "referenceNumber": 64,
+      "referenceNumber": 14,
       "name": "PS/PDF font exception (2017-08-17)",
       "licenseExceptionId": "PS-or-PDF-font-exception-20170817",
       "seeAlso": [
@@ -716,7 +727,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004-exception.json",
-      "referenceNumber": 10,
+      "referenceNumber": 2,
       "name": "INRIA QPL 1.0 2004 variant exception",
       "licenseExceptionId": "QPL-1.0-INRIA-2004-exception",
       "seeAlso": [
@@ -728,7 +739,7 @@
       "reference": "https://spdx.org/licenses/Qt-GPL-exception-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Qt-GPL-exception-1.0.json",
-      "referenceNumber": 62,
+      "referenceNumber": 60,
       "name": "Qt GPL exception 1.0",
       "licenseExceptionId": "Qt-GPL-exception-1.0",
       "seeAlso": [
@@ -739,7 +750,7 @@
       "reference": "https://spdx.org/licenses/Qt-LGPL-exception-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Qt-LGPL-exception-1.1.json",
-      "referenceNumber": 77,
+      "referenceNumber": 68,
       "name": "Qt LGPL exception 1.1",
       "licenseExceptionId": "Qt-LGPL-exception-1.1",
       "seeAlso": [
@@ -750,7 +761,7 @@
       "reference": "https://spdx.org/licenses/Qwt-exception-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Qwt-exception-1.0.json",
-      "referenceNumber": 73,
+      "referenceNumber": 25,
       "name": "Qwt exception 1.0",
       "licenseExceptionId": "Qwt-exception-1.0",
       "seeAlso": [
@@ -761,7 +772,7 @@
       "reference": "https://spdx.org/licenses/romic-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/romic-exception.json",
-      "referenceNumber": 74,
+      "referenceNumber": 24,
       "name": "Romic Exception",
       "licenseExceptionId": "romic-exception",
       "seeAlso": [
@@ -777,7 +788,7 @@
       "reference": "https://spdx.org/licenses/RRDtool-FLOSS-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RRDtool-FLOSS-exception-2.0.json",
-      "referenceNumber": 68,
+      "referenceNumber": 57,
       "name": "RRDtool FLOSS exception 2.0",
       "licenseExceptionId": "RRDtool-FLOSS-exception-2.0",
       "seeAlso": [
@@ -786,10 +797,21 @@
       ]
     },
     {
+      "reference": "https://spdx.org/licenses/rsync-linking-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/rsync-linking-exception.json",
+      "referenceNumber": 43,
+      "name": "rsync Linking Exception",
+      "licenseExceptionId": "rsync-linking-exception",
+      "seeAlso": [
+        "https://github.com/RsyncProject/rsync/blob/master/COPYING"
+      ]
+    },
+    {
       "reference": "https://spdx.org/licenses/SANE-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SANE-exception.json",
-      "referenceNumber": 61,
+      "referenceNumber": 65,
       "name": "SANE Exception",
       "licenseExceptionId": "SANE-exception",
       "seeAlso": [
@@ -802,7 +824,7 @@
       "reference": "https://spdx.org/licenses/SHL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-2.0.json",
-      "referenceNumber": 23,
+      "referenceNumber": 77,
       "name": "Solderpad Hardware License v2.0",
       "licenseExceptionId": "SHL-2.0",
       "seeAlso": [
@@ -813,7 +835,7 @@
       "reference": "https://spdx.org/licenses/SHL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-2.1.json",
-      "referenceNumber": 43,
+      "referenceNumber": 51,
       "name": "Solderpad Hardware License v2.1",
       "licenseExceptionId": "SHL-2.1",
       "seeAlso": [
@@ -824,7 +846,7 @@
       "reference": "https://spdx.org/licenses/Simple-Library-Usage-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Simple-Library-Usage-exception.json",
-      "referenceNumber": 8,
+      "referenceNumber": 1,
       "name": "Simple Library Usage Exception",
       "licenseExceptionId": "Simple-Library-Usage-exception",
       "seeAlso": [
@@ -832,10 +854,32 @@
       ]
     },
     {
+      "reference": "https://spdx.org/licenses/Spelling-Provider-LGPL-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Spelling-Provider-LGPL-exception.json",
+      "referenceNumber": 71,
+      "name": "Spelling Provider LGPL exception",
+      "licenseExceptionId": "Spelling-Provider-LGPL-exception",
+      "seeAlso": [
+        "https://github.com/rrthomas/enchant/blob/774ff6dc2e441ba2b9b786f8edbe00e014960408/lib/internal.vapi#L18"
+      ]
+    },
+    {
+      "reference": "https://spdx.org/licenses/sqlitestudio-OpenSSL-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/sqlitestudio-OpenSSL-exception.json",
+      "referenceNumber": 21,
+      "name": "sqlitestudio OpenSSL exception",
+      "licenseExceptionId": "sqlitestudio-OpenSSL-exception",
+      "seeAlso": [
+        "https://github.com/pawelsalawa/sqlitestudio/blob/master/LICENSE"
+      ]
+    },
+    {
       "reference": "https://spdx.org/licenses/stunnel-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/stunnel-exception.json",
-      "referenceNumber": 66,
+      "referenceNumber": 11,
       "name": "stunnel Exception",
       "licenseExceptionId": "stunnel-exception",
       "seeAlso": [
@@ -846,7 +890,7 @@
       "reference": "https://spdx.org/licenses/SWI-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SWI-exception.json",
-      "referenceNumber": 75,
+      "referenceNumber": 53,
       "name": "SWI exception",
       "licenseExceptionId": "SWI-exception",
       "seeAlso": [
@@ -857,7 +901,7 @@
       "reference": "https://spdx.org/licenses/Swift-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Swift-exception.json",
-      "referenceNumber": 55,
+      "referenceNumber": 35,
       "name": "Swift Exception",
       "licenseExceptionId": "Swift-exception",
       "seeAlso": [
@@ -869,7 +913,7 @@
       "reference": "https://spdx.org/licenses/Texinfo-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Texinfo-exception.json",
-      "referenceNumber": 71,
+      "referenceNumber": 4,
       "name": "Texinfo exception",
       "licenseExceptionId": "Texinfo-exception",
       "seeAlso": [
@@ -880,7 +924,7 @@
       "reference": "https://spdx.org/licenses/u-boot-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/u-boot-exception-2.0.json",
-      "referenceNumber": 82,
+      "referenceNumber": 79,
       "name": "U-Boot exception 2.0",
       "licenseExceptionId": "u-boot-exception-2.0",
       "seeAlso": [
@@ -891,7 +935,7 @@
       "reference": "https://spdx.org/licenses/UBDL-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UBDL-exception.json",
-      "referenceNumber": 30,
+      "referenceNumber": 6,
       "name": "Unmodified Binary Distribution exception",
       "licenseExceptionId": "UBDL-exception",
       "seeAlso": [
@@ -902,7 +946,7 @@
       "reference": "https://spdx.org/licenses/Universal-FOSS-exception-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Universal-FOSS-exception-1.0.json",
-      "referenceNumber": 48,
+      "referenceNumber": 36,
       "name": "Universal FOSS Exception, Version 1.0",
       "licenseExceptionId": "Universal-FOSS-exception-1.0",
       "seeAlso": [
@@ -913,7 +957,7 @@
       "reference": "https://spdx.org/licenses/vsftpd-openssl-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/vsftpd-openssl-exception.json",
-      "referenceNumber": 63,
+      "referenceNumber": 23,
       "name": "vsftpd OpenSSL exception",
       "licenseExceptionId": "vsftpd-openssl-exception",
       "seeAlso": [
@@ -926,18 +970,18 @@
       "reference": "https://spdx.org/licenses/WxWindows-exception-3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/WxWindows-exception-3.1.json",
-      "referenceNumber": 16,
+      "referenceNumber": 3,
       "name": "WxWindows Library Exception 3.1",
       "licenseExceptionId": "WxWindows-exception-3.1",
       "seeAlso": [
-        "http://www.opensource.org/licenses/WXwindows"
+        "http://www.opensource.org/license/WXwindows"
       ]
     },
     {
       "reference": "https://spdx.org/licenses/x11vnc-openssl-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/x11vnc-openssl-exception.json",
-      "referenceNumber": 40,
+      "referenceNumber": 83,
       "name": "x11vnc OpenSSL Exception",
       "licenseExceptionId": "x11vnc-openssl-exception",
       "seeAlso": [
@@ -945,5 +989,5 @@
       ]
     }
   ],
-  "releaseDate": "2025-11-21T00:00:00Z"
+  "releaseDate": "2026-07-16T00:00:00Z"
 }

--- a/pkg/licenses/license.go
+++ b/pkg/licenses/license.go
@@ -116,6 +116,7 @@ func LookupSpdxLicense(licenseKey string) (License, error) {
 	}
 
 	license = overlayRestrictiveFromAboutCode(license)
+	license = overlayFreeAnyUseFromAboutCode(license)
 
 	return license, nil
 }
@@ -314,6 +315,28 @@ func overlayRestrictiveFromAboutCode(spdx meta) meta {
 	// considered to be a “restrictive” license.
 	if ac, ok := licenseListAboutCode[spdx.short]; ok && ac.restrictive {
 		spdx.restrictive = true
+	}
+	return spdx
+}
+
+// overlayFreeAnyUseFromAboutCode sets spdx.freeAnyUse to true if AboutCode
+// metadata marks the same license ID as public domain. No other fields are changed.
+func overlayFreeAnyUseFromAboutCode(spdx meta) meta {
+	if spdx.freeAnyUse {
+		return spdx
+	}
+
+	// --NOTE--
+	// The SPDX license list does not publish any "free for any use" flag. Its
+	// entries carry only isOsiApproved and isFsfLibre, so meta.freeAnyUse is
+	// always false for SPDX-sourced licenses and every document licence that
+	// resolves through the SPDX list (including CC0-1.0, the dataLicense SPDX
+	// itself mandates) scored 0 on sbom_sharable.
+	//
+	// We use the AboutCode `Public Domain` license category to fill the gap,
+	// the same way restrictiveness is derived from its copyleft categories.
+	if ac, ok := licenseListAboutCode[spdx.short]; ok && ac.freeAnyUse {
+		spdx.freeAnyUse = true
 	}
 	return spdx
 }

--- a/pkg/licenses/license_test.go
+++ b/pkg/licenses/license_test.go
@@ -244,3 +244,73 @@ func TestLookupExpression_CustomLicenses(t *testing.T) {
 		})
 	}
 }
+
+func TestLookupExpression_FreeAnyUseLicenses(t *testing.T) {
+	testcases := []struct {
+		exp            string
+		wantFreeAnyUse bool
+	}{
+		// Public domain ids that are on the SPDX list. Before the AboutCode
+		// overlay these all reported freeAnyUse=false, because the SPDX
+		// license list publishes no such flag.
+		{exp: "CC0-1.0", wantFreeAnyUse: true},
+		{exp: "Unlicense", wantFreeAnyUse: true},
+		{exp: "WTFPL", wantFreeAnyUse: true},
+		{exp: "PDDL-1.0", wantFreeAnyUse: true},
+		{exp: "CC-PDDC", wantFreeAnyUse: true},
+		{exp: "NIST-PD", wantFreeAnyUse: true},
+		{exp: "blessing", wantFreeAnyUse: true},
+
+		// Permissive and copyleft ids must stay false.
+		{exp: "MIT", wantFreeAnyUse: false},
+		{exp: "Apache-2.0", wantFreeAnyUse: false},
+		{exp: "BSD-3-Clause", wantFreeAnyUse: false},
+		{exp: "GPL-3.0-only", wantFreeAnyUse: false},
+		{exp: "AGPL-3.0-only", wantFreeAnyUse: false},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.exp, func(t *testing.T) {
+			lics := LookupExpression(test.exp, nil)
+
+			if len(lics) == 0 {
+				t.Fatalf("expected license for %s, got none", test.exp)
+			}
+
+			lic := lics[0]
+
+			if lic.FreeAnyUse() != test.wantFreeAnyUse {
+				t.Fatalf(
+					"expected freeAnyUse=%v for %s, got %v",
+					test.wantFreeAnyUse,
+					test.exp,
+					lic.FreeAnyUse(),
+				)
+			}
+		})
+	}
+}
+
+// The overlay must not disturb the fields it does not own.
+func TestFreeAnyUseOverlay_LeavesOtherFieldsAlone(t *testing.T) {
+	lic, err := LookupSpdxLicense("CC0-1.0")
+	if err != nil {
+		t.Fatalf("expected CC0-1.0 on the spdx list, got %v", err)
+	}
+
+	if !lic.Spdx() {
+		t.Fatalf("expected source spdx, got %s", lic.Source())
+	}
+
+	if lic.Name() != "Creative Commons Zero v1.0 Universal" {
+		t.Fatalf("unexpected name %q", lic.Name())
+	}
+
+	if !lic.FsfLibre() {
+		t.Fatalf("expected fsfLibre to survive the overlay")
+	}
+
+	if lic.Deprecated() || lic.OsiApproved() || lic.Restrictive() || lic.Exception() {
+		t.Fatalf("overlay changed a field it does not own: %+v", lic)
+	}
+}

--- a/pkg/licenses/license_test.go
+++ b/pkg/licenses/license_test.go
@@ -314,3 +314,50 @@ func TestFreeAnyUseOverlay_LeavesOtherFieldsAlone(t *testing.T) {
 		t.Fatalf("overlay changed a field it does not own: %+v", lic)
 	}
 }
+
+// AboutCode's `Non-Commercial` category must count as restrictive. It was
+// introduced in the 2026 license database refresh and absorbed 24 licenses
+// that were previously categorised Copyleft, Copyleft Limited or Free
+// Restricted, so omitting it would quietly relax the classification.
+func TestLookupExpression_NonCommercialIsRestrictive(t *testing.T) {
+	testcases := []string{
+		"CC-BY-NC-4.0",
+		"CC-BY-NC-SA-4.0",
+		"CC-BY-NC-ND-4.0",
+		"CC-BY-NC-1.0",
+		"PolyForm-Noncommercial-1.0.0",
+		"FSL-1.1-MIT",
+		"SUL-1.0",
+		"Aladdin",
+		"NCGL-UK-2.0",
+		"OpenPBS-2.3",
+	}
+
+	for _, exp := range testcases {
+		t.Run(exp, func(t *testing.T) {
+			lics := LookupExpression(exp, nil)
+
+			if len(lics) == 0 {
+				t.Fatalf("expected license for %s, got none", exp)
+			}
+
+			if !lics[0].Restrictive() {
+				t.Fatalf("expected %s to be restrictive", exp)
+			}
+		})
+	}
+}
+
+// Guards the license database refresh: these counts change only when
+// pkg/licenses/files is regenerated, and the AboutCode category vocabulary
+// drives both the restrictive and freeAnyUse classifications.
+func TestLicenseDatabase_LoadedCounts(t *testing.T) {
+	if got, want := len(licenseList), 819; got != want {
+		t.Fatalf("expected %d spdx licenses and exceptions, got %d", want, got)
+	}
+
+	// Keyed by SPDX id, so this exceeds the 2733 raw AboutCode records.
+	if got, want := len(licenseListAboutCode), 2862; got != want {
+		t.Fatalf("expected %d aboutcode entries, got %d", want, got)
+	}
+}


### PR DESCRIPTION
Three commits: a scoring bug fix, a license database refresh, and the classifier change the refresh requires.

---

## 1. `sbom_sharable` never scored above zero

`sbom_sharable` scored **0.0 for essentially every SBOM**, and `sbomqs list --feature sbom_sharable` never matched a document.

`meta.freeAnyUse` was populated only from `spdxLicenseDetail.IsFreeAnyUse` (`embed_licenses.go:96`). **The SPDX license list publishes no such field.** Its entries carry exactly nine keys:

```
reference, isDeprecatedLicenseId, detailsUrl, referenceNumber,
name, licenseId, seeAlso, isOsiApproved, isFsfLibre
```

So the flag unmarshalled to `false` for all 716 embedded licenses. `sharableLicenseCheck` requires `freeLics == len(lics)`, meaning every document licence resolving through the SPDX list counted as non-free, `CC0-1.0` included. Since CC0-1.0 is the `dataLicense` the SPDX spec mandates, **every SPDX SBOM scored 0 on the entire Sharing category.**

`loadAboutCodeLicense` already derives `freeAnyUse` from the AboutCode `Public Domain` category, but `LookupSpdxLicense` returns before that lookup, so it was only reachable for ids absent from the SPDX list. The tell was the asymmetry: `overlayRestrictiveFromAboutCode` existed with no `freeAnyUse` counterpart.

**Fix:** overlay the flag from AboutCode onto SPDX-sourced licenses, mirroring how restrictiveness is already handled. 22 SPDX-listed ids gain it, among them `CC0-1.0`, `Unlicense`, `WTFPL` and `PDDL-1.0`.

Note this is *not* fixable by regenerating the license data, since the field has never existed upstream. The dead `IsFreeAnyUse` field is documented in place rather than removed so the next person does not try.

## 2. License database refresh

`make update-licenses`, sources unchanged.

| | before | after |
|---|---|---|
| SPDX licenses | 716 | 733 |
| SPDX list version | `2e6a0e5` | `e4c1f27` |
| SPDX exceptions | 82 | 86 |
| AboutCode records | 2615 | 2733 |

Nothing was removed and no deprecation flag changed. `CDDL-1.1` gained `isOsiApproved`. New exceptions: `Google-Patent-WebM`, `Spelling-Provider-LGPL-exception`, `rsync-linking-exception`, `sqlitestudio-OpenSSL-exception`.

## 3. `Non-Commercial` must count as restrictive

The refresh is not inert. AboutCode added a **`Non-Commercial` category** holding 209 licenses, 166 of which moved from an existing category. 24 came out of categories `isRestrictive` already matched:

```
Copyleft         -> Non-Commercial   ac3filter, afpl-8.0, afpl-9.0, odb-ncuel
Copyleft Limited -> Non-Commercial   divx-open-1.0, openpbs-2.3, scsl-2.8, scsl-3.0, ...
Free Restricted  -> Non-Commercial   mame, imagen, sustainable-use-1.0, ncgl-uk-2.0, ...
```

`isRestrictive` matches only `copyleft` and `restricted`, so **taking the data update alone would silently reclassify these as unrestricted.** 30 SPDX-listed ids sit in the new category, including the entire CC-BY-NC family, `PolyForm-Noncommercial-1.0.0`, `FSL-1.1-MIT`, `FSL-1.1-ALv2`, `SUL-1.0` and `Aladdin`.

Reporting a ban on commercial use as unrestricted is backwards for the consumers this check serves, so the classifier matches the new category rather than pinning old behaviour.

This is the one judgement call in the PR. Commit 3 is independently revertible if you disagree, though reverting it means shipping the silent relaxation.

## Score impact

`samples/photon.spdx.json`:

| | before | after |
|---|---|---|
| `sbom_sharable` | 0 | 10 |
| `avg_score` | 5.9545 | 6.1240 |

Fixture with 5 components, two non-commercial:

| | before | after |
|---|---|---|
| `comp_with_restrictive_licenses` (v1) | 8.00 | 4.00 |
| `comp_no_restrictive_licenses` (v2) | 8.00 | 4.00 |

**Correction to my earlier claim that v2 is unaffected.** That holds for `freeAnyUse`, which only v1 reads, but the license data and the restrictive classifier feed both engines. v2 scores do move.

Documents with no declared licence (`free 0 :: of 0`) still score 0 on `sbom_sharable`. Existing behaviour, out of scope.

## Consumers

- `pkg/scorer/sharing.go:31` — v1 `sbom_sharable`
- `pkg/list/doceval.go:176` — `list --feature sbom_sharable`
- `comp_with_restrictive_licenses` (v1) and `comp_no_restrictive_licenses` (v2) via the category change

Scores move in both directions, so this wants a changelog entry and a version bump. At least one third-party tool replicates v1 semantics feature by feature and pins to a specific sbomqs version.

## Tests

- `TestLookupExpression_FreeAnyUseLicenses` — 7 public domain ids true, 5 permissive/copyleft false
- `TestFreeAnyUseOverlay_LeavesOtherFieldsAlone` — overlay touches nothing but `freeAnyUse`
- `TestLookupExpression_NonCommercialIsRestrictive` — 10 ids across the new category
- `TestLicenseDatabase_LoadedCounts` — fails loudly if a future refresh shifts the vocabulary again

`go test ./...` passes at each of the three commits individually, so the history stays bisectable. The only failure is `pkg/tui`, untracked local WIP missing `golang.org/x/term`, unrelated to this branch.

Separately noticed and **not** addressed here: `score` panics with a nil pointer on `samples/sbom.cdx.signed.json` in `common.RetrieveSignatureFromSBOM`. Reproduces on `main`, so it predates this branch.

