### PR TITLE
chore(scorer): clarify required-fields check and fix stale grade bands

### DIFF
--- a/docs/commands/score.md
+++ b/docs/commands/score.md
@@ -503,19 +503,19 @@ $ sbomqs score --legacy --category ntia my-app.spdx.json
 
 #### Numeric Scores (0-10)
 
-- **9-10**: Excellent - SBOM is high quality and compliant
-- **7-8.9**: Good - SBOM meets most requirements
-- **5-6.9**: Fair - SBOM has gaps that should be addressed
-- **3-4.9**: Poor - SBOM is missing critical information
-- **0-2.9**: Failing - SBOM is severely incomplete
+- **9.0-10.0**: Excellent - SBOM is high quality and compliant
+- **8.0-8.9**: Good - SBOM meets most requirements
+- **7.0-7.9**: Acceptable - SBOM has gaps that should be addressed
+- **5.0-6.9**: Poor - SBOM is missing critical information
+- **below 5.0**: Failing - SBOM is severely incomplete
 
 #### Letter Grades
 
-- **A**: 8.0-10.0 - Excellent quality
-- **B**: 6.0-7.9 - Good quality
-- **C**: 4.0-5.9 - Fair quality
-- **D**: 2.0-3.9 - Poor quality
-- **F**: 0.0-1.9 - Failing quality
+- **A**: 9.0-10.0 - Excellent quality
+- **B**: 8.0-8.9 - Good quality
+- **C**: 7.0-7.9 - Acceptable quality
+- **D**: 5.0-6.9 - Poor quality
+- **F**: below 5.0 - Failing quality
 
 ### Key Quality Indicators
 

--- a/pkg/scorer/semantic.go
+++ b/pkg/scorer/semantic.go
@@ -21,6 +21,17 @@ import (
 	"github.com/samber/lo"
 )
 
+// sbomWithRequiredFieldCheck scores the spec-mandated fields of the document
+// header and of every package, blended into one value.
+//
+// The two halves are treated asymmetrically on purpose. Package completeness
+// earns partial credit, but the document header is a gate: a document missing
+// its own required fields is not spec-valid, so it scores zero however complete
+// its packages are.
+//
+// Known wart, unchanged here: a document with zero components takes the partial
+// path with a package score of 0 and lands on 5.0, where every sibling
+// component check instead reports N/A and sets Ignore.
 func sbomWithRequiredFieldCheck(d sbom.Document, c *check) score {
 	s := newScoreFromCheck(c)
 
@@ -30,30 +41,21 @@ func sbomWithRequiredFieldCheck(d sbom.Document, c *check) score {
 	noOfPkgs := lo.CountBy(d.Components(), func(c sbom.GetComponent) bool {
 		return c.RequiredFields()
 	})
-	pkgsOK := false
-	if totalComponents > 0 && noOfPkgs == totalComponents {
-		pkgsOK = true
-	}
+	pkgsOK := totalComponents > 0 && noOfPkgs == totalComponents
 
-	var docScore, pkgScore float64
-
-	if !docOK && pkgsOK {
-		docScore = 0
-		pkgScore = 10.0
-		s.setScore((docScore + pkgScore) / 2.0)
+	switch {
+	case !docOK:
 		s.setScore(0.0)
-	}
 
-	if docOK && !pkgsOK {
-		docScore = 10.0
+	case pkgsOK:
+		s.setScore(10.0)
+
+	default:
+		pkgScore := 0.0
 		if totalComponents > 0 {
 			pkgScore = (float64(noOfPkgs) / float64(totalComponents)) * 10.0
 		}
-		s.setScore((docScore + pkgScore) / 2.0)
-	}
-
-	if docOK && pkgsOK {
-		s.setScore(10.0)
+		s.setScore((10.0 + pkgScore) / 2.0)
 	}
 
 	s.setDesc(fmt.Sprintf("Doc Fields:%t Pkg Fields:%t", docOK, pkgsOK))

--- a/pkg/scorer/semantic_test.go
+++ b/pkg/scorer/semantic_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Interlynk.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interlynk-io/sbomqs/v2/pkg/sbom"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Document header and both packages complete.
+var cdxDocAndPkgsComplete = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {"timestamp": "2026-08-17T00:00:00Z"},
+  "components": [
+    {"type": "library", "bom-ref": "a", "name": "lib-a", "version": "1.0"},
+    {"type": "library", "bom-ref": "b", "name": "lib-b", "version": "1.0"}
+  ]
+}
+`)
+
+// One of two packages is missing a required field.
+var cdxDocOKPkgsPartial = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {"timestamp": "2026-08-17T00:00:00Z"},
+  "components": [
+    {"type": "library", "bom-ref": "a", "name": "lib-a", "version": "1.0"},
+    {"type": "library", "bom-ref": "b", "version": "1.0"}
+  ]
+}
+`)
+
+// Valid header, no components at all.
+var cdxDocOKNoComponents = []byte(`
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {"timestamp": "2026-08-17T00:00:00Z"},
+  "components": []
+}
+`)
+
+// Characterization tests. These pin the blended doc+package formula, including
+// its quirks, so the scoring cannot drift unnoticed.
+func TestSbomWithRequiredFieldCheck(t *testing.T) {
+	ctx := context.Background()
+
+	testcases := []struct {
+		name      string
+		doc       []byte
+		wantScore float64
+		wantDesc  string
+	}{
+		{
+			name:      "doc and packages complete",
+			doc:       cdxDocAndPkgsComplete,
+			wantScore: 10.0,
+			wantDesc:  "Doc Fields:true Pkg Fields:true",
+		},
+		{
+			// (10 + 10*1/2) / 2
+			name:      "doc complete, one of two packages complete",
+			doc:       cdxDocOKPkgsPartial,
+			wantScore: 7.5,
+			wantDesc:  "Doc Fields:true Pkg Fields:false",
+		},
+		{
+			// Known wart: no packages to check, yet the package half scores 0
+			// and drags the result to 5.0 instead of reporting N/A the way
+			// every sibling component check does.
+			name:      "doc complete, zero components",
+			doc:       cdxDocOKNoComponents,
+			wantScore: 5.0,
+			wantDesc:  "Doc Fields:true Pkg Fields:false",
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			doc, err := sbom.NewSBOMDocumentFromBytes(ctx, test.doc, sbom.Signature{})
+			require.NoError(t, err)
+
+			c := &check{Category: string(semantic), Key: "sbom_required_fields"}
+			got := sbomWithRequiredFieldCheck(doc, c)
+
+			assert.InDelta(t, test.wantScore, got.Score(), 1e-9)
+			assert.Equal(t, test.wantDesc, got.Descr())
+		})
+	}
+}


### PR DESCRIPTION
Two small, independent corrections. **Neither changes any score.**

---

## 1. `sbomWithRequiredFieldCheck` now says what it does

The `!docOK && pkgsOK` branch computed a blended score and then immediately overwrote it:

```go
docScore = 0
pkgScore = 10.0
s.setScore((docScore + pkgScore) / 2.0)
s.setScore(0.0)                          // <- wins
```

The override is *correct*, and `git blame` puts it in the initial checkin rather than later drift. The two halves are asymmetric on purpose: package completeness earns partial credit, but the document header is a gate, since a document missing its own required fields is not spec-valid however complete its packages are. That intent is now stated once in a comment instead of implied by a discarded assignment, and the dead `docScore`/`pkgScore` locals are gone.

The fourth combination, `!docOK && !pkgsOK`, matched no branch at all and fell through on the zero value. Right answer, reached by accident. A `switch` on `!docOK` covers both failing cases explicitly.

### Behaviour is provably unchanged

Scored six documents on this branch and on `main`, comparing every feature score and `avg_score`:

```
IDENTICAL  photon.spdx.json
IDENTICAL  sbom_cdx.json
IDENTICAL  nc.cdx.json            (non-commercial licences)
IDENTICAL  ids.cdx.json           (bom-refs, no purl/cpe)
IDENTICAL  truly-empty.cdx.json   (zero components)
IDENTICAL  empty.cdx.json         (primary component only)
```

New characterization tests pin the blended formula so it cannot drift unnoticed: doc+packages complete, doc complete with one of two packages complete (7.5), and the zero-component case.

### One bug found, deliberately not fixed here

A document with **zero components** takes the partial path with a package score of 0 and lands on **5.0**:

```
sbom_required_fields   score=5.00  ignored=false  "Doc Fields:true Pkg Fields:false"
comp_with_name         score=0.00  ignored=true   "N/A (no components)"
```

Every sibling component check reports N/A and sets `Ignore`. This is the only one that penalises having nothing to measure, and `Pkg Fields:false` is misleading when there are no packages to have fields.

Fixing it changes scores and there are two defensible answers, N/A for the whole feature versus scoring the document half alone at 10.0, so it is recorded in a comment and a test here rather than decided in a no-op cleanup PR.

(Note the primary component counts toward the component list, so `"components": []` still enumerates 1 and does not hit this path. It needs a document with no `metadata.component` either.)

## 2. Grade bands in `docs/commands/score.md` were wrong

Every band:

| | documented | actual |
|---|---|---|
| A | 8.0-10.0 | **9.0-10.0** |
| B | 6.0-7.9 | **8.0-8.9** |
| C | 4.0-5.9 | **7.0-7.9** |
| D | 2.0-3.9 | **5.0-6.9** |
| F | 0.0-1.9 | **below 5.0** |

Authority is `ToGrade` in `pkg/scorer/v2/formulae/farmulas.go:178`, duplicated verbatim as `scoreToGrade` in `pkg/reporter/v2/basic.go:128` and `detailed.go`. `docs/specs/SBOMQS-2.0-SPEC.md:466` already had it right, so the two documents contradicted each other and a reader had no way to tell which to trust.

Also aligned the numeric band list immediately above, which would otherwise have disagreed with the corrected table on where failing starts. Swept the rest of the docs: all remaining grade statements now match the code.

Worth noting this table is externally visible. A third-party tool documenting sbomqs interoperability flags this page as stale, and it is the most user-facing error currently in the repo.

---

`go test ./...` passes. The only failure is `pkg/tui`, untracked local WIP missing `golang.org/x/term`, unrelated to this branch.

Touches no file that PRs #732, #733 or #734 touch, so it can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
