### PR TITLE
fix(cmd): make compliance --ntia select the 2026 profile it advertises

### DIFF
--- a/cmd/compliance.go
+++ b/cmd/compliance.go
@@ -131,14 +131,18 @@ func setupEngineParams(cmd *cobra.Command, args []string) *engine.Params {
 		engParams.Oct = true
 	}
 	engParams.Fsct, _ = cmd.Flags().GetBool("fsct")
-	engParams.Ntia, _ = cmd.Flags().GetBool("cisa-2026")
+	if v, _ := cmd.Flags().GetBool("cisa-2026"); v {
+		engParams.Ntia = true
+	}
 	if v, _ := cmd.Flags().GetBool("cisa2026"); v {
 		engParams.Ntia = true
 	}
 	if v, _ := cmd.Flags().GetBool("cisa"); v {
 		engParams.Ntia = true
 	}
-	engParams.Ntia2021, _ = cmd.Flags().GetBool("cisa-2021")
+	if v, _ := cmd.Flags().GetBool("cisa-2021"); v {
+		engParams.Ntia2021 = true
+	}
 	if v, _ := cmd.Flags().GetBool("cisa2021"); v {
 		engParams.Ntia2021 = true
 	}


### PR DESCRIPTION
`compliance --ntia` is registered as "NTIA minimum elements (2026)" and the help example next to it says CISA-2026, but the run you get is the 2021 one. Different report, different score, and nothing tells you.

`setupEngineParams` reads `ntia` into `engParams.Ntia`, then forty lines further down assigns that same field again from `cisa-2026`. That one's a plain assignment where the `cisa2026` and `cisa` blocks right below it do `if v { ... = true }`, so with `--cisa-2026` off it writes false straight back over your `--ntia`, and the report type falls through to the NTIA-2021 default.

Both of these on current main, same file:

> sbomqs compliance --ntia --basic samples/photon.spdx.json
> NTIA Report
> Score:3.3 RequiredScore:6.6 OptionalScore:0.0 for samples/photon.spdx.json
>
> sbomqs compliance --cisa --basic samples/photon.spdx.json
> NTIA Minimum Elements (2026) Compliance Report
> Score:4.3 RequiredScore:4.3 OptionalScore:0.0 for samples/photon.spdx.json

`--cisa` is documented as the same standard, so the two names for one profile disagree. After the patch `--ntia` gives the second of those, and `--ntia-2021` still gives the first.

`engParams.Ntia2021` is overwritten the same way a few lines further on, from `cisa-2021`. Theres nothing to see there on its own, beacuse NTIA-2021 is the fallback anyway, so it's only the `--ntia` half you can watch go wrong.

It came in with #754, which collapsed the seperate `Cisa2026` and `Cisa2021` fields onto `Ntia` and `Ntia2021`, and shipped in v2.1.1. I've left those fields and the switch cases that read them alone; nothing sets them any more, but that's a different change and `--ntia` works without it.
