### PR TITLE
fix(scorer): score required fields on the header when there are no packages

### DIFF
--- a/pkg/scorer/semantic.go
+++ b/pkg/scorer/semantic.go
@@ -29,9 +29,11 @@ import (
 // its own required fields is not spec-valid, so it scores zero however complete
 // its packages are.
 //
-// Known wart, unchanged here: a document with zero components takes the partial
-// path with a package score of 0 and lands on 5.0, where every sibling
-// component check instead reports N/A and sets Ignore.
+// A document with no components is scored on its header alone. There are no
+// package fields to be absent, so an empty package half must not halve the
+// result. Reporting N/A instead would be worse than it looks: AvgScore keeps
+// ignored entries in its denominator, so an ignored feature costs exactly as
+// much as a zero.
 func sbomWithRequiredFieldCheck(d sbom.Document, c *check) score {
 	s := newScoreFromCheck(c)
 
@@ -47,15 +49,17 @@ func sbomWithRequiredFieldCheck(d sbom.Document, c *check) score {
 	case !docOK:
 		s.setScore(0.0)
 
-	case pkgsOK:
+	case totalComponents == 0, pkgsOK:
 		s.setScore(10.0)
 
 	default:
-		pkgScore := 0.0
-		if totalComponents > 0 {
-			pkgScore = (float64(noOfPkgs) / float64(totalComponents)) * 10.0
-		}
+		pkgScore := (float64(noOfPkgs) / float64(totalComponents)) * 10.0
 		s.setScore((10.0 + pkgScore) / 2.0)
+	}
+
+	if totalComponents == 0 {
+		s.setDesc(fmt.Sprintf("Doc Fields:%t Pkg Fields:n/a (no components)", docOK))
+		return *s
 	}
 
 	s.setDesc(fmt.Sprintf("Doc Fields:%t Pkg Fields:%t", docOK, pkgsOK))

--- a/pkg/scorer/semantic_test.go
+++ b/pkg/scorer/semantic_test.go
@@ -90,13 +90,12 @@ func TestSbomWithRequiredFieldCheck(t *testing.T) {
 			wantDesc:  "Doc Fields:true Pkg Fields:false",
 		},
 		{
-			// Known wart: no packages to check, yet the package half scores 0
-			// and drags the result to 5.0 instead of reporting N/A the way
-			// every sibling component check does.
+			// No packages to check, so the header alone decides. Previously
+			// the empty package half halved this to 5.0.
 			name:      "doc complete, zero components",
 			doc:       cdxDocOKNoComponents,
-			wantScore: 5.0,
-			wantDesc:  "Doc Fields:true Pkg Fields:false",
+			wantScore: 10.0,
+			wantDesc:  "Doc Fields:true Pkg Fields:n/a (no components)",
 		},
 	}
 


### PR DESCRIPTION
> **Stacked on #735.** Base is `chore/scorer-cleanup-and-grade-docs`, which owns the characterization test this PR updates. Merge #735 first, or retarget to `main` after it lands.

## The bug

A document with zero components and a valid header scored **5.0** on `sbom_required_fields`:

```
sbom_required_fields   score=5.00  ignored=false  "Doc Fields:true Pkg Fields:false"
comp_with_name         score=0.00  ignored=true   "N/A (no components)"
comp_with_licenses     score=0.00  ignored=true   "N/A (no components)"
```

It took the partial-credit path with a package score of 0, so an empty package half halved an otherwise perfect result. `Pkg Fields:false` also asserts something untrue: there are no packages to have fields.

## Why not N/A

The obvious fix is to report N/A and set `Ignore`, matching every sibling component check. **That is worse**, and the reason is worth stating because it applies to the whole v1 engine.

`AvgScore` (`pkg/scorer/scores.go:47`) is:

```go
score / float64(s.Count())   // Count() is ALL entries, ignored included
```

Verified on a zero-component document: 59 entries, 35 ignored, `sum(non-ignored) / 59` reproduces the reported `avg_score` to the digit. So an ignored entry stays in the denominator while contributing nothing to the numerator.

**Marking a feature N/A costs exactly as much as scoring it 0.0.** It prints "not applicable" while quietly applying the maximum penalty.

v2 shows what was intended. `ComputeCategoryScore` skips ignored features when accumulating `totalFeatureWeight`, so N/A genuinely renormalizes there. v1 never got that treatment. Until it does, N/A is not a neutral option in v1, and choosing it here would import v2's intent while getting the opposite numeric effect.

There is no v2 equivalent of `sbom_required_fields`, so there was no cross-engine precedent to follow either.

## The fix

The header alone decides. The check asks whether required fields are present; with no packages, the document's fields are the only required fields that exist, and they are present, so 10.0. The description now says `Pkg Fields:n/a (no components)` instead of claiming false.

## Blast radius

Only documents with **no components at all**. Note the primary component counts toward the component list, so `"components": []` still enumerates one and is unaffected; this needs a document with no `metadata.component` either, which is why it went unnoticed.

| document | before | after |
|---|---|---|
| `truly-empty.cdx.json` | 5.0, avg 2.7966 | **10.0, avg 2.8814** |
| `photon.spdx.json` | 10.0 | unchanged |
| `sbom_cdx.json` | 10.0 | unchanged |
| `empty.cdx.json` (primary component only) | 10.0 | unchanged |
| `ids.cdx.json` | 10.0 | unchanged |
| `nc.cdx.json` | 10.0 | unchanged |

## Out of scope

The `AvgScore` quirk itself. Every N/A in the v1 engine is a silent zero, which for a zero-component document means 35 of 59 entries are scored as failures. Changing that moves every score in the engine and at least one third-party tool replicates the formula deliberately, quirk included. It belongs in the v1 quirks reference, not here.

`go test ./...` passes. The only failure is `pkg/tui`, untracked local WIP missing `golang.org/x/term`, unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
