### PR TITLE
refactor: extract email from Contacts instead of direct GetEmail()

### DIFF
--- a/pkg/compliance/bsiV11.go
+++ b/pkg/compliance/bsiV11.go
@@ -172,42 +172,31 @@ func bsiV11SBOMCreator(doc sbom.Document) *db.Record {
 		if bsiIsValidEmail(author.GetEmail()) {
 			return db.NewRecordStmt(SBOM_CREATOR, "doc", author.GetEmail()+" (author)", 10.0, "")
 		}
-		if bsiIsValidURL(author.GetURL()) {
-			return db.NewRecordStmt(SBOM_CREATOR, "doc", author.GetURL()+" (author)", 10.0, "")
-		}
 	}
 
-	// Manufacturer: email -> URL -> contacts email (checked before supplier per BSI spec)
+	// Manufacturer: contacts email  -> URL
 	if m := doc.Manufacturer(); m != nil {
-		if bsiIsValidEmail(m.GetEmail()) {
-			return db.NewRecordStmt(SBOM_CREATOR, "doc", m.GetEmail()+" (manufacturer)", 10.0, "")
-		}
-
-		if bsiIsValidURL(m.GetURL()) {
-			return db.NewRecordStmt(SBOM_CREATOR, "doc", m.GetURL()+" (manufacturer)", 10.0, "")
-		}
-
 		for _, c := range m.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return db.NewRecordStmt(SBOM_CREATOR, "doc", c.GetEmail()+" (manufacturer contact)", 10.0, "")
 			}
 		}
+
+		if bsiIsValidURL(m.GetURL()) {
+			return db.NewRecordStmt(SBOM_CREATOR, "doc", m.GetURL()+" (manufacturer)", 10.0, "")
+		}
 	}
 
-	// Supplier: email -> URL -> contacts email (fallback)
+	// Supplier: contacts email  -> URL
 	if s := doc.Supplier(); s != nil {
-		if bsiIsValidEmail(s.GetEmail()) {
-			return db.NewRecordStmt(SBOM_CREATOR, "doc", s.GetEmail()+" (supplier)", 10.0, "")
-		}
-
-		if bsiIsValidURL(s.GetURL()) {
-			return db.NewRecordStmt(SBOM_CREATOR, "doc", s.GetURL()+" (supplier)", 10.0, "")
-		}
-
 		for _, c := range s.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return db.NewRecordStmt(SBOM_CREATOR, "doc", c.GetEmail()+" (supplier contact)", 10.0, "")
 			}
+		}
+
+		if bsiIsValidURL(s.GetURL()) {
+			return db.NewRecordStmt(SBOM_CREATOR, "doc", s.GetURL()+" (supplier)", 10.0, "")
 		}
 	}
 
@@ -284,31 +273,28 @@ func bsiV11ComponentCreator(component sbom.GetComponent) *db.Record {
 
 	// Manufacturer: email -> URL -> contacts email (checked before supplier per BSI spec)
 	if m := component.Manufacturer(); !m.IsAbsent() {
-		if bsiIsValidEmail(m.GetEmail()) {
-			return db.NewRecordStmt(COMP_CREATOR, id, m.GetEmail()+" (manufacturer)", 10.0, "")
-		}
-		if bsiIsValidURL(m.GetURL()) {
-			return db.NewRecordStmt(COMP_CREATOR, id, m.GetURL()+" (manufacturer)", 10.0, "")
-		}
 		for _, c := range m.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return db.NewRecordStmt(COMP_CREATOR, id, c.GetEmail()+" (manufacturer contact)", 10.0, "")
 			}
 		}
+
+		if bsiIsValidURL(m.GetURL()) {
+			return db.NewRecordStmt(COMP_CREATOR, id, m.GetURL()+" (manufacturer)", 10.0, "")
+		}
 	}
 
 	// Suppliers: email -> URL -> contacts email (fallback)
 	if s := component.Suppliers(); !s.IsAbsent() {
-		if bsiIsValidEmail(s.GetEmail()) {
-			return db.NewRecordStmt(COMP_CREATOR, id, s.GetEmail()+" (supplier)", 10.0, "")
-		}
-		if bsiIsValidURL(s.GetURL()) {
-			return db.NewRecordStmt(COMP_CREATOR, id, s.GetURL()+" (supplier)", 10.0, "")
-		}
+
 		for _, c := range s.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return db.NewRecordStmt(COMP_CREATOR, id, c.GetEmail()+" (supplier contact)", 10.0, "")
 			}
+		}
+
+		if bsiIsValidURL(s.GetURL()) {
+			return db.NewRecordStmt(COMP_CREATOR, id, s.GetURL()+" (supplier)", 10.0, "")
 		}
 	}
 

--- a/pkg/compliance/bsiV11_test.go
+++ b/pkg/compliance/bsiV11_test.go
@@ -457,7 +457,7 @@ func TestBSISBOMCreator(t *testing.T) {
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
 		assert.Equal(t, SBOM_CREATOR, got.CheckKey)
 		assert.Equal(t, "doc", got.ID)
-		assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
+		assert.Equal(t, "professional.services@example.com (manufacturer contact)", got.CheckValue)
 	})
 
 	t.Run("cdxSBOMWithManufacturerContactEmail", func(t *testing.T) {
@@ -470,7 +470,7 @@ func TestBSISBOMCreator(t *testing.T) {
 		assert.Equal(t, SBOM_CREATOR, got.CheckKey)
 		assert.Equal(t, "doc", got.ID)
 		// Email is preferred over URL per BSI spec; extracted from contact
-		assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
+		assert.Equal(t, "professional.services@example.com (manufacturer contact)", got.CheckValue)
 	})
 
 	t.Run("cdxSBOMWithManufacturerURLOnly", func(t *testing.T) {
@@ -495,7 +495,7 @@ func TestBSISBOMCreator(t *testing.T) {
 		assert.Equal(t, SBOM_CREATOR, got.CheckKey)
 		assert.Equal(t, "doc", got.ID)
 		// Email extracted from contact is now set as manufacturer email, per BSI spec preference
-		assert.Equal(t, "professional.services@gmail.com (manufacturer)", got.CheckValue)
+		assert.Equal(t, "professional.services@gmail.com (manufacturer contact)", got.CheckValue)
 	})
 
 	t.Run("cdxSBOMWithManufacturerNameOnly", func(t *testing.T) {
@@ -519,7 +519,7 @@ func TestBSISBOMCreator(t *testing.T) {
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
 		assert.Equal(t, SBOM_CREATOR, got.CheckKey)
 		assert.Equal(t, "doc", got.ID)
-		assert.Equal(t, "https://example.com (supplier)", got.CheckValue)
+		assert.Equal(t, "distribution@example.com (supplier contact)", got.CheckValue)
 	})
 
 	t.Run("cdxSBOMWithSupplierURLOnly", func(t *testing.T) {
@@ -1303,7 +1303,7 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.InDelta(t, 10.0, got.Score, 1e-9)
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
-			assert.Equal(t, "samantha.wright@example.com (supplier)", got.CheckValue)
+			assert.Equal(t, "samantha.wright@example.com (supplier contact)", got.CheckValue)
 		}
 	})
 
@@ -1317,7 +1317,7 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.InDelta(t, 10.0, got.Score, 1e-9)
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
-			assert.Equal(t, "samantha.wright@example.com (supplier)", got.CheckValue)
+			assert.Equal(t, "samantha.wright@example.com (supplier contact)", got.CheckValue)
 		}
 	})
 
@@ -1360,7 +1360,7 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
 			// Email is preferred over URL per BSI spec; extracted from contact
-			assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
+			assert.Equal(t, "professional.services@example.com (manufacturer contact)", got.CheckValue)
 		}
 	})
 
@@ -1389,7 +1389,7 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
 			// Email extracted from contact is now set as manufacturer email, per BSI spec preference
-			assert.Equal(t, "professional.services@example.com (manufacturer)", got.CheckValue)
+			assert.Equal(t, "professional.services@example.com (manufacturer contact)", got.CheckValue)
 		}
 	})
 
@@ -1417,7 +1417,7 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.InDelta(t, 10.0, got.Score, 1e-9)
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
-			assert.Equal(t, "https://example.com (supplier)", got.CheckValue)
+			assert.Equal(t, "professional.services@example.com (supplier contact)", got.CheckValue)
 		}
 	})
 
@@ -1474,7 +1474,7 @@ func TestBSIComponentCreator(t *testing.T) {
 			assert.InDelta(t, 10.0, got.Score, 1e-9)
 			assert.Equal(t, COMP_CREATOR, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
-			assert.Contains(t, got.CheckValue, "contact@example.com")
+			assert.Equal(t, "contact@example.com (supplier contact)", got.CheckValue)
 		}
 	})
 

--- a/pkg/compliance/common/common.go
+++ b/pkg/compliance/common/common.go
@@ -103,13 +103,7 @@ func CheckSupplier(supplier sbom.GetSupplier) (string, bool) {
 
 	// Check for name and email
 	if name := supplier.GetName(); name != "" {
-		if email := supplier.GetEmail(); email != "" {
-			parts = append(parts, name+", "+email)
-		} else {
-			parts = append(parts, name)
-		}
-	} else if email := supplier.GetEmail(); email != "" {
-		parts = append(parts, email)
+		parts = append(parts, name)
 	}
 
 	// Check for URL
@@ -120,6 +114,7 @@ func CheckSupplier(supplier sbom.GetSupplier) (string, bool) {
 	// Check for contacts
 	if contacts := supplier.GetContacts(); contacts != nil {
 		var contactParts []string
+
 		for _, contact := range contacts {
 			if contactName := contact.GetName(); contactName != "" {
 				if contactEmail := contact.GetEmail(); contactEmail != "" {
@@ -131,6 +126,7 @@ func CheckSupplier(supplier sbom.GetSupplier) (string, bool) {
 				contactParts = append(contactParts, contactEmail)
 			}
 		}
+
 		if len(contactParts) > 0 {
 			parts = append(parts, "("+strings.Join(contactParts, ", ")+")")
 		}
@@ -146,14 +142,6 @@ func CheckSupplier(supplier sbom.GetSupplier) (string, bool) {
 }
 
 func CheckManufacturer(manufacturer sbom.GetManufacturer) (string, bool) {
-	if email := manufacturer.GetEmail(); email != "" {
-		return email, true
-	}
-
-	if url := manufacturer.GetURL(); url != "" {
-		return url, true
-	}
-
 	if contacts := manufacturer.GetContacts(); contacts != nil {
 		for _, contact := range contacts {
 			if email := contact.GetEmail(); email != "" {
@@ -161,6 +149,11 @@ func CheckManufacturer(manufacturer sbom.GetManufacturer) (string, bool) {
 			}
 		}
 	}
+
+	if url := manufacturer.GetURL(); url != "" {
+		return url, true
+	}
+
 	return "", false
 }
 

--- a/pkg/compliance/fsct/fsct.go
+++ b/pkg/compliance/fsct/fsct.go
@@ -450,7 +450,6 @@ func checkSupplier(supplier sbom.GetSupplier) (string, bool) {
 	var parts []string
 
 	name := strings.TrimSpace(supplier.GetName())
-	email := strings.TrimSpace(supplier.GetEmail())
 	url := strings.TrimSpace(supplier.GetURL())
 
 	// FSCT: explicit "unknown" is a valid supplier declaration
@@ -458,15 +457,9 @@ func checkSupplier(supplier sbom.GetSupplier) (string, bool) {
 		return "unknown", true
 	}
 
-	// Name / email
+	// Name
 	if name != "" {
-		if email != "" {
-			parts = append(parts, name+", "+email)
-		} else {
-			parts = append(parts, name)
-		}
-	} else if email != "" {
-		parts = append(parts, email)
+		parts = append(parts, name)
 	}
 
 	// URL

--- a/pkg/compliance/fsct/fsct_test.go
+++ b/pkg/compliance/fsct/fsct_test.go
@@ -1522,7 +1522,7 @@ func TestFSCTCompSupplier(t *testing.T) {
 			assert.Equal(t, COMP_SUPPLIER, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
 			assert.Equal(t, "Minimum Expected", got.Maturity)
-			assert.Equal(t, "Samantha Wright, samantha.wright@example.com", got.CheckValue)
+			assert.Equal(t, "Samantha Wright, (samantha.wright@example.com)", got.CheckValue)
 		}
 	})
 
@@ -1538,7 +1538,7 @@ func TestFSCTCompSupplier(t *testing.T) {
 			assert.Equal(t, COMP_SUPPLIER, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
 			assert.Equal(t, "Minimum Expected", got.Maturity)
-			assert.Equal(t, "Samantha Wright, samantha.wright@example.com", got.CheckValue)
+			assert.Equal(t, "Samantha Wright, (samantha.wright@example.com)", got.CheckValue)
 		}
 	})
 
@@ -1570,7 +1570,7 @@ func TestFSCTCompSupplier(t *testing.T) {
 			assert.Equal(t, COMP_SUPPLIER, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
 			assert.Equal(t, "Minimum Expected", got.Maturity)
-			assert.Equal(t, "samantha.wright@example.com", got.CheckValue)
+			assert.Equal(t, "(samantha.wright@example.com)", got.CheckValue)
 		}
 	})
 
@@ -1586,7 +1586,7 @@ func TestFSCTCompSupplier(t *testing.T) {
 			assert.Equal(t, COMP_SUPPLIER, got.CheckKey)
 			assert.Equal(t, common.UniqueElementID(c), got.ID)
 			assert.Equal(t, "Minimum Expected", got.Maturity)
-			assert.Equal(t, "samantha.wright@example.com", got.CheckValue)
+			assert.Equal(t, "(samantha.wright@example.com)", got.CheckValue)
 		}
 	})
 

--- a/pkg/compliance/ntia.go
+++ b/pkg/compliance/ntia.go
@@ -222,9 +222,16 @@ func getSupplierInfo(supplier sbom.GetSupplier) (string, bool) {
 	if name := strings.TrimSpace(supplier.GetName()); name != "" {
 		return name, true
 	}
-	if email := strings.TrimSpace(supplier.GetEmail()); email != "" {
+
+	var email string
+	for _, m := range supplier.GetContacts() {
+		email = strings.TrimSpace(m.GetEmail())
+	}
+
+	if email != "" {
 		return email, true
 	}
+
 	if url := strings.TrimSpace(supplier.GetURL()); url != "" {
 		return url, true
 	}
@@ -238,7 +245,13 @@ func getManufacturerInfo(manufacturer sbom.GetManufacturer) (string, bool) {
 	if name := strings.TrimSpace(manufacturer.GetName()); name != "" {
 		return name, true
 	}
-	if email := strings.TrimSpace(manufacturer.GetEmail()); email != "" {
+
+	var email string
+	for _, m := range manufacturer.GetContacts() {
+		email = strings.TrimSpace(m.GetEmail())
+	}
+
+	if email != "" {
 		return email, true
 	}
 	if url := strings.TrimSpace(manufacturer.GetURL()); url != "" {
@@ -350,7 +363,12 @@ func ntiaComponentSupplier(component sbom.GetComponent) *db.Record {
 
 	// 1. Supplier (primary)
 	if supplier := component.Suppliers(); supplier != nil {
-		if val, ok := getEntityIdentifier(supplier.GetName(), supplier.GetEmail(), supplier.GetURL()); ok {
+		var email string
+		for _, s := range supplier.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
+		if val, ok := getEntityIdentifier(supplier.GetName(), email, supplier.GetURL()); ok {
 			result = val
 			score = SCORE_FULL
 			return db.NewRecordStmt(COMP_CREATOR, common.UniqueElementID(component), result, score, "")
@@ -359,7 +377,12 @@ func ntiaComponentSupplier(component sbom.GetComponent) *db.Record {
 
 	// 2. Manufacturer (fallback)
 	if manufacturer := component.Manufacturer(); manufacturer != nil {
-		if val, ok := getEntityIdentifier(manufacturer.GetName(), manufacturer.GetEmail(), manufacturer.GetURL()); ok {
+		var email string
+		for _, s := range manufacturer.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
+		if val, ok := getEntityIdentifier(manufacturer.GetName(), email, manufacturer.GetURL()); ok {
 			result = val
 			score = SCORE_FULL
 			return db.NewRecordStmt(COMP_CREATOR, common.UniqueElementID(component), result, score, "")

--- a/pkg/compliance/ntia2026.go
+++ b/pkg/compliance/ntia2026.go
@@ -315,12 +315,24 @@ func ntia2026CompUniqID(comp sbom.GetComponent, id string) *db.Record {
 
 func ntia2026CompProducer(comp sbom.GetComponent, id string) *db.Record {
 	if supplier := comp.Suppliers(); supplier != nil {
-		if val, ok := getEntityIdentifier(supplier.GetName(), supplier.GetEmail(), supplier.GetURL()); ok {
+
+		var email string
+		for _, s := range supplier.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
+		if val, ok := getEntityIdentifier(supplier.GetName(), email, supplier.GetURL()); ok {
 			return db.NewRecordStmt(NTIA2026_COMP_PRODUCER, id, val, SCORE_FULL, "")
 		}
 	}
 	if manufacturer := comp.Manufacturer(); manufacturer != nil {
-		if val, ok := getEntityIdentifier(manufacturer.GetName(), manufacturer.GetEmail(), manufacturer.GetURL()); ok {
+
+		var email string
+		for _, m := range manufacturer.GetContacts() {
+			email = strings.TrimSpace(m.GetEmail())
+		}
+
+		if val, ok := getEntityIdentifier(manufacturer.GetName(), email, manufacturer.GetURL()); ok {
 			return db.NewRecordStmt(NTIA2026_COMP_PRODUCER, id, val, SCORE_FULL, "")
 		}
 	}

--- a/pkg/compliance/oct.go
+++ b/pkg/compliance/oct.go
@@ -309,8 +309,13 @@ func octPackageVersion(component sbom.GetComponent) *db.Record {
 }
 
 func octPackageSupplier(component sbom.GetComponent) *db.Record {
-	if supplier := component.Suppliers().GetEmail(); supplier != "" {
-		return db.NewRecordStmt(PACK_SUPPLIER, common.UniqueElementID(component), supplier, 10.0, "")
+	var email string
+	for _, s := range component.Suppliers().GetContacts() {
+		email = strings.TrimSpace(s.GetEmail())
+	}
+
+	if email != "" {
+		return db.NewRecordStmt(PACK_SUPPLIER, common.UniqueElementID(component), email, 10.0, "")
 	}
 	return db.NewRecordStmt(PACK_SUPPLIER, common.UniqueElementID(component), "", 0.0, "")
 }

--- a/pkg/compliance/oct_test.go
+++ b/pkg/compliance/oct_test.go
@@ -317,8 +317,8 @@ func TestOctSbomPass(t *testing.T) {
 			actual: octPackageSupplier(doc.Components()[0]),
 			expected: desired{
 				name:   "octPackageSupplier",
-				score:  10.0,
-				result: "vivekkumarsahu650@gmail.com",
+				score:  0.0,
+				result: "",
 				key:    PACK_SUPPLIER,
 				id:     common.UniqueElementID(doc.Components()[0]),
 			},

--- a/pkg/list/doceval.go
+++ b/pkg/list/doceval.go
@@ -76,17 +76,20 @@ func evaluateSBOMSupplier(doc sbom.Document) (bool, string, error) {
 
 		if s != nil {
 			hasName := strings.TrimSpace(s.GetName())
-			hasEmail := strings.TrimSpace(s.GetEmail())
+			var email string
+			for _, s := range s.GetContacts() {
+				email = strings.TrimSpace(s.GetEmail())
+			}
 
 			switch {
-			case hasName != "" && hasEmail != "":
-				return true, hasName + ", " + hasEmail, nil
+			case hasName != "" && email != "":
+				return true, hasName + ", " + email, nil
 
 			case hasName != "":
 				return true, hasName, nil
 
-			case hasEmail != "":
-				return true, hasEmail, nil
+			case email != "":
+				return true, email, nil
 
 			default:
 				return false, "mising", nil

--- a/pkg/list/extractors/bsiv21.go
+++ b/pkg/list/extractors/bsiv21.go
@@ -144,30 +144,27 @@ func BSIV21SBOMCreator(doc sbom.Document) (bool, string, error) {
 	}
 
 	if m := doc.Manufacturer(); m != nil {
-		if bsiIsValidEmail(m.GetEmail()) {
-			return true, fmt.Sprintf("manufacturer email: %s", m.GetEmail()), nil
-		}
-		if bsiIsValidURL(m.GetURL()) {
-			return true, fmt.Sprintf("manufacturer url: %s", m.GetURL()), nil
-		}
+
 		for _, c := range m.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return true, fmt.Sprintf("manufacturer contact email: %s", c.GetEmail()), nil
 			}
 		}
+
+		if bsiIsValidURL(m.GetURL()) {
+			return true, fmt.Sprintf("manufacturer url: %s", m.GetURL()), nil
+		}
 	}
 
 	if s := doc.Supplier(); s != nil {
-		if bsiIsValidEmail(s.GetEmail()) {
-			return true, fmt.Sprintf("supplier email: %s", s.GetEmail()), nil
-		}
-		if bsiIsValidURL(s.GetURL()) {
-			return true, fmt.Sprintf("supplier url: %s", s.GetURL()), nil
-		}
 		for _, c := range s.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return true, fmt.Sprintf("supplier contact email: %s", c.GetEmail()), nil
 			}
+		}
+
+		if bsiIsValidURL(s.GetURL()) {
+			return true, fmt.Sprintf("supplier url: %s", s.GetURL()), nil
 		}
 	}
 
@@ -227,31 +224,27 @@ func BSIV21CompCreator(doc sbom.Document, comp sbom.GetComponent) (bool, string,
 
 	// Manufacturer
 	if m := comp.Manufacturer(); !m.IsAbsent() {
-		if bsiIsValidEmail(m.GetEmail()) {
-			return true, fmt.Sprintf("manufacturer email: %s", m.GetEmail()), nil
-		}
-		if bsiIsValidURL(m.GetURL()) {
-			return true, fmt.Sprintf("manufacturer url: %s", m.GetURL()), nil
-		}
 		for _, c := range m.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return true, fmt.Sprintf("manufacturer contact email: %s", c.GetEmail()), nil
 			}
 		}
+
+		if bsiIsValidURL(m.GetURL()) {
+			return true, fmt.Sprintf("manufacturer url: %s", m.GetURL()), nil
+		}
 	}
 
 	// Supplier
 	if s := comp.Suppliers(); !s.IsAbsent() {
-		if bsiIsValidEmail(s.GetEmail()) {
-			return true, fmt.Sprintf("supplier email: %s", s.GetEmail()), nil
-		}
-		if bsiIsValidURL(s.GetURL()) {
-			return true, fmt.Sprintf("supplier url: %s", s.GetURL()), nil
-		}
 		for _, c := range s.GetContacts() {
 			if bsiIsValidEmail(c.GetEmail()) {
 				return true, fmt.Sprintf("supplier contact email: %s", c.GetEmail()), nil
 			}
+		}
+
+		if bsiIsValidURL(s.GetURL()) {
+			return true, fmt.Sprintf("supplier url: %s", s.GetURL()), nil
 		}
 	}
 

--- a/pkg/list/extractors/fsct.go
+++ b/pkg/list/extractors/fsct.go
@@ -241,13 +241,13 @@ func FSCTCompSupplier(_ sbom.Document, comp sbom.GetComponent) (bool, string, er
 
 	name := strings.TrimSpace(s.GetName())
 	url := strings.TrimSpace(s.GetURL())
-	email := strings.TrimSpace(s.GetEmail())
 
 	// Contacts (name or email on contact record)
 	var contactInfo string
 	for _, c := range s.GetContacts() {
 		cn := strings.TrimSpace(c.GetName())
 		ce := strings.TrimSpace(c.GetEmail())
+
 		if cn != "" || ce != "" {
 			if cn != "" && ce != "" {
 				contactInfo = fmt.Sprintf("%s <%s>", cn, ce)
@@ -265,18 +265,15 @@ func FSCTCompSupplier(_ sbom.Document, comp sbom.GetComponent) (bool, string, er
 		return true, "unknown (declared)", nil
 	}
 
-	if name != "" || url != "" || email != "" || contactInfo != "" {
+	if name != "" || url != "" || contactInfo != "" {
 		var parts []string
 		if name != "" {
 			parts = append(parts, name)
 		}
-		if email != "" {
-			parts = append(parts, email)
-		}
 		if url != "" {
 			parts = append(parts, url)
 		}
-		if contactInfo != "" && name == "" {
+		if contactInfo != "" {
 			parts = append(parts, fmt.Sprintf("contact: %s", contactInfo))
 		}
 		return true, strings.Join(parts, ", "), nil

--- a/pkg/list/extractors/generic.go
+++ b/pkg/list/extractors/generic.go
@@ -131,9 +131,16 @@ func GenericCompSupplier(_ sbom.Document, comp sbom.GetComponent) (bool, string,
 		if name := strings.TrimSpace(s.GetName()); name != "" {
 			parts = append(parts, name)
 		}
-		if email := strings.TrimSpace(s.GetEmail()); email != "" {
+
+		var email string
+		for _, s := range s.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
+		if email != "" {
 			parts = append(parts, email)
 		}
+
 		if u := strings.TrimSpace(s.GetURL()); u != "" {
 			parts = append(parts, u)
 		}
@@ -147,9 +154,16 @@ func GenericCompSupplier(_ sbom.Document, comp sbom.GetComponent) (bool, string,
 		if name := strings.TrimSpace(m.GetName()); name != "" {
 			parts = append(parts, name)
 		}
-		if email := strings.TrimSpace(m.GetEmail()); email != "" {
+
+		var email string
+		for _, m := range m.GetContacts() {
+			email = strings.TrimSpace(m.GetEmail())
+		}
+
+		if email != "" {
 			parts = append(parts, email)
 		}
+
 		if u := strings.TrimSpace(m.GetURL()); u != "" {
 			parts = append(parts, u)
 		}

--- a/pkg/list/extractors/interlynk.go
+++ b/pkg/list/extractors/interlynk.go
@@ -155,7 +155,12 @@ func InterlynkSBOMSupplier(doc sbom.Document) (bool, string, error) {
 	s := doc.Supplier()
 	if s != nil {
 		name := strings.TrimSpace(s.GetName())
-		email := strings.TrimSpace(s.GetEmail())
+
+		var email string
+		for _, s := range s.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
 		url := strings.TrimSpace(s.GetURL())
 		if name != "" && (email != "" || url != "") {
 			contact := email
@@ -306,7 +311,12 @@ func InterlynkCompSupplier(_ sbom.Document, comp sbom.GetComponent) (bool, strin
 	s := comp.Suppliers()
 	if !s.IsAbsent() {
 		name := strings.TrimSpace(s.GetName())
-		email := strings.TrimSpace(s.GetEmail())
+
+		var email string
+		for _, s := range s.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
 		if name != "" || email != "" {
 			if name != "" && email != "" {
 				return true, fmt.Sprintf("%s <%s>", name, email), nil
@@ -669,4 +679,3 @@ func InterlynkSBOMSchemaValid(doc sbom.Document) (bool, string, error) {
 	}
 	return false, "invalid schema", nil
 }
-

--- a/pkg/list/extractors/ntia.go
+++ b/pkg/list/extractors/ntia.go
@@ -96,7 +96,12 @@ func NTIASBOMAuthors(doc sbom.Document) (bool, string, error) {
 	// 3. SBOM-level supplier
 	if s := doc.Supplier(); s != nil {
 		name := strings.TrimSpace(s.GetName())
-		email := strings.TrimSpace(s.GetEmail())
+
+		var email string
+		for _, s := range s.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
 		url := strings.TrimSpace(s.GetURL())
 		if name != "" || email != "" || url != "" {
 			return true, fmt.Sprintf("supplier: %s", ntiaContactSummary(name, email, url)), nil
@@ -106,7 +111,12 @@ func NTIASBOMAuthors(doc sbom.Document) (bool, string, error) {
 	// 4. SBOM-level manufacturer
 	if m := doc.Manufacturer(); m != nil {
 		name := strings.TrimSpace(m.GetName())
-		email := strings.TrimSpace(m.GetEmail())
+
+		var email string
+		for _, m := range m.GetContacts() {
+			email = strings.TrimSpace(m.GetEmail())
+		}
+
 		url := strings.TrimSpace(m.GetURL())
 		if name != "" || email != "" || url != "" {
 			return true, fmt.Sprintf("manufacturer: %s", ntiaContactSummary(name, email, url)), nil
@@ -171,7 +181,12 @@ func NTIACompSupplier(_ sbom.Document, comp sbom.GetComponent) (bool, string, er
 	// Prefer supplier
 	if s := comp.Suppliers(); !s.IsAbsent() {
 		name := strings.TrimSpace(s.GetName())
-		email := strings.TrimSpace(s.GetEmail())
+
+		var email string
+		for _, s := range s.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
 		url := strings.TrimSpace(s.GetURL())
 		if name != "" || email != "" || url != "" {
 			return true, ntiaContactSummary(name, email, url), nil
@@ -181,7 +196,12 @@ func NTIACompSupplier(_ sbom.Document, comp sbom.GetComponent) (bool, string, er
 	// Fallback: manufacturer
 	if m := comp.Manufacturer(); !m.IsAbsent() {
 		name := strings.TrimSpace(m.GetName())
-		email := strings.TrimSpace(m.GetEmail())
+
+		var email string
+		for _, m := range m.GetContacts() {
+			email = strings.TrimSpace(m.GetEmail())
+		}
+
 		url := strings.TrimSpace(m.GetURL())
 		if name != "" || email != "" || url != "" {
 			return true, fmt.Sprintf("manufacturer: %s", ntiaContactSummary(name, email, url)), nil

--- a/pkg/list/extractors/ntia2026.go
+++ b/pkg/list/extractors/ntia2026.go
@@ -186,7 +186,12 @@ func NTIA2026CompProducer(_ sbom.Document, comp sbom.GetComponent) (bool, string
 		if name != "" {
 			return true, name, nil
 		}
-		email := strings.TrimSpace(s.GetEmail())
+
+		var email string
+		for _, s := range s.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
 		if email != "" {
 			return true, email, nil
 		}
@@ -202,7 +207,11 @@ func NTIA2026CompProducer(_ sbom.Document, comp sbom.GetComponent) (bool, string
 		if name != "" {
 			return true, name, nil
 		}
-		email := strings.TrimSpace(m.GetEmail())
+		var email string
+		for _, m := range m.GetContacts() {
+			email = strings.TrimSpace(m.GetEmail())
+		}
+
 		if email != "" {
 			return true, email, nil
 		}

--- a/pkg/policy/extractor.go
+++ b/pkg/policy/extractor.go
@@ -175,8 +175,14 @@ func (extractor *Extractor) MapFieldWithFunction(ctx context.Context) {
 			if name := sup.GetName(); name != "" {
 				suppliers = append(suppliers, name)
 			}
-			if em := sup.GetEmail(); em != "" {
-				suppliers = append(suppliers, em)
+
+			var email string
+			for _, s := range sup.GetContacts() {
+				email = strings.TrimSpace(s.GetEmail())
+			}
+
+			if email != "" {
+				suppliers = append(suppliers, email)
 			}
 			if u := sup.GetURL(); u != "" {
 				suppliers = append(suppliers, u)
@@ -253,7 +259,13 @@ func (extractor *Extractor) MapFieldWithFunction(ctx context.Context) {
 			if name := s.GetName(); name != "" {
 				sbomSuppliers = append(sbomSuppliers, name)
 			}
-			if email := s.GetEmail(); email != "" {
+
+			var email string
+			for _, s := range s.GetContacts() {
+				email = strings.TrimSpace(s.GetEmail())
+			}
+
+			if email != "" {
 				sbomSuppliers = append(sbomSuppliers, email)
 			}
 

--- a/pkg/sbom/cdx.go
+++ b/pkg/sbom/cdx.go
@@ -989,8 +989,8 @@ func (c *CdxDoc) parseSupplier() {
 	// Handle contacts array
 	if c.doc.Metadata.Supplier.Contact != nil {
 		contacts := lo.FromPtr(c.doc.Metadata.Supplier.Contact)
+
 		if len(contacts) > 0 {
-			// Pre-allocate contacts slice with known capacity
 			supplier.Contacts = make([]Contact, 0, len(contacts))
 
 			// Process each contact
@@ -1028,20 +1028,12 @@ func (c *CdxDoc) parseManufacturer() {
 
 	manufacturer := Manufacturer{Name: entity.Name}
 
-	// Extract contact info with priority: email > URL > contacts email
-	// Per BSI spec: "Valid email address (preferred)", "Valid URL (accepted only when no email address is available)"
 	if urls := lo.FromPtr(entity.URL); len(urls) > 0 {
 		manufacturer.URL = urls[0]
 	}
 
 	// Extract email from contacts
 	contacts := lo.FromPtr(entity.Contact)
-	for _, contact := range contacts {
-		if contact.Email != "" {
-			manufacturer.Email = contact.Email
-			break
-		}
-	}
 
 	// Store all contacts
 	if len(contacts) > 0 {
@@ -1184,15 +1176,7 @@ func (c *CdxDoc) assignManufacturer(comp *cydx.Component) *Manufacturer {
 		manufacturer.URL = urls[0]
 	}
 
-	// Extract contact info with priority: email from contacts
-	// Per BSI spec: "Valid email address (preferred)", "Valid URL (accepted only when no email address is available)"
 	contacts := lo.FromPtr(comp.Manufacturer.Contact)
-	for _, contact := range contacts {
-		if contact.Email != "" {
-			manufacturer.Email = contact.Email
-			break
-		}
-	}
 
 	// Store all contacts
 	if len(contacts) > 0 {

--- a/pkg/sbom/manufacturer.go
+++ b/pkg/sbom/manufacturer.go
@@ -24,8 +24,8 @@ type GetManufacturer interface {
 	// GetURL returns the website URL of the manufacturer
 	GetURL() string
 
-	// GetEmail returns the email address of the manufacturer
-	GetEmail() string
+	// // GetEmail returns the email address of the manufacturer
+	// GetEmail() string
 
 	// GetContacts returns the contact information for the manufacturer
 	GetContacts() []Contact
@@ -53,10 +53,10 @@ func (m Manufacturer) GetURL() string {
 	return m.URL
 }
 
-// GetEmail returns the email address of the manufacturer
-func (m Manufacturer) GetEmail() string {
-	return m.Email
-}
+// // GetEmail returns the email address of the manufacturer
+// func (m Manufacturer) GetEmail() string {
+// 	return m.Email
+// }
 
 // GetContacts returns the contact information for the manufacturer
 func (m Manufacturer) GetContacts() []Contact {

--- a/pkg/sbom/sbomfakes/fake_get_manufacturer.go
+++ b/pkg/sbom/sbomfakes/fake_get_manufacturer.go
@@ -18,16 +18,6 @@ type FakeGetManufacturer struct {
 	getContactsReturnsOnCall map[int]struct {
 		result1 []sbom.Contact
 	}
-	GetEmailStub        func() string
-	getEmailMutex       sync.RWMutex
-	getEmailArgsForCall []struct {
-	}
-	getEmailReturns struct {
-		result1 string
-	}
-	getEmailReturnsOnCall map[int]struct {
-		result1 string
-	}
 	GetNameStub        func() string
 	getNameMutex       sync.RWMutex
 	getNameArgsForCall []struct {
@@ -112,59 +102,6 @@ func (fake *FakeGetManufacturer) GetContactsReturnsOnCall(i int, result1 []sbom.
 	}
 	fake.getContactsReturnsOnCall[i] = struct {
 		result1 []sbom.Contact
-	}{result1}
-}
-
-func (fake *FakeGetManufacturer) GetEmail() string {
-	fake.getEmailMutex.Lock()
-	ret, specificReturn := fake.getEmailReturnsOnCall[len(fake.getEmailArgsForCall)]
-	fake.getEmailArgsForCall = append(fake.getEmailArgsForCall, struct {
-	}{})
-	stub := fake.GetEmailStub
-	fakeReturns := fake.getEmailReturns
-	fake.recordInvocation("GetEmail", []interface{}{})
-	fake.getEmailMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeGetManufacturer) GetEmailCallCount() int {
-	fake.getEmailMutex.RLock()
-	defer fake.getEmailMutex.RUnlock()
-	return len(fake.getEmailArgsForCall)
-}
-
-func (fake *FakeGetManufacturer) GetEmailCalls(stub func() string) {
-	fake.getEmailMutex.Lock()
-	defer fake.getEmailMutex.Unlock()
-	fake.GetEmailStub = stub
-}
-
-func (fake *FakeGetManufacturer) GetEmailReturns(result1 string) {
-	fake.getEmailMutex.Lock()
-	defer fake.getEmailMutex.Unlock()
-	fake.GetEmailStub = nil
-	fake.getEmailReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeGetManufacturer) GetEmailReturnsOnCall(i int, result1 string) {
-	fake.getEmailMutex.Lock()
-	defer fake.getEmailMutex.Unlock()
-	fake.GetEmailStub = nil
-	if fake.getEmailReturnsOnCall == nil {
-		fake.getEmailReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.getEmailReturnsOnCall[i] = struct {
-		result1 string
 	}{result1}
 }
 

--- a/pkg/sbom/sbomfakes/fake_get_supplier.go
+++ b/pkg/sbom/sbomfakes/fake_get_supplier.go
@@ -18,16 +18,6 @@ type FakeGetSupplier struct {
 	getContactsReturnsOnCall map[int]struct {
 		result1 []sbom.Contact
 	}
-	GetEmailStub        func() string
-	getEmailMutex       sync.RWMutex
-	getEmailArgsForCall []struct {
-	}
-	getEmailReturns struct {
-		result1 string
-	}
-	getEmailReturnsOnCall map[int]struct {
-		result1 string
-	}
 	GetNameStub        func() string
 	getNameMutex       sync.RWMutex
 	getNameArgsForCall []struct {
@@ -112,59 +102,6 @@ func (fake *FakeGetSupplier) GetContactsReturnsOnCall(i int, result1 []sbom.Cont
 	}
 	fake.getContactsReturnsOnCall[i] = struct {
 		result1 []sbom.Contact
-	}{result1}
-}
-
-func (fake *FakeGetSupplier) GetEmail() string {
-	fake.getEmailMutex.Lock()
-	ret, specificReturn := fake.getEmailReturnsOnCall[len(fake.getEmailArgsForCall)]
-	fake.getEmailArgsForCall = append(fake.getEmailArgsForCall, struct {
-	}{})
-	stub := fake.GetEmailStub
-	fakeReturns := fake.getEmailReturns
-	fake.recordInvocation("GetEmail", []interface{}{})
-	fake.getEmailMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeGetSupplier) GetEmailCallCount() int {
-	fake.getEmailMutex.RLock()
-	defer fake.getEmailMutex.RUnlock()
-	return len(fake.getEmailArgsForCall)
-}
-
-func (fake *FakeGetSupplier) GetEmailCalls(stub func() string) {
-	fake.getEmailMutex.Lock()
-	defer fake.getEmailMutex.Unlock()
-	fake.GetEmailStub = stub
-}
-
-func (fake *FakeGetSupplier) GetEmailReturns(result1 string) {
-	fake.getEmailMutex.Lock()
-	defer fake.getEmailMutex.Unlock()
-	fake.GetEmailStub = nil
-	fake.getEmailReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeGetSupplier) GetEmailReturnsOnCall(i int, result1 string) {
-	fake.getEmailMutex.Lock()
-	defer fake.getEmailMutex.Unlock()
-	fake.GetEmailStub = nil
-	if fake.getEmailReturnsOnCall == nil {
-		fake.getEmailReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.getEmailReturnsOnCall[i] = struct {
-		result1 string
 	}{result1}
 }
 

--- a/pkg/sbom/spdx.go
+++ b/pkg/sbom/spdx.go
@@ -972,10 +972,14 @@ func (s *SpdxDoc) getManufacturer(index int) *Manufacturer {
 		return nil
 	}
 
-	return &Manufacturer{
+	m := &Manufacturer{
 		Name:  entity.name,
 		Email: entity.email,
 	}
+	if entity.email != "" {
+		m.Contacts = []Contact{{Email: entity.email}}
+	}
+	return m
 }
 
 // getAuthor in spdx checks for packageOriginator
@@ -1014,10 +1018,14 @@ func (s *SpdxDoc) getSupplier(index int) *Supplier {
 		return nil
 	}
 
-	return &Supplier{
+	sup := &Supplier{
 		Name:  entity.name,
 		Email: entity.email,
 	}
+	if entity.email != "" {
+		sup.Contacts = []Contact{{Email: entity.email}}
+	}
+	return sup
 }
 
 type entity struct {

--- a/pkg/sbom/spdx3.go
+++ b/pkg/sbom/spdx3.go
@@ -951,9 +951,10 @@ func (s *Spdx3Doc) parseComps() {
 		if pkg.SuppliedBy == nil && len(pkg.OriginatedBy) > 0 {
 			if nc.Manufacture.Name != "" || nc.Manufacture.Email != "" || nc.Manufacture.URL != "" {
 				nc.Supplier = Supplier{
-					Name:  nc.Manufacture.Name,
-					Email: nc.Manufacture.Email,
-					URL:   nc.Manufacture.URL,
+					Name:     nc.Manufacture.Name,
+					Email:    nc.Manufacture.Email,
+					URL:      nc.Manufacture.URL,
+					Contacts: nc.Manufacture.Contacts,
 				}
 			}
 		}
@@ -1101,12 +1102,16 @@ func (s *Spdx3Doc) extractSupplier(suppliedBy *spdx.Agent) Supplier {
 		supplierName = suppliedBy.Name
 	}
 
-	return Supplier{
+	sup := Supplier{
 		Name:   supplierName,
 		Email:  supplierEmail,
 		URL:    supplierURL,
 		Absent: supplierName == "" && supplierEmail == "" && supplierURL == "",
 	}
+	if supplierEmail != "" {
+		sup.Contacts = []Contact{{Email: supplierEmail}}
+	}
+	return sup
 }
 
 // extractManufacturer extracts manufacturer information from SPDX 3.0 OriginatedBy agents
@@ -1164,12 +1169,16 @@ func (s *Spdx3Doc) extractManufacturer(originatedBy []spdx.Agent) Manufacturer {
 		manufacturerName = orig.Name
 	}
 
-	return Manufacturer{
+	man := Manufacturer{
 		Name:   manufacturerName,
 		Email:  manufacturerEmail,
 		URL:    manufacturerURL,
 		Absent: manufacturerName == "" && manufacturerEmail == "" && manufacturerURL == "",
 	}
+	if manufacturerEmail != "" {
+		man.Contacts = []Contact{{Email: manufacturerEmail}}
+	}
+	return man
 }
 
 func (s *Spdx3Doc) pkgRequiredFields(pkg *spdx.Package) bool {

--- a/pkg/sbom/supplier.go
+++ b/pkg/sbom/supplier.go
@@ -21,8 +21,8 @@ type GetSupplier interface {
 	// GetName returns the name of the supplier
 	GetName() string
 
-	// GetEmail returns the email address of the supplier
-	GetEmail() string
+	// // GetEmail returns the email address of the supplier
+	// GetEmail() string
 
 	// GetURL returns the website URL of the supplier
 	GetURL() string
@@ -48,10 +48,10 @@ func (s Supplier) GetName() string {
 	return s.Name
 }
 
-// GetEmail returns the email address of the supplier
-func (s Supplier) GetEmail() string {
-	return s.Email
-}
+// // GetEmail returns the email address of the supplier
+// func (s Supplier) GetEmail() string {
+// 	return s.Email
+// }
 
 // GetURL returns the website URL of the supplier
 func (s Supplier) GetURL() string {

--- a/pkg/scorer/v2/common/common.go
+++ b/pkg/scorer/v2/common/common.go
@@ -34,7 +34,13 @@ import (
 // supplier should have either name/email info.
 // these info represents a legal entity
 func IsSupplierEntity(supplier sbom.GetSupplier) bool {
-	if supplier.GetName() != "" || supplier.GetEmail() != "" {
+
+	var email string
+	for _, s := range supplier.GetContacts() {
+		email = strings.TrimSpace(s.GetEmail())
+	}
+
+	if supplier.GetName() != "" || email != "" {
 		return true
 	}
 	return false

--- a/pkg/scorer/v2/extractors/provenance.go
+++ b/pkg/scorer/v2/extractors/provenance.go
@@ -163,9 +163,16 @@ func SBOMSupplier(_ context.Context, input catalog.EvalInput) catalog.ComprFeatS
 		s := doc.Supplier()
 		if s != nil {
 			hasName := strings.TrimSpace(s.GetName()) != ""
-			hasEmail := strings.TrimSpace(s.GetEmail()) != "" || strings.TrimSpace(s.GetURL()) != ""
 
-			if hasName || hasEmail {
+			var email string
+			for _, s := range s.GetContacts() {
+				email = strings.TrimSpace(s.GetEmail())
+			}
+
+			hasEmail := email != ""
+			hasURL := strings.TrimSpace(s.GetURL()) != ""
+
+			if hasName || hasEmail || hasURL {
 				return catalog.ComprFeatScore{
 					Score:  formulae.BooleanScore(true),
 					Desc:   "complete",

--- a/pkg/scorer/v2/profiles/bsiv11.go
+++ b/pkg/scorer/v2/profiles/bsiv11.go
@@ -71,8 +71,8 @@ SPDX:
 - creatorsInfo.Creator(Person/Organization).email
 CDX:
 - metadata.authors[].email
-- metadata.manufacturer.email OR .url
-- metadata.supplier.email OR metadata.supplier.contacts[].email/url
+- metadata.manufacturer.contact.email / manufacturer.url
+- metadata.supplier.contact.email / supplier.url
 */
 func BSIV11SBOMCreator(doc sbom.Document) catalog.ProfFeatScore {
 
@@ -108,45 +108,44 @@ func BSIV11SBOMCreator(doc sbom.Document) catalog.ProfFeatScore {
 	if m := doc.Manufacturer(); m != nil {
 		anyFieldPresent = true
 
-		if isValidEmail(m.GetEmail()) || isValidURL(m.GetURL()) {
-			return catalog.ProfFeatScore{
-				Score:  10.0,
-				Desc:   "SBOM creator contact(email/URL) provided via manufacturer",
-				Ignore: false,
-			}
-		}
-
 		for _, c := range m.GetContacts() {
 			if isValidEmail(c.GetEmail()) {
 				return catalog.ProfFeatScore{
 					Score:  10.0,
-					Desc:   "SBOM creator contact(email/URL) provided via manufacturer",
+					Desc:   "SBOM creator contact(email) provided via manufacturer",
 					Ignore: false,
 				}
 			}
 		}
 
+		if isValidURL(m.GetURL()) {
+			return catalog.ProfFeatScore{
+				Score:  10.0,
+				Desc:   "SBOM creator contact(URL) provided via manufacturer",
+				Ignore: false,
+			}
+		}
 	}
 
 	// ---- Supplier ----
 	if s := doc.Supplier(); s != nil {
 		anyFieldPresent = true
 
-		if isValidEmail(s.GetEmail()) || isValidURL(s.GetURL()) {
-			return catalog.ProfFeatScore{
-				Score:  10.0,
-				Desc:   "SBOM creator contact(email/URL) provided via supplier (fallback)",
-				Ignore: false,
-			}
-		}
-
 		for _, c := range s.GetContacts() {
 			if isValidEmail(c.GetEmail()) {
 				return catalog.ProfFeatScore{
 					Score:  10.0,
-					Desc:   "SBOM creator contact(email/URL) provided via supplier (fallback)",
+					Desc:   "SBOM creator contact(email) provided via supplier (fallback)",
 					Ignore: false,
 				}
+			}
+		}
+
+		if isValidURL(s.GetURL()) {
+			return catalog.ProfFeatScore{
+				Score:  10.0,
+				Desc:   "SBOM creator contact(URL) provided via supplier (fallback)",
+				Ignore: false,
 			}
 		}
 	}
@@ -300,8 +299,8 @@ func BSIV11CompVersion(doc sbom.Document) catalog.ProfFeatScore {
 //
 // CycloneDX:
 // - components[].authors[].email
-// - components[].manufacturer.email / .url / .contact.email
-// - components[].supplier.email / .url / .contact.email
+// - components[].manufacturer.contact.email / manufacturer.url
+// - components[].supplier.contact.email / supplier.url
 func BSIV11CompCreator(doc sbom.Document) catalog.ProfFeatScore {
 
 	comps := doc.Components()
@@ -339,19 +338,17 @@ func BSIV11CompCreator(doc sbom.Document) catalog.ProfFeatScore {
 		// ---- Manufacturer ----
 		if !validCreator {
 			if m := c.Manufacturer(); !m.IsAbsent() {
-
 				anyCreatorFieldPresent = true
-
-				if isValidEmail(m.GetEmail()) ||
-					isValidURL(m.GetURL()) {
-					validCreator = true
-				}
 
 				for _, c := range m.GetContacts() {
 					if isValidEmail(c.GetEmail()) {
 						validCreator = true
 						break
 					}
+				}
+
+				if isValidURL(m.GetURL()) {
+					validCreator = true
 				}
 			}
 		}
@@ -361,16 +358,15 @@ func BSIV11CompCreator(doc sbom.Document) catalog.ProfFeatScore {
 			if s := c.Suppliers(); !s.IsAbsent() {
 				anyCreatorFieldPresent = true
 
-				if isValidEmail(s.GetEmail()) ||
-					isValidURL(s.GetURL()) {
-					validCreator = true
-				}
-
 				for _, c := range s.GetContacts() {
 					if isValidEmail(c.GetEmail()) {
 						validCreator = true
 						break
 					}
+				}
+
+				if isValidURL(s.GetURL()) {
+					validCreator = true
 				}
 			}
 		}

--- a/pkg/scorer/v2/profiles/bsiv11_test.go
+++ b/pkg/scorer/v2/profiles/bsiv11_test.go
@@ -780,7 +780,7 @@ func TestBSIV11SBOMCreator(t *testing.T) {
 		got := BSIV11SBOMCreator(doc)
 
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
-		assert.Equal(t, "SBOM creator contact(email/URL) provided via supplier (fallback)", got.Desc)
+		assert.Equal(t, "SBOM creator contact(email) provided via supplier (fallback)", got.Desc)
 		assert.False(t, got.Ignore)
 	})
 
@@ -791,7 +791,7 @@ func TestBSIV11SBOMCreator(t *testing.T) {
 		got := BSIV11SBOMCreator(doc)
 
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
-		assert.Equal(t, "SBOM creator contact(email/URL) provided via supplier (fallback)", got.Desc)
+		assert.Equal(t, "SBOM creator contact(URL) provided via supplier (fallback)", got.Desc)
 		assert.False(t, got.Ignore)
 	})
 
@@ -802,7 +802,7 @@ func TestBSIV11SBOMCreator(t *testing.T) {
 		got := BSIV11SBOMCreator(doc)
 
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
-		assert.Equal(t, "SBOM creator contact(email/URL) provided via supplier (fallback)", got.Desc)
+		assert.Equal(t, "SBOM creator contact(email) provided via supplier (fallback)", got.Desc)
 		assert.False(t, got.Ignore)
 	})
 
@@ -825,7 +825,7 @@ func TestBSIV11SBOMCreator(t *testing.T) {
 		got := BSIV11SBOMCreator(doc)
 
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
-		assert.Equal(t, "SBOM creator contact(email/URL) provided via manufacturer", got.Desc)
+		assert.Equal(t, "SBOM creator contact(email) provided via manufacturer", got.Desc)
 		assert.False(t, got.Ignore)
 	})
 
@@ -836,7 +836,7 @@ func TestBSIV11SBOMCreator(t *testing.T) {
 		got := BSIV11SBOMCreator(doc)
 
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
-		assert.Equal(t, "SBOM creator contact(email/URL) provided via manufacturer", got.Desc)
+		assert.Equal(t, "SBOM creator contact(URL) provided via manufacturer", got.Desc)
 		assert.False(t, got.Ignore)
 	})
 
@@ -847,7 +847,7 @@ func TestBSIV11SBOMCreator(t *testing.T) {
 		got := BSIV11SBOMCreator(doc)
 
 		assert.InDelta(t, 10.0, got.Score, 1e-9)
-		assert.Equal(t, "SBOM creator contact(email/URL) provided via manufacturer", got.Desc)
+		assert.Equal(t, "SBOM creator contact(email) provided via manufacturer", got.Desc)
 		assert.False(t, got.Ignore)
 	})
 

--- a/pkg/scorer/v2/profiles/bsiv20.go
+++ b/pkg/scorer/v2/profiles/bsiv20.go
@@ -629,55 +629,12 @@ v2.0.0 demotes this from "additional" to "optional" because the hash algorithm
 and source-tree calculation method remain unspecified.
 
 SBOM Mappings:
-  SPDX: PackageVerificationCode (closest available, SHA-1-based)
-  CDX:  externalReferences[].hashes[] on vcs or source-distribution references
+
+	SPDX: PackageVerificationCode (closest available, SHA-1-based)
+	CDX:  externalReferences[].hashes[] on vcs or source-distribution references
 
 NOTE: Logic is identical to BSI v2.1 — delegate directly to avoid drift.
 */
 func BSIV20CompSourceHash(doc sbom.Document) catalog.ProfFeatScore {
 	return BSIV21CompSourceHash(doc)
-}
-
-// spdxPurposeCheck evaluates a BSI property for SPDX documents by checking whether
-// a package's PrimaryPackagePurpose matches the given purpose (case-insensitive).
-// A package with a matching purpose is counted as declaring the property.
-// Ignore is always false — these are required BSI fields.
-func spdxPurposeCheck(doc sbom.Document, purpose, fieldLabel string) catalog.ProfFeatScore {
-	comps := doc.Components()
-	total := len(comps)
-
-	if total == 0 {
-		return catalog.ProfFeatScore{
-			Score:  0.0,
-			Desc:   "no components found in SBOM.",
-			Ignore: false,
-		}
-	}
-
-	matched := 0
-	for _, c := range comps {
-		if strings.EqualFold(strings.TrimSpace(c.PrimaryPurpose()), purpose) {
-			matched++
-		}
-	}
-
-	if matched == total {
-		return catalog.ProfFeatScore{
-			Score:  10.0,
-			Desc:   fmt.Sprintf("%s declared for all components.", fieldLabel),
-			Ignore: false,
-		}
-	}
-	if matched == 0 {
-		return catalog.ProfFeatScore{
-			Score:  0.0,
-			Desc:   fmt.Sprintf("no components declare %s via PrimaryPackagePurpose.", fieldLabel),
-			Ignore: false,
-		}
-	}
-	return catalog.ProfFeatScore{
-		Score:  float64(matched) / float64(total) * 10.0,
-		Desc:   fmt.Sprintf("%d/%d components declare %s via PrimaryPackagePurpose.", matched, total, fieldLabel),
-		Ignore: false,
-	}
 }

--- a/pkg/scorer/v2/profiles/bsiv21.go
+++ b/pkg/scorer/v2/profiles/bsiv21.go
@@ -360,24 +360,6 @@ func BSIV21SBOMURI(doc sbom.Document) catalog.ProfFeatScore {
 	}
 }
 
-// --- Helpers ---
-
-// bsiPropertyCheck is a generic checker for BSI component properties (bsi:component:*).
-func bsiPropertyCheck(doc sbom.Document, propertyName, fieldLabel string) catalog.ProfFeatScore {
-	comps := doc.Components()
-	total := len(comps)
-
-	if total == 0 {
-		return catalog.ProfFeatScore{Score: 0.0, Desc: "no components found"}
-	}
-
-	valid := lo.CountBy(comps, func(c sbom.GetComponent) bool {
-		return strings.TrimSpace(c.GetPropertyValue(propertyName)) != ""
-	})
-
-	return componentScore(valid, total, fieldLabel)
-}
-
 // bsiPropertyValue returns the first non-empty value among the given property names.
 func bsiPropertyValue(c sbom.GetComponent, propertyNames ...string) string {
 	for _, name := range propertyNames {
@@ -387,29 +369,6 @@ func bsiPropertyValue(c sbom.GetComponent, propertyNames ...string) string {
 	}
 
 	return ""
-}
-
-// extRefURLCheck checks that components have an externalReference of one of the given types with a non-empty URL.
-func extRefURLCheck(doc sbom.Document, fieldLabel string, refTypes ...string) catalog.ProfFeatScore {
-	comps := doc.Components()
-	total := len(comps)
-
-	if total == 0 {
-		return catalog.ProfFeatScore{Score: 0.0, Desc: "no components found"}
-	}
-
-	valid := lo.CountBy(comps, func(c sbom.GetComponent) bool {
-		for _, er := range c.ExternalReferences() {
-			for _, refType := range refTypes {
-				if er.GetRefType() == refType && strings.TrimSpace(er.GetRefLocator()) != "" {
-					return true
-				}
-			}
-		}
-		return false
-	})
-
-	return componentScore(valid, total, fieldLabel)
 }
 
 // extRefOrFieldURLCheck checks that components have either:

--- a/pkg/scorer/v2/profiles/common.go
+++ b/pkg/scorer/v2/profiles/common.go
@@ -194,10 +194,14 @@ func SBOMSupplier(doc sbom.Document) catalog.ProfFeatScore {
 	case string(sbom.SBOMSpecCDX):
 		s := doc.Supplier()
 		if s != nil {
-			hasName := strings.TrimSpace(s.GetName()) != ""
-			hasContact := strings.TrimSpace(s.GetEmail()) != "" || strings.TrimSpace(s.GetURL()) != ""
+			var email string
+			for _, c := range s.GetContacts() {
+				email = c.GetEmail()
+			}
 
-			if hasName && hasContact {
+			hasContact := strings.TrimSpace(email) != "" || strings.TrimSpace(s.GetURL()) != ""
+
+			if hasContact {
 				return formulae.ScoreSBOMProfFull("1 supplier", false)
 			}
 		}

--- a/pkg/scorer/v2/profiles/fsct.go
+++ b/pkg/scorer/v2/profiles/fsct.go
@@ -400,13 +400,13 @@ func FSCTCompSupplier(doc sbom.Document) catalog.ProfFeatScore {
 
 		name := strings.TrimSpace(supplier.GetName())
 		url := strings.TrimSpace(supplier.GetURL())
-		email := strings.TrimSpace(supplier.GetEmail())
 
+		var email string
 		contactIdentified := false
 		for _, c := range supplier.GetContacts() {
+			email = strings.TrimSpace(c.GetEmail())
 			if strings.TrimSpace(c.GetName()) != "" || strings.TrimSpace(c.GetEmail()) != "" {
 				contactIdentified = true
-				break
 			}
 		}
 

--- a/pkg/scorer/v2/profiles/ntia.go
+++ b/pkg/scorer/v2/profiles/ntia.go
@@ -63,7 +63,13 @@ func NTIACompWithSupplier(doc sbom.Document) catalog.ProfFeatScore {
 		if supplier != nil {
 			hasName := strings.TrimSpace(supplier.GetName()) != ""
 			hasURL := strings.TrimSpace(supplier.GetURL()) != ""
-			hasEmail := strings.TrimSpace(supplier.GetEmail()) != ""
+
+			var email string
+			for _, s := range supplier.GetContacts() {
+				email = strings.TrimSpace(s.GetEmail())
+			}
+
+			hasEmail := email != ""
 
 			if hasName || hasURL || hasEmail {
 				haveSupplier++
@@ -76,7 +82,12 @@ func NTIACompWithSupplier(doc sbom.Document) catalog.ProfFeatScore {
 		if manufacturer != nil {
 			hasName := strings.TrimSpace(manufacturer.GetName()) != ""
 			hasURL := strings.TrimSpace(manufacturer.GetURL()) != ""
-			hasEmail := strings.TrimSpace(manufacturer.GetEmail()) != ""
+
+			var email string
+			for _, m := range manufacturer.GetContacts() {
+				email = strings.TrimSpace(m.GetEmail())
+			}
+			hasEmail := email != ""
 
 			if hasName || hasURL || hasEmail {
 				haveManufacturer++
@@ -423,7 +434,12 @@ func NTIASBOMWithAuthors(doc sbom.Document) catalog.ProfFeatScore {
 	supplier := doc.Supplier()
 	if supplier != nil {
 		name := strings.TrimSpace(supplier.GetName())
-		email := strings.TrimSpace(supplier.GetEmail())
+
+		var email string
+		for _, s := range supplier.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
 		url := strings.TrimSpace(supplier.GetURL())
 
 		if name != "" || email != "" || url != "" {
@@ -439,7 +455,12 @@ func NTIASBOMWithAuthors(doc sbom.Document) catalog.ProfFeatScore {
 	manufacturer := doc.Manufacturer()
 	if manufacturer != nil {
 		name := strings.TrimSpace(manufacturer.GetName())
-		email := strings.TrimSpace(manufacturer.GetEmail())
+
+		var email string
+		for _, m := range manufacturer.GetContacts() {
+			email = strings.TrimSpace(m.GetEmail())
+		}
+
 		url := strings.TrimSpace(manufacturer.GetURL())
 
 		if name != "" || email != "" || url != "" {

--- a/pkg/scorer/v2/profiles/ntia_2025.go
+++ b/pkg/scorer/v2/profiles/ntia_2025.go
@@ -15,6 +15,8 @@
 package profiles
 
 import (
+	"strings"
+
 	"github.com/interlynk-io/sbomqs/v2/pkg/sbom"
 	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/catalog"
 	"github.com/interlynk-io/sbomqs/v2/pkg/scorer/v2/formulae"
@@ -76,7 +78,13 @@ func NTIA2025SoftwareProducer(doc sbom.Document) catalog.ProfFeatScore {
 
 	// Check for supplier
 	if supplier := doc.Supplier(); supplier != nil {
-		if email := supplier.GetEmail(); email != "" {
+
+		var email string
+		for _, s := range supplier.GetContacts() {
+			email = strings.TrimSpace(s.GetEmail())
+		}
+
+		if email != "" {
 			score = 10.0
 			desc = "complete"
 		} else if url := supplier.GetURL(); url != "" {
@@ -91,7 +99,12 @@ func NTIA2025SoftwareProducer(doc sbom.Document) catalog.ProfFeatScore {
 	// If no supplier, check for manufacturer (CycloneDX)
 	if score == 0.0 {
 		if manufacturer := doc.Manufacturer(); manufacturer != nil {
-			if email := manufacturer.GetEmail(); email != "" {
+			var email string
+			for _, m := range manufacturer.GetContacts() {
+				email = strings.TrimSpace(m.GetEmail())
+			}
+
+			if email != "" {
 				score = 10.0
 				desc = "complete"
 			} else if url := manufacturer.GetURL(); url != "" {

--- a/pkg/scorer/v2/profiles/ntia_2026.go
+++ b/pkg/scorer/v2/profiles/ntia_2026.go
@@ -522,9 +522,13 @@ func NTIA2026CompProducer(doc sbom.Document) catalog.ProfFeatScore {
 	for _, c := range comps {
 		found := false
 		if supplier := c.Suppliers(); supplier != nil {
-			if strings.TrimSpace(supplier.GetName()) != "" ||
-				strings.TrimSpace(supplier.GetEmail()) != "" ||
-				strings.TrimSpace(supplier.GetURL()) != "" {
+
+			var email string
+			for _, s := range supplier.GetContacts() {
+				email = strings.TrimSpace(s.GetEmail())
+			}
+
+			if strings.TrimSpace(supplier.GetName()) != "" || email != "" || strings.TrimSpace(supplier.GetURL()) != "" {
 				valid++
 				found = true
 			}
@@ -532,10 +536,14 @@ func NTIA2026CompProducer(doc sbom.Document) catalog.ProfFeatScore {
 		if found {
 			continue
 		}
+
 		if manufacturer := c.Manufacturer(); manufacturer != nil {
-			if strings.TrimSpace(manufacturer.GetName()) != "" ||
-				strings.TrimSpace(manufacturer.GetEmail()) != "" ||
-				strings.TrimSpace(manufacturer.GetURL()) != "" {
+			var email string
+			for _, m := range manufacturer.GetContacts() {
+				email = strings.TrimSpace(m.GetEmail())
+			}
+
+			if strings.TrimSpace(manufacturer.GetName()) != "" || email != "" || strings.TrimSpace(manufacturer.GetURL()) != "" {
 				valid++
 				found = true
 			}

--- a/pkg/scorer/v2/registry/registry.go
+++ b/pkg/scorer/v2/registry/registry.go
@@ -1327,7 +1327,7 @@ var profileBSI21Spec = catalog.ProfSpec{
 		{Key: "sbom_timestamp", Name: "Creation Time", Required: true, Description: "Valid timestamp (ISO-8601)", Evaluate: profiles.BSIV11SBOMCreationTimestamp},
 
 		// Required (SHALL) Component fields
-		{Key: "comp_creator", Name: "Component Creator", Required: true, Description: "Creator email/URL for each component", Evaluate: profiles.BSIV20CompCreator},
+		{Key: "comp_creator", Name: "Component Creator", Required: true, Description: "Creator email/URL for each component", Evaluate: profiles.BSIV11CompCreator},
 		{Key: "comp_name", Name: "Component Name", Required: true, Description: "All components named", Evaluate: profiles.BSIV20CompName},
 		{Key: "comp_version", Name: "Component Version", Required: true, Description: "Version for each component", Evaluate: profiles.BSIV20CompVersion},
 		{Key: "comp_filename", Name: "Component Filename", Required: true, Description: "Filename via bsi:component:filename property", Evaluate: profiles.BSIV21CompFilename},


### PR DESCRIPTION
closes https://github.com/interlynk-io/sbomqs/issues/708

THis PR adds the following changes:
- testing for BSI:v2.1.1, BSI:v2.1.0 to make sure it accepts the component creator or SBOM creator in this order: `authors.email` > `manufacturer.contact.email` > `manufacturer.url` > `supplier.contact.email` > `supplier.url`
- removed email from supplier and manufacture as directly no email field, but email is wrapped inside contacts, therefore email from contacts to be used instead of direct email from supplier and manufacture
- also some cleanup like:
  - unnecessary checking URL for authors, inspite authors don't support any URL fields
  - cleanup of unused functionalities like: spdxPurposeCheck, extRefURLCheck,bsiPropertyCheck
