### PR TITLE
fix(signature): guard nil publicKey and stop writing artifacts to CWD

### DIFF
--- a/pkg/compliance/bsiV20.go
+++ b/pkg/compliance/bsiV20.go
@@ -150,9 +150,6 @@ func bsiV20SbomSignature(doc sbom.Document) *db.Record {
 			result = "Signature provided but verification failed!"
 		}
 
-		common.RemoveFileIfExists("extracted_public_key.pem")
-		common.RemoveFileIfExists("extracted_signature.bin")
-		common.RemoveFileIfExists("standalone_sbom.json")
 	}
 
 	return db.NewRecordStmtOptional(SBOM_SIGNATURE, "doc", result, score)

--- a/pkg/compliance/common/sig.go
+++ b/pkg/compliance/common/sig.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/interlynk-io/sbomqs/v2/pkg/logger"
@@ -49,6 +50,39 @@ type PublicKey struct {
 	E   string `json:"e"`
 }
 
+// signatureArtifactDirPattern names the temporary directory that holds the
+// files extracted from an embedded CycloneDX signature.
+const signatureArtifactDirPattern = "sbomqs-signature-*"
+
+// RemoveSignatureArtifacts deletes files written by RetrieveSignatureFromSBOM
+// and prunes the temporary directory holding them. Paths outside a directory
+// created by RetrieveSignatureFromSBOM are ignored, so it is safe to pass a
+// signature value that is not a path at all.
+func RemoveSignatureArtifacts(paths ...string) {
+	prefix := strings.TrimSuffix(signatureArtifactDirPattern, "*")
+
+	dirs := map[string]struct{}{}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+
+		dir := filepath.Dir(path)
+		if !strings.HasPrefix(filepath.Base(dir), prefix) {
+			continue
+		}
+
+		RemoveFileIfExists(path)
+		dirs[dir] = struct{}{}
+	}
+
+	for dir := range dirs {
+		// Only succeeds once the directory is empty, which keeps a shared
+		// directory alive until its last artifact is gone.
+		_ = os.Remove(dir)
+	}
+}
+
 func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, string, string, error) {
 	log := logger.FromContext(ctx)
 	log.Debug("Retrieving signature from SBOM", zap.String("file", sbomFile))
@@ -63,12 +97,6 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 
 	var sbom SBOM
 
-	//nolint
-	extracted_signature := "extracted_signature.bin"
-
-	//nolint
-	extracted_publick_key := "extracted_public_key.pem"
-
 	if err := json.Unmarshal(data, &sbom); err != nil {
 		log.Error("Failed to parse SBOM json", zap.Error(err))
 		return "", "", "", fmt.Errorf("error unmarshalling SBOM JSON: %w", err)
@@ -78,7 +106,21 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 		log.Debug("SBOM doesn't contains signature and public key")
 		return sbomFile, "", "", nil
 	}
-	log.Debug("Signature and public key are extracted from SBOM")
+	log.Debug("Signature found in SBOM")
+
+	// Artifacts go to a temporary directory. Writing them next to the caller's
+	// working directory left extracted_signature.bin, extracted_public_key.pem
+	// and standalone_sbom.json behind on most code paths, since only two of the
+	// six callers cleaned up and they did so only on one success branch.
+	artifactDir, err := os.MkdirTemp("", signatureArtifactDirPattern)
+	if err != nil {
+		log.Error("Failed to create signature artifact directory", zap.Error(err))
+		return "", "", "", fmt.Errorf("error creating signature artifact directory: %w", err)
+	}
+
+	extractedSignature := filepath.Join(artifactDir, "extracted_signature.bin")
+	extractedPublicKey := filepath.Join(artifactDir, "extracted_public_key.pem")
+	standaloneSBOMFile := filepath.Join(artifactDir, "standalone_sbom.json")
 
 	signatureValue, err := base64.StdEncoding.DecodeString(sbom.Signature.Value)
 	if err != nil {
@@ -86,30 +128,41 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 		return "", "", "", fmt.Errorf("error decoding signature: %w", err)
 	}
 
-	if err := os.WriteFile(extracted_signature, signatureValue, 0o600); err != nil {
+	if err := os.WriteFile(extractedSignature, signatureValue, 0o600); err != nil {
 		log.Error("Failed to write signature to as file", zap.Error(err))
 	}
-	log.Debug("Signature extracted and wrtitten to a file", zap.String("path", "extracted_signature.bin"))
+	log.Debug("Signature extracted and written to a file", zap.String("path", extractedSignature))
 
-	// extract the public key modulus and exponent
-	modulus, err := base64.StdEncoding.DecodeString(sbom.Signature.PublicKey.N)
-	if err != nil {
-		return "", "", "", fmt.Errorf("error decoding public key modulus: %w", err)
-	}
-	exponent := DecodeBase64URLEncodingToInt(sbom.Signature.PublicKey.E)
-	if exponent == 0 {
-		log.Debug("Invalid public key exponent")
-	}
+	// The public key is optional. CycloneDX JSF allows a signature to carry no
+	// inline publicKey, leaving verification material to be referenced by
+	// certPath/keyId or supplied out of band. Dereferencing it unconditionally
+	// panicked on any such document, samples/sbom.cdx.signed.json included.
+	publicKeyPath := ""
+	if sbom.Signature.PublicKey == nil {
+		log.Debug("Signature carries no embedded public key")
+	} else {
+		// extract the public key modulus and exponent
+		modulus, err := base64.StdEncoding.DecodeString(sbom.Signature.PublicKey.N)
+		if err != nil {
+			return "", "", "", fmt.Errorf("error decoding public key modulus: %w", err)
+		}
+		exponent := DecodeBase64URLEncodingToInt(sbom.Signature.PublicKey.E)
+		if exponent == 0 {
+			log.Debug("Invalid public key exponent")
+		}
 
-	// create the RSA public key
-	pubKey := &rsa.PublicKey{
-		N: DecodeBigInt(modulus),
-		E: exponent,
-	}
+		// create the RSA public key
+		pubKey := &rsa.PublicKey{
+			N: DecodeBigInt(modulus),
+			E: exponent,
+		}
 
-	pubKeyPEM := PublicKeyToPEM(pubKey)
-	if err := os.WriteFile(extracted_publick_key, pubKeyPEM, 0o600); err != nil {
-		log.Error("Failed to write public key to file", zap.String("path", "extracted_publick_key"), zap.Error(err))
+		pubKeyPEM := PublicKeyToPEM(pubKey)
+		if err := os.WriteFile(extractedPublicKey, pubKeyPEM, 0o600); err != nil {
+			log.Error("Failed to write public key to file", zap.String("path", extractedPublicKey), zap.Error(err))
+		} else {
+			publicKeyPath = extractedPublicKey
+		}
 	}
 
 	// remove the "signature" section
@@ -124,13 +177,12 @@ func RetrieveSignatureFromSBOM(ctx context.Context, sbomFile string) (string, st
 	}
 
 	// save the modified SBOM to a new file without a trailing newline
-	standaloneSBOMFile := "standalone_sbom.json"
 	if err := os.WriteFile(standaloneSBOMFile, bytes.TrimSuffix(normalizedSBOM.Bytes(), []byte("\n")), 0o600); err != nil {
 		return "", "", "", fmt.Errorf("error writing standalone SBOM file: %w", err)
 	}
 
 	log.Debug("New modified SBOM saved to", zap.String("path", standaloneSBOMFile))
-	return standaloneSBOMFile, extracted_signature, extracted_publick_key, nil
+	return standaloneSBOMFile, extractedSignature, publicKeyPath, nil
 }
 
 func DecodeBase64URLEncodingToInt(input string) int {

--- a/pkg/compliance/common/sig_test.go
+++ b/pkg/compliance/common/sig_test.go
@@ -1,0 +1,216 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A signature block with no publicKey. CycloneDX JSF permits this: the
+// verification material can be referenced by certPath/keyId or supplied out of
+// band. This is the shape of samples/sbom.cdx.signed.json.
+const sbomSignatureWithoutPublicKey = `{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": [],
+  "signature": {
+    "algorithm": "ES256",
+    "value": "MEUCIG9lOD40k/frCtBGY6bVXincsOoXUz83uxHU3pdvdY2XAiEApU6pHZDzKym1msnAOpTZNPBwa+wLriwGMZIY1ScOzDs="
+  }
+}`
+
+const sbomSignatureWithPublicKey = `{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": [],
+  "signature": {
+    "algorithm": "RS256",
+    "value": "c2lnbmF0dXJlLXZhbHVl",
+    "publicKey": {
+      "kty": "RSA",
+      "n": "sMuFYqvJ8n0aQqDCZTa1lTNKQ1ZKBhLOF2sVYt1ETyU=",
+      "e": "AQAB"
+    }
+  }
+}`
+
+const sbomWithoutSignature = `{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": []
+}`
+
+func writeSBOM(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "sbom.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+	return path
+}
+
+// Regression test for the nil pointer dereference on Signature.PublicKey.
+// Before the guard this panicked with SIGSEGV rather than returning.
+func TestRetrieveSignatureFromSBOM_SignatureWithoutPublicKey(t *testing.T) {
+	path := writeSBOM(t, sbomSignatureWithoutPublicKey)
+
+	standalone, signature, publicKey, err := RetrieveSignatureFromSBOM(context.Background(), path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer RemoveSignatureArtifacts(standalone, signature, publicKey)
+
+	if publicKey != "" {
+		t.Fatalf("expected no public key path, got %q", publicKey)
+	}
+
+	if signature == "" {
+		t.Fatal("expected the signature to still be extracted")
+	}
+
+	if _, err := os.Stat(signature); err != nil {
+		t.Fatalf("expected signature artifact at %s: %v", signature, err)
+	}
+
+	if _, err := os.Stat(standalone); err != nil {
+		t.Fatalf("expected standalone SBOM at %s: %v", standalone, err)
+	}
+}
+
+func TestRetrieveSignatureFromSBOM_SignatureWithPublicKey(t *testing.T) {
+	path := writeSBOM(t, sbomSignatureWithPublicKey)
+
+	standalone, signature, publicKey, err := RetrieveSignatureFromSBOM(context.Background(), path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer RemoveSignatureArtifacts(standalone, signature, publicKey)
+
+	for name, artifact := range map[string]string{
+		"standalone SBOM": standalone,
+		"signature":       signature,
+		"public key":      publicKey,
+	} {
+		if artifact == "" {
+			t.Fatalf("expected a %s path", name)
+		}
+		if _, err := os.Stat(artifact); err != nil {
+			t.Fatalf("expected %s artifact at %s: %v", name, artifact, err)
+		}
+	}
+
+	// The standalone copy is the document with the signature section removed.
+	data, err := os.ReadFile(standalone)
+	if err != nil {
+		t.Fatalf("failed to read standalone SBOM: %v", err)
+	}
+	if strings.Contains(string(data), "\"signature\"") {
+		t.Fatal("expected the signature section to be stripped")
+	}
+}
+
+func TestRetrieveSignatureFromSBOM_NoSignature(t *testing.T) {
+	path := writeSBOM(t, sbomWithoutSignature)
+
+	standalone, signature, publicKey, err := RetrieveSignatureFromSBOM(context.Background(), path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if standalone != path {
+		t.Fatalf("expected the original path back, got %q", standalone)
+	}
+
+	if signature != "" || publicKey != "" {
+		t.Fatalf("expected no artifacts, got signature=%q publicKey=%q", signature, publicKey)
+	}
+}
+
+// Artifacts must never land next to the caller's working directory.
+func TestRetrieveSignatureFromSBOM_DoesNotWriteToWorkingDirectory(t *testing.T) {
+	path := writeSBOM(t, sbomSignatureWithPublicKey)
+
+	standalone, signature, publicKey, err := RetrieveSignatureFromSBOM(context.Background(), path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer RemoveSignatureArtifacts(standalone, signature, publicKey)
+
+	for _, artifact := range []string{standalone, signature, publicKey} {
+		if !filepath.IsAbs(artifact) {
+			t.Fatalf("expected an absolute temp path, got %q", artifact)
+		}
+		if !strings.HasPrefix(filepath.Base(filepath.Dir(artifact)), "sbomqs-signature-") {
+			t.Fatalf("expected %q to live in a sbomqs signature temp dir", artifact)
+		}
+	}
+
+	for _, leaked := range []string{"extracted_signature.bin", "extracted_public_key.pem", "standalone_sbom.json"} {
+		if _, err := os.Stat(leaked); err == nil {
+			t.Fatalf("%s was written to the working directory", leaked)
+		}
+	}
+}
+
+func TestRemoveSignatureArtifacts_RemovesFilesAndDir(t *testing.T) {
+	path := writeSBOM(t, sbomSignatureWithPublicKey)
+
+	standalone, signature, publicKey, err := RetrieveSignatureFromSBOM(context.Background(), path)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	dir := filepath.Dir(standalone)
+
+	RemoveSignatureArtifacts(standalone, signature, publicKey)
+
+	for _, artifact := range []string{standalone, signature, publicKey} {
+		if _, err := os.Stat(artifact); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed", artifact)
+		}
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("expected temp dir %s to be pruned", dir)
+	}
+}
+
+// The same struct field carries a raw signature value on the CycloneDX parse
+// path, so cleanup must ignore anything that is not one of our artifacts.
+func TestRemoveSignatureArtifacts_IgnoresForeignPaths(t *testing.T) {
+	dir := t.TempDir()
+	bystander := filepath.Join(dir, "important.json")
+	if err := os.WriteFile(bystander, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	RemoveSignatureArtifacts("", bystander, "MEUCIG9lOD40k/frCtBGY6bVXincsOoXUz83uxHU3pdvdY2X")
+
+	if _, err := os.Stat(bystander); err != nil {
+		t.Fatalf("expected %s to survive cleanup: %v", bystander, err)
+	}
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected %s to survive cleanup: %v", dir, err)
+	}
+}

--- a/pkg/engine/compliance.go
+++ b/pkg/engine/compliance.go
@@ -128,7 +128,7 @@ func getSbomDocument(ctx context.Context, ep *Params) (*sbom.Document, error) {
 		zap.String("path", path),
 	)
 
-	_, signature, publicKey, err := common.GetSignatureBundle(ctx, path, "", "")
+	standalone, signature, publicKey, err := common.GetSignatureBundle(ctx, path, "", "")
 	if err != nil {
 		log.Error("Failed to fetch signature bundle",
 			zap.String("path", path),
@@ -136,6 +136,9 @@ func getSbomDocument(ctx context.Context, ep *Params) (*sbom.Document, error) {
 		)
 		return nil, err
 	}
+	// The bundle is extracted to a temp directory; whoever asks for it owns it.
+	// Compliance only tests these for emptiness, never reads them.
+	defer common.RemoveSignatureArtifacts(standalone, signature, publicKey)
 
 	sig := sbom.Signature{
 		SigValue:  signature,

--- a/pkg/engine/score.go
+++ b/pkg/engine/score.go
@@ -300,7 +300,7 @@ func handlePaths(ctx context.Context, ep *Params) error {
 				return err
 			}
 
-			_, signature, publicKey, err := common.GetSignatureBundle(ctx, path, "", "")
+			standalone, signature, publicKey, err := common.GetSignatureBundle(ctx, path, "", "")
 			if err != nil {
 				log.Error("Failed to fetch signature bundle",
 					zap.String("path", path),
@@ -316,11 +316,16 @@ func handlePaths(ctx context.Context, ep *Params) error {
 
 			doc, err := sbom.NewSBOMDocument(ctx, f, sig)
 			if err != nil {
+				common.RemoveSignatureArtifacts(standalone, signature, publicKey)
 				return err
 			}
 
 			sr := scorer.NewScorer(ctx, doc)
 			score := sr.Score()
+
+			// The bundle is extracted to a temp directory; whoever asks for it
+			// owns it. Scoring only tests these for emptiness, never reads them.
+			common.RemoveSignatureArtifacts(standalone, signature, publicKey)
 
 			docs = append(docs, doc)
 			scores = append(scores, score)
@@ -403,7 +408,7 @@ func processFile(ctx context.Context, ep *Params, path string, fs billy.Filesyst
 
 	var doc sbom.Document
 
-	_, signature, publicKey, err := common.GetSignatureBundle(ctx, path, "", "")
+	standalone, signature, publicKey, err := common.GetSignatureBundle(ctx, path, "", "")
 	if err != nil {
 		log.Error("Failed to fetch signature bundle",
 			zap.String("path", path),
@@ -411,6 +416,9 @@ func processFile(ctx context.Context, ep *Params, path string, fs billy.Filesyst
 		)
 		return nil, nil, err
 	}
+	// The bundle is extracted to a temp directory; whoever asks for it owns it.
+	// Scoring only tests these for emptiness, never reads them.
+	defer common.RemoveSignatureArtifacts(standalone, signature, publicKey)
 
 	sig := sbom.Signature{
 		SigValue:  signature,

--- a/pkg/scorer/bsi.go
+++ b/pkg/scorer/bsi.go
@@ -366,9 +366,6 @@ func sbomWithSignatureCheck(doc sbom.Document, c *check) score {
 			s.setScore(5.0)
 			s.setDesc("Signature provided but verification failed!")
 		}
-		common.RemoveFileIfExists("extracted_public_key.pem")
-		common.RemoveFileIfExists("extracted_signature.bin")
-		common.RemoveFileIfExists("standalone_sbom.json")
 	} else {
 		s.setScore(0.0)
 		s.setDesc("No signature provided")

--- a/pkg/scorer/v2/score/resolver.go
+++ b/pkg/scorer/v2/score/resolver.go
@@ -139,13 +139,16 @@ func ExtractSignature(ctx context.Context, cfg config.Config, path string) (sbom
 		zap.String("path", path),
 	)
 
-	_, signature, pubKey, err := common.GetSignatureBundle(ctx, path, sigValue, publicKey)
+	standalone, signature, pubKey, err := common.GetSignatureBundle(ctx, path, sigValue, publicKey)
 	if err != nil {
 		log.Debug("Signature verification not configured",
 			zap.String("path", path),
 		)
 		return sbom.Signature{}, err
 	}
+	// The bundle is extracted to a temp directory; whoever asks for it owns it.
+	// Scoring only tests these for emptiness, never reads them.
+	defer common.RemoveSignatureArtifacts(standalone, signature, pubKey)
 
 	return sbom.Signature{
 		SigValue:  signature,


### PR DESCRIPTION
## The crash

`sbomqs score samples/sbom.cdx.signed.json` panics. Both engines, and `compliance` too.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10]
github.com/interlynk-io/sbomqs/v2/pkg/compliance/common.RetrieveSignatureFromSBOM
```

`RetrieveSignatureFromSBOM` guards `sbom.Signature == nil`, then dereferences `sbom.Signature.PublicKey` without checking it:

```go
modulus, err := base64.StdEncoding.DecodeString(sbom.Signature.PublicKey.N)
```

`PublicKey` is a `*PublicKey`. The signature block in the shipped sample is:

```json
{"algorithm": "ES256", "value": "MEUCIG9lOD40k/frCtBGY6bVXincsOoXUz83uxHU3pdvdY2X..."}
```

No `publicKey`, so the pointer is nil. The panic address `0x10` is the offset of `N` past the 16-byte `Kty` string header.

**The document is valid.** CycloneDX JSF permits a signature with no inline public key, since verification material can be referenced by `certPath`/`keyId` or supplied out of band. sbomqs crashes on legitimate input, and ships that input as a sample, so anyone following the docs hits it.

The scorers already had the correct branch for this case:

```go
if pubKey == "" && len(certPath) == 0 {
    return ... "Signature present but no verification material!", 5.0
}
```

The panic meant it was unreachable. `sbom_signature` now scores 5.0 on that sample, which is what the existing code always intended.

## Working directory pollution

Same function, separate problem. It wrote three artifacts into the process working directory:

```
extracted_signature.bin
extracted_public_key.pem
standalone_sbom.json
```

Cleanup existed in only two of six call sites (`pkg/compliance/bsiV20.go`, `pkg/scorer/bsi.go`), hardcoded the filenames, and sat after several early `return`s, so most paths leaked. None of the three are gitignored. Scoring a signed SBOM dirtied the user's tree, which is how I found the panic in the first place.

Now: a per-call temp directory (`sbomqs-signature-*`), owned by whichever caller requested the bundle. The ad-hoc deletes move out of the scoring functions, which had no business removing files, and into the four `GetSignatureBundle` callers.

`RemoveSignatureArtifacts` only touches paths inside a directory it created. That matters because `sbom.Signature.SigValue` holds a raw base64 signature on the CycloneDX parse path and a file path on this one, so cleanup has to tolerate being handed a value that is not a path. Covered by a test.

## What this does not do

Nothing reads these artifacts. `VerifySignature`, the only reader, has no callers. So writing them is arguably pointless, and returning the signature value and PEM directly would be better and would match what `pkg/sbom/cdx.go` already puts in those fields.

I did not do that here. The returned paths are what the scorers test for emptiness to decide a signature is present, so changing them is a semantic change across four call sites and belongs in its own PR. This one keeps the contract and fixes the crash.

## Verification

| command on `samples/sbom.cdx.signed.json` | before | after |
|---|---|---|
| `score` | SIGSEGV | exit 0 |
| `score --legacy` | SIGSEGV | exit 0 |
| `compliance --bsi-v2.0` | SIGSEGV | exit 0 |

Zero artifacts in the working directory, zero temp directories left behind after all three.

## Tests

New `pkg/compliance/common/sig_test.go`, the package's first:

- `..._SignatureWithoutPublicKey` — the regression test
- `..._SignatureWithPublicKey` — full extraction, signature section stripped from the standalone copy
- `..._NoSignature` — returns the original path untouched
- `..._DoesNotWriteToWorkingDirectory` — artifacts are absolute temp paths, and the three legacy filenames are absent from CWD
- `TestRemoveSignatureArtifacts_RemovesFilesAndDir`
- `TestRemoveSignatureArtifacts_IgnoresForeignPaths` — a raw signature value passed as a path destroys nothing

I confirmed the regression test earns its keep by stubbing the guard back out: it reproduces the original SIGSEGV at the same `addr=0x10`, and passes with the guard restored.

`go test ./...` passes. The only failure is `pkg/tui`, untracked local WIP missing `golang.org/x/term`, unrelated to this branch.

Note `gofmt -l` flags `pkg/scorer/bsi.go` for trailing whitespace on lines this PR does not touch. Left alone to keep the diff clean.

