### PR TITLE
fix(cmd): point score and compliance help examples at samples that exist

### DIFF
--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -35,28 +35,28 @@ BSI TR-03183-2, Framing Software Component Transparency (v3) and OpenChain Telco
 	Example: ` sbomqs compliance  < --ntia | --bsi | --bsi-v2 | --bsi-v21 | --fsct | --oct >  [--basic | --json]   <SBOM file>
 
   # Check a NTIA minimum elements compliance against a SBOM in a table output
-  sbomqs compliance --ntia samples/sbomqs-spdx-syft.json
+  sbomqs compliance --ntia samples/photon.spdx.json
 
   # Check BSI TR-03183-2 compliance (latest version, currently v2.1.0)
-  sbomqs compliance --bsi samples/sbomqs-cdx.json
+  sbomqs compliance --bsi samples/sbom_cdx.json
 
   # Check a BSI TR-03183-2 v1.1 compliance against a SBOM in a table output
-  sbomqs compliance --bsi-v1 samples/sbomqs-spdx-syft.json
+  sbomqs compliance --bsi-v1 samples/photon.spdx.json
 
   # Check a BSI TR-03183-2 v2.0.0 compliance against a SBOM in a table output
-  sbomqs compliance --bsi-v2 samples/sbomqs-spdx-syft.json
+  sbomqs compliance --bsi-v2 samples/photon.spdx.json
 
   # Check a BSI TR-03183-2 v2.1.0 compliance against a SBOM in a table output
-  sbomqs compliance --bsi-v21 samples/sbomqs-cdx.json
+  sbomqs compliance --bsi-v21 samples/sbom_cdx.json
 
    # Check a Framing Software Component Transparency (v3) compliance against a SBOM in a table output
-  sbomqs compliance --fsct samples/sbomqs-spdx-syft.json
+  sbomqs compliance --fsct samples/photon.spdx.json
 
   # Check a OpenChain Telco compliance against a SBOM in a JSON output
-  sbomqs compliance --oct --json samples/sbomqs-spdx-syft.json
+  sbomqs compliance --oct --json samples/photon.spdx.json
 
    # Check a Framing Software Component Transparency (v3) compliance against a SBOM in a table colorful output
-  sbomqs compliance --fsct --color samples/sbomqs-spdx-syft.json
+  sbomqs compliance --fsct --color samples/photon.spdx.json
 
 `,
 	Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/score.go
+++ b/cmd/score.go
@@ -86,38 +86,38 @@ var scoreCmd = &cobra.Command{
 	Example: `sbomqs score [--category <category>] [--basic|--json|--detailed] [--profile <profile>] <SBOM file>
 
   # Get a score for a SBOM in table output
-  sbomqs score samples/sbomqs-spdx-syft.json
+  sbomqs score samples/photon.spdx.json
 
   # Get a score for a SBOM in basic output
-  sbomqs score --basic samples/sbomqs-spdx-syft.json
+  sbomqs score --basic samples/photon.spdx.json
 
   # Get a score for a SBOM in JSON output
-  sbomqs score --json samples/sbomqs-spdx-syft.json
+  sbomqs score --json samples/photon.spdx.json
 
   # Get a detailed score for a SBOM
-  sbomqs score --detailed samples/sbomqs-spdx-syft.json
+  sbomqs score --detailed samples/photon.spdx.json
 
   # Score a SBOM for the ntia profile
-  sbomqs score --profile ntia samples/sbomqs-spdx-syft.json
+  sbomqs score --profile ntia samples/photon.spdx.json
 
   # Score a SBOM for ntia, bsi, oct-v1.1, interlynk profiles
-  sbomqs score --profile ntia,bsi,oct-v1.1,interlynk samples/sbomqs-spdx-syft.json
+  sbomqs score --profile ntia,bsi,oct-v1.1,interlynk samples/photon.spdx.json
 
   # Get a score for multiple comprehensive categories
-  sbomqs score --category identification,integrity samples/sbomqs-spdx-syft.json
+  sbomqs score --category identification,integrity samples/photon.spdx.json
 
   # Recursively score all SBOMs under a directory
   sbomqs score --recursive testdata
 
   # Enable component quality analysis with API key via flag
-  sbomqs score --enable-component-analysis --api-key "your-api-key" samples/sbomqs-spdx-syft.json
+  sbomqs score --enable-component-analysis --api-key "your-api-key" samples/photon.spdx.json
 
   # Enable component quality analysis with API key via environment variable
   export INTERLYNK_SECURITY_TOKEN="your-api-key"
-  sbomqs score --enable-component-analysis samples/sbomqs-spdx-syft.json
+  sbomqs score --enable-component-analysis samples/photon.spdx.json
 
   # Enable component quality analysis with custom API URL
-  sbomqs score --enable-component-analysis --api-url "https://api.interlynk.io" --api-key "your-api-key" samples/sbomqs-spdx-syft.json
+  sbomqs score --enable-component-analysis --api-url "https://api.interlynk.io" --api-key "your-api-key" samples/photon.spdx.json
 `,
 
 	Args: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
> `sbomqs score samples/sbomqs-spdx-syft.json`

That's the first thing `sbomqs score --help` offers you. Run it from a fresh clone and you get `Error: failed to validate engine params: no valid paths provided`. Exit 1. `samples/sbomqs-spdx-syft.json` was deleted in #524, and the copy that PR left under `testdata/` went in #549, so the name isnt in the tree at all now. `samples/sbomqs-cdx.json` over in the compliance examples is the same. Between them the two commands print fifteen examples that stop right there - the three `--enable-component-analysis` ones name the same file but want an API key before they ever look for it.

There are three files left in `samples/`. `docs/getting-started.md` already sends people to `samples/photon.spdx.json`, so teh SPDX examples use that one and the two CycloneDX ones use `samples/sbom_cdx.json`. Ran all fifteen with the new paths and they're fine.

`cmd/policy.go` has dead sample paths too, but its example also wants a `policies.yaml` thats not in the repo, so a swap wouldn't fix that one and I've left it alone. Fine to close this if you'd rather.
