### PR TITLE
fix(ntia): score comp_with_uniq_ids on purl/cpe, not bom-ref

### DIFF
--- a/pkg/scorer/bsi.go
+++ b/pkg/scorer/bsi.go
@@ -73,30 +73,6 @@ func sbomWithURICheck(doc sbom.Document, c *check) score {
 	return *s
 }
 
-func bsiCompWithUniqIDCheck(d sbom.Document, c *check) score {
-	s := newScoreFromCheck(c)
-
-	totalComponents := len(d.Components())
-	if totalComponents == 0 {
-		s.setScore(0.0)
-		s.setDesc("N/A (no components)")
-		s.setIgnore(true)
-		return *s
-	}
-
-	compIDs := lo.CountBy(d.Components(), func(c sbom.GetComponent) bool {
-		purl := c.GetPurls()
-		cpes := c.GetCpes()
-		return len(purl) > 0 || len(cpes) > 0
-	})
-
-	if totalComponents > 0 {
-		s.setScore((float64(compIDs) / float64(totalComponents)) * 10.0)
-	}
-	s.setDesc(fmt.Sprintf("%d/%d have unique ID's", compIDs, totalComponents))
-	return *s
-}
-
 // check whether provided license is compliant or non-compliant
 func compWithLicensesCompliantCheck(d sbom.Document, c *check) score {
 	s := newScoreFromCheck(c)

--- a/pkg/scorer/criteria.go
+++ b/pkg/scorer/criteria.go
@@ -51,7 +51,7 @@ var checks = []check{
 	// bsi-v1.1
 	{string(bsiv1_1), "comp_with_name", false, "components have a name", compWithNameCheck},
 	{string(bsiv1_1), "comp_with_version", false, "components have a version", compWithVersionCheck},
-	{string(bsiv1_1), "comp_with_uniq_ids", false, "components have uniq ids", bsiCompWithUniqIDCheck},
+	{string(bsiv1_1), "comp_with_uniq_ids", false, "components have uniq ids", compWithUniqIDCheck},
 	{string(bsiv1_1), "comp_with_supplier", false, "components have suppliers", compWithSupplierCheck},
 	{string(bsiv1_1), "comp_with_licenses", false, "components have licenses", compWithLicensesCompliantCheck},
 	{string(bsiv1_1), "comp_with_checksums_sha256", false, "components have checksums with sha256", compWithSHA256ChecksumsCheck},
@@ -68,7 +68,7 @@ var checks = []check{
 	// bsi-v2.0.0
 	{string(bsiv2_0), "comp_with_name", false, "components have a name", compWithNameCheck},
 	{string(bsiv2_0), "comp_with_version", false, "components have a version", compWithVersionCheck},
-	{string(bsiv2_0), "comp_with_uniq_ids", false, "components have uniq ids", bsiCompWithUniqIDCheck},
+	{string(bsiv2_0), "comp_with_uniq_ids", false, "components have uniq ids", compWithUniqIDCheck},
 	{string(bsiv2_0), "comp_with_supplier", false, "components have suppliers", compWithSupplierCheck},
 	{string(bsiv2_0), "comp_with_associated_license", false, "components have associated licenses", compWithAssociatedLicensesCheck},
 	{string(bsiv2_0), "comp_with_concluded_license", false, "components have concluded licenses", compWithConcludedLicensesCheck},

--- a/pkg/scorer/ntia.go
+++ b/pkg/scorer/ntia.go
@@ -88,6 +88,20 @@ func compWithVersionCheck(d sbom.Document, c *check) score {
 	return *s
 }
 
+// compWithUniqIDCheck implements the NTIA minimum element "Other Unique
+// Identifiers": "At least one additional identifier if available (e.g., CPE,
+// PURL, SWID)."
+//
+// Mappings:
+//   - SPDX: PackageExternalRefs (PURL), PackageCPEs
+//   - CycloneDX: component external references (PURL), component CPEs
+//
+// "Unique" here means globally identifying, i.e. usable as a lookup key against
+// a vulnerability database. It does not mean "not duplicated within the
+// document", and NTIA asks nothing about intra-document distinctness. This
+// previously counted components with a non-empty bom-ref/SPDXID, which is a
+// document-local handle unrelated to the element, and so disagreed with the
+// list command, the v2 NTIA profile and the BSI checks that share this key.
 func compWithUniqIDCheck(d sbom.Document, c *check) score {
 	s := newScoreFromCheck(c)
 
@@ -99,19 +113,12 @@ func compWithUniqIDCheck(d sbom.Document, c *check) score {
 		return *s
 	}
 
-	compIDs := lo.FilterMap(d.Components(), func(c sbom.GetComponent, _ int) (string, bool) {
-		if c.GetID() == "" {
-			return "", false
-		}
-		return strings.Join([]string{d.Spec().GetNamespace(), c.GetID()}, ""), true
+	withIDs := lo.CountBy(d.Components(), func(c sbom.GetComponent) bool {
+		return len(c.GetPurls()) > 0 || len(c.GetCpes()) > 0
 	})
 
-	// uniqComps := lo.Uniq(compIDs)
-
-	if totalComponents > 0 {
-		s.setScore((float64(len(compIDs)) / float64(totalComponents)) * 10.0)
-	}
-	s.setDesc(fmt.Sprintf("%d/%d have unique ID's", len(compIDs), totalComponents))
+	s.setScore((float64(withIDs) / float64(totalComponents)) * 10.0)
+	s.setDesc(fmt.Sprintf("%d/%d have unique ID's", withIDs, totalComponents))
 	return *s
 }
 

--- a/pkg/scorer/ntia_test.go
+++ b/pkg/scorer/ntia_test.go
@@ -1,0 +1,199 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interlynk-io/sbomqs/v2/pkg/sbom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Components carry bom-refs but no purl and no cpe. This is the case the old
+// implementation scored 10.0 on, because it counted bom-refs.
+var cdxCompsWithLocalIDsOnly = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "components": [
+    {"type": "library", "bom-ref": "a", "name": "lib-a", "version": "1.0"},
+    {"type": "library", "bom-ref": "b", "name": "lib-b", "version": "1.0"}
+  ]
+}
+`)
+
+var cdxCompsWithPurl = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "components": [
+    {"type": "library", "bom-ref": "a", "name": "lib-a", "version": "1.0", "purl": "pkg:npm/lib-a@1.0"},
+    {"type": "library", "bom-ref": "b", "name": "lib-b", "version": "1.0", "purl": "pkg:npm/lib-b@1.0"}
+  ]
+}
+`)
+
+var cdxCompsWithCpeOnly = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "components": [
+    {"type": "library", "bom-ref": "a", "name": "lib-a", "version": "1.0", "cpe": "cpe:2.3:a:vendor:lib-a:1.0:*:*:*:*:*:*:*"},
+    {"type": "library", "bom-ref": "b", "name": "lib-b", "version": "1.0", "cpe": "cpe:2.3:a:vendor:lib-b:1.0:*:*:*:*:*:*:*"}
+  ]
+}
+`)
+
+// One of four components carries an identifier.
+var cdxCompsWithMixedIDs = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "components": [
+    {"type": "library", "bom-ref": "a", "name": "lib-a", "version": "1.0", "purl": "pkg:npm/lib-a@1.0"},
+    {"type": "library", "bom-ref": "b", "name": "lib-b", "version": "1.0"},
+    {"type": "library", "bom-ref": "c", "name": "lib-c", "version": "1.0"},
+    {"type": "library", "bom-ref": "d", "name": "lib-d", "version": "1.0"}
+  ]
+}
+`)
+
+var spdxCompsWithPurl = []byte(`
+{
+  "spdxVersion": "SPDX-2.3",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "test",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://example.com/test",
+  "creationInfo": {"created": "2026-08-17T00:00:00Z", "creators": ["Tool: test-1.0"]},
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-a", "name": "lib-a", "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/lib-a@1.0"}
+      ]
+    }
+  ]
+}
+`)
+
+var spdxCompsWithLocalIDsOnly = []byte(`
+{
+  "spdxVersion": "SPDX-2.3",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "test",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://example.com/test",
+  "creationInfo": {"created": "2026-08-17T00:00:00Z", "creators": ["Tool: test-1.0"]},
+  "packages": [
+    {"SPDXID": "SPDXRef-a", "name": "lib-a", "versionInfo": "1.0", "downloadLocation": "NOASSERTION"}
+  ]
+}
+`)
+
+// comp_with_uniq_ids implements the NTIA minimum element "Other Unique
+// Identifiers": at least one lookup identifier (PURL, CPE, SWID) per component.
+// A bom-ref or SPDXID is a document-local handle and must not satisfy it.
+func TestCompWithUniqIDCheck(t *testing.T) {
+	ctx := context.Background()
+
+	testcases := []struct {
+		name      string
+		doc       []byte
+		wantScore float64
+		wantDesc  string
+	}{
+		{
+			name:      "cdx purl on every component",
+			doc:       cdxCompsWithPurl,
+			wantScore: 10.0,
+			wantDesc:  "2/2 have unique ID's",
+		},
+		{
+			name:      "cdx cpe on every component",
+			doc:       cdxCompsWithCpeOnly,
+			wantScore: 10.0,
+			wantDesc:  "2/2 have unique ID's",
+		},
+		{
+			// Regression: bom-refs alone previously scored 10.0.
+			name:      "cdx bom-ref only, no purl or cpe",
+			doc:       cdxCompsWithLocalIDsOnly,
+			wantScore: 0.0,
+			wantDesc:  "0/2 have unique ID's",
+		},
+		{
+			name:      "cdx one of four has a purl",
+			doc:       cdxCompsWithMixedIDs,
+			wantScore: 2.5,
+			wantDesc:  "1/4 have unique ID's",
+		},
+		{
+			name:      "spdx externalRef purl",
+			doc:       spdxCompsWithPurl,
+			wantScore: 10.0,
+			wantDesc:  "1/1 have unique ID's",
+		},
+		{
+			// Regression: SPDXID alone previously scored 10.0.
+			name:      "spdx SPDXID only, no externalRefs",
+			doc:       spdxCompsWithLocalIDsOnly,
+			wantScore: 0.0,
+			wantDesc:  "0/1 have unique ID's",
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			doc, err := sbom.NewSBOMDocumentFromBytes(ctx, test.doc, sbom.Signature{})
+			require.NoError(t, err)
+
+			c := &check{Category: string(ntiam), Key: "comp_with_uniq_ids"}
+			got := compWithUniqIDCheck(doc, c)
+
+			assert.InDelta(t, test.wantScore, got.Score(), 1e-9)
+			assert.Equal(t, test.wantDesc, got.Descr())
+			assert.False(t, got.Ignore())
+		})
+	}
+}
+
+func TestCompWithUniqIDCheck_NoComponents(t *testing.T) {
+	ctx := context.Background()
+
+	doc, err := sbom.NewSBOMDocumentFromBytes(ctx, []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "components": []
+}
+`), sbom.Signature{})
+	require.NoError(t, err)
+
+	c := &check{Category: string(ntiam), Key: "comp_with_uniq_ids"}
+	got := compWithUniqIDCheck(doc, c)
+
+	assert.InDelta(t, 0.0, got.Score(), 1e-9)
+	assert.Equal(t, "N/A (no components)", got.Descr())
+	assert.True(t, got.Ignore())
+}

--- a/pkg/scorer/v2/extractors/identification.go
+++ b/pkg/scorer/v2/extractors/identification.go
@@ -57,8 +57,13 @@ func CompWithVersion(_ context.Context, input catalog.EvalInput) catalog.ComprFe
 	return formulae.ScoreCompFull(have, len(comps), "versions", false)
 }
 
-// CompWithUniqLocalIDs: percentage of components whose local ID is present and unique within the SBOM.
-// such as bom-ref, spdxid
+// CompWithUniqLocalIDs: percentage of components carrying a local ID, such as
+// a CycloneDX bom-ref or an SPDXID.
+//
+// Presence only. Distinctness within the document is not checked, so two
+// components sharing a bom-ref both count. This is deliberately a structural
+// check and is not the NTIA "Other Unique Identifiers" element, which asks for
+// a global lookup key and is implemented by the ntia profile's comp_uniq_id.
 func CompWithUniqLocalIDs(_ context.Context, input catalog.EvalInput) catalog.ComprFeatScore {
 	doc := input.Doc
 	comps := doc.Components()
@@ -73,5 +78,5 @@ func CompWithUniqLocalIDs(_ context.Context, input catalog.EvalInput) catalog.Co
 		return strings.Join([]string{doc.Spec().GetNamespace(), c.GetID()}, ""), true
 	})
 
-	return formulae.ScoreCompFull(len(have), len(comps), "unique IDs", false)
+	return formulae.ScoreCompFull(len(have), len(comps), "local IDs", false)
 }


### PR DESCRIPTION
## What the check is for

`comp_with_uniq_ids` implements the NTIA minimum element **"Other Unique Identifiers"**. `docs/reference/ntia-compliance.md:179` quotes the definition:

> "At least one additional identifier if available (e.g., CPE, PURL, SWID)."

and line 26 maps it to SPDX `ExternalRef (PURL, CPE, SWID)` and CycloneDX `component.purl, component.cpe`.

"Unique" means **globally identifying**, i.e. usable as a lookup key against a vulnerability database. NTIA asks nothing about whether identifiers are distinct within a document.

The v1 check was counting components with a non-empty `bom-ref`/`SPDXID`. That is a document-local handle with no relationship to the element. It is present on essentially every component of every real SBOM, so the check scored ~10.0 unconditionally.

## Three of four implementations were already right

| implementation | reads | |
|---|---|---|
| `docs/reference/ntia-compliance.md` | purl / cpe / swid | correct |
| `pkg/list` `GenericCompUniqIDs` | purl, cpe, swhid, swid, omnibor | correct |
| v2 `NTIACompWithUniqID` | purl, cpe | correct |
| **v1 `compWithUniqIDCheck`** | **bom-ref / SPDXID** | **wrong** |

`pkg/list/registry.go:283` even aliases `comp_with_uniq_ids` straight to the purl/cpe extractor.

Worse, a **single legacy report** resolved the same feature key two different ways, because the BSI rows already pointed at a correct variant:

```
NTIA-minimum-elements  comp_with_uniq_ids  10.0   <- bom-ref
bsi-v1.1               comp_with_uniq_ids   0.0   <- purl/cpe
bsi-v2.0               comp_with_uniq_ids   0.0   <- purl/cpe
```

The check sitting in the NTIA category was the only one not implementing NTIA.

## The lo.Uniq red herring

`compWithUniqIDCheck` carried a commented-out `lo.Uniq` line, disabled in `f706c77` (Apr 2024). That commit says it fixed "an off by one error where when all ID elements are removed there was a 1/n ratio instead of 0/n", but the pre-change code filtered empty IDs *before* deduping, so all-empty already yielded 0/n. A 1/n result comes from n components sharing one identical ID, which is dedupe working as written.

Both the deduping and the non-deduping versions measured the wrong property, which is why the symptom kept moving. The line is gone along with the namespace join.

## Changes

- `compWithUniqIDCheck` now counts components with at least one PURL or CPE
- `bsiCompWithUniqIDCheck` becomes identical to it and is deleted; all three criteria rows share `compWithUniqIDCheck`, matching how `comp_with_name` and `comp_with_supplier` are already shared across standards
- v2's `CompWithUniqLocalIDs` doc comment claimed "present **and unique**" and its output said "unique IDs" for a check that tests neither. Wording corrected; behaviour unchanged and correct for its key, `comp_with_local_id`, which is a deliberate structural check and not the NTIA element

Scope note: NTIA names SWID, and this counts only PURL and CPE, matching the v2 NTIA profile and the previous BSI variant. Widening all of them to SWID/SWHID/OmniBOR the way `list` does is a separate decision, not something to change in only one engine.

## Score impact

**This lowers scores.** Any SBOM with bom-refs and no purl or cpe drops from 10.0 to 0.0 on this feature. Both shipped samples were affected:

| sample | comp_with_uniq_ids | avg_score |
|---|---|---|
| `samples/photon.spdx.json` | 10.00 → 0.00 | 5.9545 → 5.7850 |
| `samples/sbom_cdx.json` | 10.00 → 0.51 | 5.8743 → 5.7135 |

Wants a changelog entry and a version bump. It also breaks parity for third-party tools replicating v1 feature-by-feature, though in this case parity was with a bug.

After the fix all four implementations agree on the same fixture (3 components, bom-refs, no purl/cpe): v1 NTIA `0.0`, v1 bsi-v1.1 `0.0`, v1 bsi-v2.0 `0.0`, v2 ntia profile `0.0`, `list` reports none.

## Tests

`pkg/scorer/ntia_test.go`, the package's first test file:

- CycloneDX purl on every component, cpe on every component
- CycloneDX bom-ref only, no purl or cpe (the regression)
- CycloneDX one of four with a purl (fractional scoring)
- SPDX `externalRefs` purl, and SPDX `SPDXID` only (the regression)
- zero components stays N/A and ignored

I checked these earn their keep by restoring the old body: three cases fail with `2/2`, `4/4` and `1/1` against the expected `0/2`, `1/4` and `0/1`.

No documentation changed. The code now matches what `docs/reference/ntia-compliance.md` already specified.

`go test ./...` passes. The only failure is `pkg/tui`, untracked local WIP missing `golang.org/x/term`, unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
